### PR TITLE
Bugfix: delete key would rename if set

### DIFF
--- a/lua/lib/config.lua
+++ b/lua/lib/config.lua
@@ -37,7 +37,7 @@ local bindings = {
     cd = keybindings.cd or '.',
     create = keybindings.create or 'a',
     remove = keybindings.remove or 'd',
-    rename = keybindings.remove or 'r',
+    rename = keybindings.rename or 'r',
 }
 
 return {


### PR DESCRIPTION
I just copied the default settings from the README and was very confused that `d` would rename a file...