### PR TITLE
Delete current buffer if tree is last window

### DIFF
--- a/lua/tree.lua
+++ b/lua/tree.lua
@@ -131,7 +131,7 @@ end
 function M.on_leave()
   vim.defer_fn(function()
     if #api.nvim_list_wins() == 1 and lib.win_open() then
-      api.nvim_command(':qa!')
+      api.nvim_command(':bd!')
     end
   end, 50)
 end


### PR DESCRIPTION
Currently if `LuaTree` is the last window and `g:autoclose_tree` is set to `1` `:qa!` is executed. This command will **quit vim** which I'm _guessing_ is not the desired functionality because what this means is if you have the tree open and a buffer in the other split and press `q` or `bd` with the tree open your vim session will be closed which is very frustrating 😅 .

This PR switch the command to use to `:bd`, which works by unloading the tree buffer and closing **it's** window but not vim which is what I'd expect this command to do.