### PR TITLE
Always focus tree when finding file.

### DIFF
--- a/lua/lib/lib.lua
+++ b/lua/lib/lib.lua
@@ -287,6 +287,10 @@ function M.win_open()
   return M.Tree.winnr() ~= nil
 end
 
+function M.win_focus()
+  api.nvim_set_current_win(M.Tree.winnr())
+end
+
 function M.toggle_ignored()
   pops.show_ignored = not pops.show_ignored
   return M.refresh_tree()

--- a/lua/tree.lua
+++ b/lua/tree.lua
@@ -116,6 +116,7 @@ function M.find_file(with_open)
 
   if with_open then
     M.open()
+    lib.win_focus()
   end
   lib.set_index_and_redraw(bufname)
 end


### PR DESCRIPTION
This is a fix for issue that i mentioned here https://github.com/kyazdani42/nvim-tree.lua/issues/58#issuecomment-663120555.

I use this command a lot, and I like to have it consistent.