### PR TITLE
Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ let g:lua_tree_show_icons = {
 " You don't have to define all keys.
 " NOTE: the 'edit' key will wrap/unwrap a folder and open a file
 let g:lua_tree_bindings = {
-    \ 'edit':            '<CR>',
+    \ 'edit':            ['<CR>', 'o'],
     \ 'edit_vsplit':     '<C-v>',
     \ 'edit_split':      '<C-x>',
     \ 'edit_tab':        '<C-t>',

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ let g:lua_tree_follow = 1 "0 by default, this option allows the cursor to be upd
 let g:lua_tree_indent_markers = 1 "0 by default, this option shows indent markers when folders are open
 let g:lua_tree_hide_dotfiles = 1 "0 by default, this option hides files and folders starting with a dot `.`
 let g:lua_tree_git_hl = 1 "0 by default, will enable file highlight for git attributes (can be used without the icons).
+let g:lua_tree_root_folder_modifier = ':~' "This is the default. See :help filename-modifiers for more options
 let g:lua_tree_show_icons = {
     \ 'git': 1,
     \ 'folders': 0,

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -192,7 +192,7 @@ you can change default keybindings by defining this variable.
 default keybindings will be applied to undefined keys.
 >
     let g:lua_tree_bindings = {
-        \ edit:          '<cr>',
+        \ edit:          ['<cr>', 'o'], // Multiple keys provided via list
         \ edit_vsplit:   '<c-v>',
         \ edit_split:    '<c-x>',
         \ edit_tab:      '<c-t>',

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -146,6 +146,12 @@ Can be `0` or `1`. When `1`, will hide dotfiles, files or folders which start
 with the `.` character.
 Default is 0
 
+|g:lua_tree_root_folder_modifier|			*g:lua_tree_hide_dotfiles*
+
+In what format to show root folder. See `:help filename-modifiers` for
+available options.
+Default is `:~`
+
 ==============================================================================
 INFORMATIONS				        *nvim-tree-info*
 
@@ -241,6 +247,7 @@ applied.
 
 LuaTreeSymlink
 LuaTreeFolderName
+LuaTreeRootFolder
 LuaTreeFolderIcon
 LuaTreeExecFile
 LuaTreeSpecialFile

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -146,7 +146,7 @@ Can be `0` or `1`. When `1`, will hide dotfiles, files or folders which start
 with the `.` character.
 Default is 0
 
-|g:lua_tree_root_folder_modifier|			*g:lua_tree_hide_dotfiles*
+|g:lua_tree_root_folder_modifier|		*g:lua_tree_root_folder_modifier*
 
 In what format to show root folder. See `:help filename-modifiers` for
 available options.

--- a/lua/lib/colors.lua
+++ b/lua/lib/colors.lua
@@ -32,6 +32,7 @@ local function get_hl_groups()
     IndentMarker = { fg = '#8094b4' },
     Symlink = { gui = 'bold', fg = colors.cyan },
     FolderIcon = { fg = '#8094b4' },
+    RootFolder = { fg = colors.purple },
 
     ExecFile = { gui = 'bold', fg = colors.green },
     SpecialFile = { gui = 'bold,underline', fg = colors.yellow },

--- a/lua/lib/config.lua
+++ b/lua/lib/config.lua
@@ -45,7 +45,7 @@ end
 function M.get_bindings()
   local keybindings = vim.g.lua_tree_bindings or {}
   return {
-    edit            = keybindings.edit or '<CR>',
+    edit            = keybindings.edit or {'<CR>', 'o'},
     edit_vsplit     = keybindings.edit_vsplit or '<C-v>',
     edit_split      = keybindings.edit_split or '<C-x>',
     edit_tab        = keybindings.edit_tab or '<C-t>',

--- a/lua/lib/lib.lua
+++ b/lua/lib/lib.lua
@@ -58,7 +58,7 @@ function M.init(with_open, with_render)
 end
 
 local function get_node_at_line(line)
-  local index = 2
+  local index = 3
   local function iter(entries)
     for _, node in ipairs(entries) do
       if index == line then
@@ -135,9 +135,9 @@ end
 function M.set_index_and_redraw(fname)
   local i
   if M.Tree.cwd == '/' then
-    i = 0
-  else
     i = 1
+  else
+    i = 2
   end
   local reload = false
 

--- a/lua/lib/lib.lua
+++ b/lua/lib/lib.lua
@@ -207,6 +207,12 @@ function M.change_dir(foldername)
   M.init(false, M.Tree.bufnr ~= nil)
 end
 
+local function set_mapping(buf, key, fn)
+  api.nvim_buf_set_keymap(buf, 'n', key, ':lua require"tree".'..fn..'<cr>', {
+      nowait = true, noremap = true, silent = true
+    })
+end
+
 local function set_mappings()
   if vim.g.lua_tree_disable_keybindings == 1 then
       return
@@ -239,9 +245,13 @@ local function set_mappings()
   }
 
   for k,v in pairs(mappings) do
-    api.nvim_buf_set_keymap(buf, 'n', k, ':lua require"tree".'..v..'<cr>', {
-        nowait = true, noremap = true, silent = true
-      })
+    if type(k) == 'table' then
+      for _, key in pairs(k) do
+        set_mapping(buf, key, v)
+      end
+    else
+      set_mapping(buf, k, v)
+    end
   end
 end
 

--- a/lua/lib/lib.lua
+++ b/lua/lib/lib.lua
@@ -58,7 +58,7 @@ function M.init(with_open, with_render)
 end
 
 local function get_node_at_line(line)
-  local index = 3
+  local index = 2
   local function iter(entries)
     for _, node in ipairs(entries) do
       if index == line then
@@ -135,9 +135,9 @@ end
 function M.set_index_and_redraw(fname)
   local i
   if M.Tree.cwd == '/' then
-    i = 1
+    i = 0
   else
-    i = 2
+    i = 1
   end
   local reload = false
 

--- a/lua/lib/renderer.lua
+++ b/lua/lib/renderer.lua
@@ -160,11 +160,20 @@ local special = {
   ["readme.md"] = true,
 }
 
+local root_folder_modifier = vim.g.lua_tree_root_folder_modifier or ':~'
+
 local function update_draw_data(tree, depth, markers)
   if tree.cwd and tree.cwd ~= '/' then
-    table.insert(lines, "..")
-    table.insert(hl, {'LuaTreeFolderName', index, 0, 2})
+    table.insert(lines, ".. (up a dir)")
+    table.insert(hl, {'LuaTreeFolderName', index, 0, 13})
     index = 1
+  end
+
+  if tree.cwd then
+    local root_name = vim.fn.fnamemodify(tree.cwd, root_folder_modifier)
+    table.insert(lines, root_name)
+    table.insert(hl, {'LuaTreeRootFolder', index, 0, string.len(root_name)})
+    index = tree.cwd ~= '/' and 2 or 1
   end
 
   for idx, node in ipairs(tree.entries) do

--- a/lua/lib/renderer.lua
+++ b/lua/lib/renderer.lua
@@ -164,16 +164,10 @@ local root_folder_modifier = vim.g.lua_tree_root_folder_modifier or ':~'
 
 local function update_draw_data(tree, depth, markers)
   if tree.cwd and tree.cwd ~= '/' then
-    table.insert(lines, ".. (up a dir)")
-    table.insert(hl, {'LuaTreeFolderName', index, 0, 13})
-    index = 1
-  end
-
-  if tree.cwd then
-    local root_name = vim.fn.fnamemodify(tree.cwd, root_folder_modifier)
+    local root_name = vim.fn.fnamemodify(tree.cwd, root_folder_modifier):gsub('/$', '').."/.."
     table.insert(lines, root_name)
     table.insert(hl, {'LuaTreeRootFolder', index, 0, string.len(root_name)})
-    index = tree.cwd ~= '/' and 2 or 1
+    index = 1
   end
 
   for idx, node in ipairs(tree.entries) do


### PR DESCRIPTION
These are the improvements I mentioned in https://github.com/kyazdani42/nvim-tree.lua/issues/76.

For multiple keys for single action, I added `o` as part of default for open action. I believe a lot of people are used to that mapping, especially if they come from nerdtree. If you disagree we can remove it.

For root folder name, I wasn't sure what is the best way to introduce it, so again, I copied nerdtree :)

I didn't provide an option to disable it, because that would introduce a lot more checks. If you think we need to have it, i'll introduce it.

Here's the screenshot how it looks for me:

![screenshot](https://i.imgur.com/wxckpea.png)
