### PR TITLE
no wrap in luatree buffer

### DIFF
--- a/lua/lib/renderer.lua
+++ b/lua/lib/renderer.lua
@@ -284,6 +284,7 @@ function M.draw(tree, reload)
     api.nvim_win_set_cursor(tree.winnr, cursor)
   end
   api.nvim_buf_set_option(tree.bufnr, 'modifiable', false)
+  api.nvim_win_set_option(tree.winnr, 'wrap', false)
 end
 
 function M.render_hl(bufnr)


### PR DESCRIPTION
If file has long name and buffer has no width enough to show complete name, it will wrap in luatree buffer that will looks like ugly.
![image](https://user-images.githubusercontent.com/41671631/97545235-a6c4b500-1a05-11eb-8c52-6d5d6c3ff34d.png)
