### PR TITLE
Add option for disabling bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ let g:lua_tree_bindings = {
     \ 'edit_tab':    '<C-t>',
     \ 'preview':     '<Tab>',
     \ 'cd':          '<C-]>',
+    }
+
+" Disable default mappings by plugin
+" Bindings are enable by default, disabled on any non-zero value
+" let lua_tree_disable_keybindings=1
+
 " default will show icon by default if no icon is provided
 " default shows no icon by default
 let g:lua_tree_icons = {

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -115,6 +115,13 @@ Can be `0` or `1`. When `1`, will bind |BufEnter| to automatically
 close the tree if it's the last window.
 Default is 0
 
+|g:lua_tree_disable_keybindings|          *g:lua_tree_disable_keybindings*
+
+Can be `0` or `1`. When `1`, will disable all keybindings by the plugin.
+|g:lua_tree_bindings| as well as default bindings will not take effect.
+Default is 0
+
+
 ==============================================================================
 INFORMATIONS				        *nvim-tree-info*
 

--- a/lua/lib/lib.lua
+++ b/lua/lib/lib.lua
@@ -195,6 +195,10 @@ function M.change_dir(foldername)
 end
 
 local function set_mappings()
+  if vim.g.lua_tree_disable_keybindings == 1 then
+      return
+  end
+
   local buf = M.Tree.bufnr
   local bindings = config.get_bindings()
 


### PR DESCRIPTION
* Option for disabling keybindings by plugin. When disabled, all bindings need to be created by the users on their own accord.