### PR TITLE
Add config option to follow buffer's directory

### DIFF
--- a/lua/tree.lua
+++ b/lua/tree.lua
@@ -153,6 +153,15 @@ function M.check_windows_and_close()
   end
 end
 
+function M.navigate_to_buffer_dir(bufname)
+  local new_path = get_cwd()
+  if new_path ~= '/' then
+    new_path = new_path .. '/'
+  end
+  set_root_path(new_path)
+  init_tree()
+end
+
 function M.check_buffer_and_open()
   local bufname = api.nvim_buf_get_name(0)
   if bufname == '' then
@@ -169,12 +178,7 @@ function M.check_buffer_and_open()
 
     M.toggle()
   else
-    local new_path = get_cwd()
-    if new_path ~= '/' then
-      new_path = new_path .. '/'
-    end
-    set_root_path(new_path)
-    init_tree()
+    M.navigate_to_buffer_dir()
   end
 end
 

--- a/plugin/tree.vim
+++ b/plugin/tree.vim
@@ -23,6 +23,7 @@ augroup LuaTree
     au BufEnter * :LuaTreeFindFile
   endif
 
+  au BufEnter * lua require'tree'.navigate_to_buffer_dir()
   au ColorScheme * lua require'tree'.reset_highlight()
 augroup end
 


### PR DESCRIPTION
@kyazdani42 I tried the most recent change to master and realised it wasn't working. The last change you made was the correct logic but it was in a function that only ran on `VimEnter` and had `auto_open` set to 1. The line is [here](https://github.com/Akin909/nvim-tree.lua/blob/5fcbc21edb08c77b3afd938958ad70178ee74d1f/plugin/tree.vim#L19).

I moved the logic you added into a separate function and call it on `BufEnter` that way when you change buffer the Lua Tree updates to the new root dir.

![nvim-tree-follow-buffer](https://user-images.githubusercontent.com/22454918/82259574-bec2e380-9953-11ea-90b1-95ae59548765.gif)

Lemme know what you think. I added it as an option rather than the default, although I think maybe it should be default behaviour