### PR TITLE
Handle git deleted state.

### DIFF
--- a/lua/lib/colors.lua
+++ b/lua/lib/colors.lua
@@ -40,6 +40,7 @@ local function get_hl_groups()
     ImageFile = { gui = 'bold', fg = colors.purple },
 
     GitDirty = { fg = colors.dark_red },
+    GitDeleted = { fg = colors.dark_red },
     GitStaged = { fg = colors.green },
     GitMerge = { fg = colors.orange },
     GitRenamed = { fg = colors.purple },
@@ -60,6 +61,7 @@ local function get_links()
     FileRenamed = 'LuaTreeGitRenamed',
     FileMerge = 'LuaTreeGitMerge',
     FileStaged = 'LuaTreeGitStaged',
+    FileDeleted = 'LuaTreeGitDeleted',
   }
 end
 

--- a/lua/lib/config.lua
+++ b/lua/lib/config.lua
@@ -9,7 +9,8 @@ function M.get_icon_state()
       staged = "✓",
       unmerged = "",
       renamed = "➜",
-      untracked = "★"
+      untracked = "★",
+      deleted = ""
     },
     folder_icons = {
       default = "",

--- a/lua/lib/renderer.lua
+++ b/lua/lib/renderer.lua
@@ -1,5 +1,6 @@
 local colors = require'lib.colors'
 local config = require'lib.config'
+local utils = require'lib.utils'
 
 local api = vim.api
 
@@ -81,6 +82,7 @@ if vim.g.lua_tree_git_hl == 1 then
     local icons = git_hl[git_status]
 
     if icons == nil then
+      utils.echo_warning('Unrecognized git state "'..git_status..'". Please open up an issue on https://github.com/kyazdani42/nvim-tree.lua/issues with this message.')
       icons = git_hl.dirty
     end
 
@@ -119,7 +121,13 @@ if icon_state.show_git_icon then
     if not git_status then return "" end
 
     local icon = ""
-    local icons = git_icon_state[git_status] or git_icon_state.dirty
+    local icons = git_icon_state[git_status]
+    if not icons then
+      if vim.g.lua_tree_git_hl ~= 1 then
+        utils.echo_warning('Unrecognized git state "'..git_status..'". Please open up an issue on https://github.com/kyazdani42/nvim-tree.lua/issues with this message.')
+      end
+      icons = git_icon_state.dirty
+    end
     for _, v in ipairs(icons) do
       table.insert(hl, { v.hl, line, depth+icon_len+#icon, depth+icon_len+#icon+#v.icon })
       icon = icon..v.icon.." "

--- a/lua/lib/renderer.lua
+++ b/lua/lib/renderer.lua
@@ -71,6 +71,7 @@ if vim.g.lua_tree_git_hl == 1 then
     ["??"] = { { hl = "LuaTreeFileNew" } },
     ["R "] = { { hl = "LuaTreeFileRenamed" } },
     ["UU"] = { { hl = "LuaTreeFileMerge" } },
+    [" D"] = { { hl = "LuaTreeFileDeleted" } },
     dirty = { { hl = "LuaTreeFileDirty" } },
   }
   get_git_hl = function(node)
@@ -78,6 +79,11 @@ if vim.g.lua_tree_git_hl == 1 then
     if not git_status then return end
 
     local icons = git_hl[git_status]
+
+    if icons == nil then
+      icons = git_hl.dirty
+    end
+
     -- TODO: how would we determine hl color when multiple git status are active ?
     return icons[1].hl
     -- return icons[#icons].hl
@@ -104,6 +110,7 @@ if icon_state.show_git_icon then
     ["??"] = { { icon = icon_state.icons.git_icons.untracked, hl = "LuaTreeGitNew" } },
     ["R "] = { { icon = icon_state.icons.git_icons.renamed, hl = "LuaTreeGitRenamed" } },
     ["UU"] = { { icon = icon_state.icons.git_icons.unmerged, hl = "LuaTreeGitMerge" } },
+    [" D"] = { { icon = icon_state.icons.git_icons.deleted, hl = "LuaTreeGitDeleted" } },
     dirty = { { icon = icon_state.icons.git_icons.unstaged, hl = "LuaTreeGitDirty" } },
   }
 
@@ -112,7 +119,7 @@ if icon_state.show_git_icon then
     if not git_status then return "" end
 
     local icon = ""
-    local icons = git_icon_state[git_status]
+    local icons = git_icon_state[git_status] or git_icon_state.dirty
     for _, v in ipairs(icons) do
       table.insert(hl, { v.hl, line, depth+icon_len+#icon, depth+icon_len+#icon+#v.icon })
       icon = icon..v.icon.." "

--- a/lua/lib/utils.lua
+++ b/lua/lib/utils.lua
@@ -1,7 +1,14 @@
 local M = {}
+local api = vim.api
 
 function M.path_to_matching_str(path)
   return path:gsub('(%-)', '(%%-)'):gsub('(%.)', '(%%.)'):gsub('(%_)', '(%%_)')
+end
+
+function M.echo_warning(msg)
+  api.nvim_command('echohl WarningMsg')
+  api.nvim_command("echom '[LuaTree] "..msg:gsub("'", "''").."'")
+  api.nvim_command('echohl None')
 end
 
 return M


### PR DESCRIPTION
Git deleted state (` D`) wasn't handled, so it threw an error, because fallback wasn't set properly.
This PR introduces handling the delete state, and properly falling back to default dirty state if not found in the table. Feel free to adjust the icon, I wasn't sure what to put.