### PR TITLE
Fix git root of nil error

### DIFF
--- a/lua/lib/git.lua
+++ b/lua/lib/git.lua
@@ -28,6 +28,7 @@ function M.reload_roots()
 end
 
 local function get_git_root(path)
+  --- FIXME this does not check if the path is a subdirectory of the roots
   if roots[path] then
     return path, roots[path]
   end
@@ -63,6 +64,9 @@ function M.update_status(entries, _cwd)
     return
   end
 
+  -- setting the git root above can still result in no git root being
+  -- found despite the repository being a git repo
+  if not git_root then return end
   local matching_cwd = utils.path_to_matching_str(git_root..'/')
   for _, node in pairs(entries) do
     local relpath = node.absolute_path:gsub(matching_cwd, '')


### PR DESCRIPTION
This PR attempts to fix #28. @kyazdani42 would be good to get your input since I'm not 100% sure on the best solution as I'm not super familiar with this bit of the code.

The issue I was seeing in #28 is that I have a project structured like
```
my_project/
	subdir/file.ext
```
I use `vim-rooter` but I tested with it disabled and it's not related. I have a session with a few buffers.
```
[my_project/subdir/file.ext] [~/random_dependency/file.ext]  [~/random_dependency/file2.ext]
```
When I navigate from `subdir/file.ext` to the next and then finally come back I see a 
```
E5108: Error executing lua .../nvim-tree.lua/lua/lib/git.lua:70: attempt to concatenate local 'git_root' (a nil value) 
```

I debugged it and narrowed it down to [this line](https://github.com/kyazdani42/nvim-tree.lua/blob/9eea2b8c62aaf1fdc08592593a6cc1fe7086f896/lua/lib/git.lua#L66). This line does not check that the git root exists. Above it there is a check then an attempt to create it but then no further check before it's used again.

It seems that [this line](https://github.com/kyazdani42/nvim-tree.lua/blob/9eea2b8c62aaf1fdc08592593a6cc1fe7086f896/lua/lib/git.lua#L31) in `get_git_root` checks the `cwd` against the table of roots and if it is not there it then only operates on directorys that aren't known to be git ones

The issue I see from logging in my case is that the `roots` looks *something* like
```lua
root = {
 ['my_project/'] = { git_status = {}}
-- but path is 'my_project/subdir'
```
so checking `roots[path]` fails and we return `git_status = true`, `git_root = nil`

#### Solutions
1. I think the proper solution would be to check if the subdir is contained with the root dir somehow (inexpensively 😓 )
2. *The lazy solution* I just check if `git_root` exists one more time before the string concatenation and return early if it doesn't. From what I can see locally it doesn't really make a difference I can still open lua tree and nothing _bad_ happens 😅 