### PR TITLE
Inherit git status from nested files on directory.

### DIFF
--- a/lua/lib/git.lua
+++ b/lua/lib/git.lua
@@ -6,7 +6,7 @@ local roots = {}
 local not_git = 'not a git repo'
 
 local function update_root_status(root)
-  local status = vim.fn.systemlist('cd '..root..' && git status --porcelain=v1')
+  local status = vim.fn.systemlist('cd '..root..' && git status --porcelain=v1 -u')
   roots[root] = {}
 
   for _, v in pairs(status) do
@@ -76,9 +76,9 @@ function M.update_status(entries, _cwd)
       node.git_status = status
     elseif node.entries ~= nil then
       local matcher = '^'..utils.path_to_matching_str(relpath)
-      for key, _ in pairs(git_status) do
+      for key, entry_status in pairs(git_status) do
         if key:match(matcher) then
-          node.git_status = 'dirty'
+          node.git_status = entry_status
           break
         end
       end

--- a/plugin/tree.vim
+++ b/plugin/tree.vim
@@ -16,6 +16,7 @@ augroup LuaTree
   endif
   au VimEnter * lua require'tree'.on_enter()
   au ColorScheme * lua require'tree'.reset_highlight()
+  au User FugitiveChanged lua require'tree'.refresh()
 augroup end
 
 command! LuaTreeOpen lua require'tree'.open()


### PR DESCRIPTION
This is a small improvement to git status.
For example, when you have two files in some existing folder, and you stage both files, directory git status is still shown as dirty, but I think it should show as staged, since everything in it is staged.

For the `-u` part, this is useful for new files and folders added. status with `-u` will return list of new files that are part of new folder.

So if you have a new folder and file named `myfolder/myfile.vim`, status without `-u` will return only `myfolder/`, where `-u` will return `myfolder/myfile.vim`.

Also, I introduced refreshing the tree when fugitive changes the git status of some file.