### PR TITLE
refacto display and add LuaTreeFolderDirty group

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ let g:lua_tree_auto_open = 1 "0 by default, opens the tree when typing `vim $DIR
 let g:lua_tree_auto_close = 1 "0 by default, closes the tree when it's the last window
 let g:lua_tree_follow = 1 "0 by default, this option allows the cursor to be updated when entering a buffer
 let g:lua_tree_indent_markers = 1 "0 by default, this option shows indent markers when folders are open
+let g:lua_tree_git_hl = 1 "0 by default, will enable file highlight for git attributes (can be used without the icons).
 let g:lua_tree_show_icons = {
     \ 'git': 1,
     \ 'folders': 0,
@@ -130,7 +131,7 @@ The Netrw vim plugin is disabled, hence features like `gx` don't work accross yo
 - Syntax highlighting ([exa](https://github.com/ogham/exa) like)
 - Change directory with `.`
 - Add / Rename / delete files
-- Git integration
+- Git integration (icons and file highlight)
 - Indent markers
 - Mouse support
 - It's fast

--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ let g:lua_tree_icons = {
     \ 'git': {
     \   'unstaged': "✗",
     \   'staged': "✓",
-    \   'unmerged': "═",
+    \   'unmerged': "",
     \   'renamed': "➜",
     \   'untracked': "★"
     \   },
     \ 'folder': {
-    \   'default': "",
-    \   'open': ""
+    \   'default': "",
+    \   'open': ""
     \   }
     \ }
 

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -95,10 +95,14 @@ when no icon is found for a file.
       \ 'git': {
       \   'unstaged': "✗",
       \   'staged': "✓",
-      \   'unmerged': "═",
+      \   'unmerged': "",
       \   'renamed': "➜",
       \   'untracked': "★"
-      \   }
+      \   },
+      \ 'folder': {
+      \   'default': "",
+      \   'open': ""
+      \  }
       \ }
 
 |g:lua_tree_git_hl|                                *g:lua_tree_git_hl*
@@ -237,7 +241,6 @@ LuaTreeImageFile
 LuaTreeMarkdownFile
 LuaTreeIndentMarker
 
-<<<<<<< HEAD
 LuaTreeLicenseIcon
 LuaTreeYamlIcon
 LuaTreeTomlIcon

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -100,7 +100,13 @@ when no icon is found for a file.
       \   'untracked': "★"
       \   }
       \ }
-<
+
+|g:lua_tree_git_hl|                                *g:lua_tree_git_hl*
+
+You can enable file highlight for git attributes by setting this property.
+This can be used with or without the icons.
+
+
 |g:lua_tree_follow|				*g:lua_tree_follow*
 
 Can be `0` or `1`. When `1`, will update the cursor to update to the correct
@@ -231,6 +237,7 @@ LuaTreeImageFile
 LuaTreeMarkdownFile
 LuaTreeIndentMarker
 
+<<<<<<< HEAD
 LuaTreeLicenseIcon
 LuaTreeYamlIcon
 LuaTreeTomlIcon
@@ -261,6 +268,15 @@ EndOfBuffer
 CursorLine
 VertSplit
 CursorColumn
+
+There are also links for file highlight with git properties
+These all link to there Git equivalent
+
+LuaTreeFileDirty
+LuaTreeFileStaged
+LuaTreeFileMerge
+LuaTreeFileNew
+LuaTreeFileRenamed
 
  vim:tw=78:ts=8:noet:ft=help:norl:
 

--- a/doc/tags
+++ b/doc/tags
@@ -1,3 +1,4 @@
+:LuaTreeClipboard	nvim-tree-lua.txt	/*:LuaTreeClipboard*
 :LuaTreeClose	nvim-tree-lua.txt	/*:LuaTreeClose*
 :LuaTreeFindFile	nvim-tree-lua.txt	/*:LuaTreeFindFile*
 :LuaTreeOpen	nvim-tree-lua.txt	/*:LuaTreeOpen*
@@ -6,7 +7,9 @@
 g:lua_tree_auto_close	nvim-tree-lua.txt	/*g:lua_tree_auto_close*
 g:lua_tree_auto_open	nvim-tree-lua.txt	/*g:lua_tree_auto_open*
 g:lua_tree_bindings	nvim-tree-lua.txt	/*g:lua_tree_bindings*
+g:lua_tree_disable_keybindings	nvim-tree-lua.txt	/*g:lua_tree_disable_keybindings*
 g:lua_tree_follow	nvim-tree-lua.txt	/*g:lua_tree_follow*
+g:lua_tree_git_hl	nvim-tree-lua.txt	/*g:lua_tree_git_hl*
 g:lua_tree_icons	nvim-tree-lua.txt	/*g:lua_tree_icons*
 g:lua_tree_ignore	nvim-tree-lua.txt	/*g:lua_tree_ignore*
 g:lua_tree_indent_markers	nvim-tree-lua.txt	/*g:lua_tree_indent_markers*

--- a/lua/lib/colors.lua
+++ b/lua/lib/colors.lua
@@ -105,7 +105,11 @@ local function get_links()
     CursorLine = 'CursorLine',
     VertSplit = 'VertSplit',
     CursorColumn = 'CursorColumn',
-    FolderDirty = 'LuaTreeFolderName'
+    FileDirty = 'LuaTreeGitDirty',
+    FileNew = 'LuaTreeGitNew',
+    FileRenamed = 'LuaTreeGitRenamed',
+    FileMerge = 'LuaTreeGitMerge',
+    FileStaged = 'LuaTreeGitStaged',
   }
 end
 

--- a/lua/lib/colors.lua
+++ b/lua/lib/colors.lua
@@ -104,7 +104,8 @@ local function get_links()
     EndOfBuffer = 'EndOfBuffer',
     CursorLine = 'CursorLine',
     VertSplit = 'VertSplit',
-    CursorColumn = 'CursorColumn'
+    CursorColumn = 'CursorColumn',
+    FolderDirty = 'LuaTreeFolderName'
   }
 end
 

--- a/lua/lib/colors.lua
+++ b/lua/lib/colors.lua
@@ -29,9 +29,9 @@ local function get_hl_groups()
   local colors = get_colors()
 
   return {
-    IndentMarker = { fg = '#90a4ae' },
+    IndentMarker = { fg = '#8094b4' },
     Symlink = { gui = 'bold', fg = colors.cyan },
-    FolderIcon = { fg = '#90a4ae' },
+    FolderIcon = { fg = '#8094b4' },
 
     ExecFile = { gui = 'bold', fg = colors.green },
     SpecialFile = { gui = 'bold,underline', fg = colors.yellow },

--- a/lua/lib/config.lua
+++ b/lua/lib/config.lua
@@ -7,13 +7,13 @@ function M.get_icon_state()
     git_icons = {
       unstaged = "✗",
       staged = "✓",
-      unmerged = "═",
+      unmerged = "",
       renamed = "➜",
       untracked = "★"
     },
     folder_icons = {
-      default = "",
-      open = ""
+      default = "",
+      open = ""
     }
   }
 

--- a/lua/lib/populate.lua
+++ b/lua/lib/populate.lua
@@ -196,7 +196,7 @@ function M.populate(entries, cwd)
     table.insert(entries, file)
   end
 
-  if not icon_config.show_git_icon then
+  if not icon_config.show_git_icon and vim.g.lua_tree_git_hl ~= 1 then
     return
   end
 


### PR DESCRIPTION
fixes #65 
You can now set `g:lua_tree_git_hl = 1` to color file from their git attributes.

TODO: update the pictures
