### PR TITLE
Update document for g:lua_tree_width

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Plug 'ryanoasis/vim-devicons'
 
 ```vim
 let g:lua_tree_side = 'right' | 'left' "left by default
-let g:lua_tree_size = 40 "30 by default
+let g:lua_tree_width = 40 "30 by default
 let g:lua_tree_ignore = [ '.git', 'node_modules', '.cache' ] "empty by default
 let g:lua_tree_auto_open = 1 "0 by default, opens the tree when typing `vim $DIR` or `vim`
 let g:lua_tree_auto_close = 1 "0 by default, closes the tree when it's the last window

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -52,7 +52,7 @@ Print clipboard content for both cut and copy
 ==============================================================================
 OPTIONS				                  *nvim-tree-options*
 
-|g:lua_tree_size|				*g:lua_tree_size*
+|g:lua_tree_width|				*g:lua_tree_width*
 
 width of the window (default to 30)
 


### PR DESCRIPTION
Replace `g:lua_tree_size` with `g:lua_tree_width` in document according to https://github.com/kyazdani42/nvim-tree.lua/blob/master/lua/lib/lib.lua#L19.

Please check, thanks.