### PR TITLE
Show selected file on toggling nvim tree

### DIFF
--- a/lua/tree.lua
+++ b/lua/tree.lua
@@ -13,7 +13,11 @@ function M.toggle()
   if lib.win_open() then
     lib.close()
   else
-    lib.open()
+    if vim.g.lua_tree_follow == 1 then
+      M.find_file(true)
+    else
+      lib.open()
+    end
   end
 end
 
@@ -112,14 +116,15 @@ local function is_file_readable(fname)
 end
 
 function M.find_file(with_open)
-  local bufname = api.nvim_buf_get_name(api.nvim_get_current_buf())
-  if not is_file_readable(bufname) then return end
+  local bufname = vim.fn.bufname()
+  local filepath = vim.fn.fnamemodify(bufname, ':p')
+  if not is_file_readable(filepath) then return end
 
   if with_open then
     M.open()
     lib.win_focus()
   end
-  lib.set_index_and_redraw(bufname)
+  lib.set_index_and_redraw(filepath)
 end
 
 function M.on_leave()


### PR DESCRIPTION
### Problem
When `let g:lua_tree_follow` is `1` then on `BufEnter` the cursor is placed on the current file. This is similar to how `LuaTreeFindFile` works. But if you have this setting set as `1` and do `LuaTreeToggle` the current file is not selected. The cursor is placed on the first item. If you leave the window and return `BufEnter` is triggered and cursor is placed on the file.

### Use case
This is really helpful if you work in a nested repository since opening the tree to the first item is not very useful as it means you have to search every time. You could use the find file command but this doesn't toggle the tree so a user would have to implement some work around.

### Changes
If a user has set `g:lua_tree_follow` to `1` and they use `LuaTreeToggle` the tree opens with the current file already in focus.

I changed the usage of `nvim_get_current_buf` and `nvim_get_bufname` since these seem to return the wrong or rather a different value from using `bufname` command in vim. The `bufname` command doesn't return the full path so I converted it to a full path with `fnamemodify`
