### PR TITLE
Fixes non-git project slow saving

### DIFF
--- a/lua/lib/lib.lua
+++ b/lua/lib/lib.lua
@@ -120,12 +120,17 @@ end
 function M.refresh_tree()
   -- local stat = luv.fs_stat(M.Tree.cwd)
   -- if stat.mtime.sec ~= M.Tree.last_modified then
-    refresh_nodes(M.Tree)
+  refresh_nodes(M.Tree)
   -- end
+  local _, status = git.get_git_root(M.Tree.cwd)
+
   if config.get_icon_state().show_git_icon or vim.g.lua_tree_git_hl then
-    git.reload_roots()
-    refresh_git(M.Tree)
+    if status ~= git.not_git then
+      git.reload_roots()
+      refresh_git(M.Tree)
+    end
   end
+
   if M.win_open() then
     renderer.draw(M.Tree, true)
   else


### PR DESCRIPTION
## What

The configured BufWritePost autocmd refreshes the current Tree
and all of its descendant nodes.

This is fine in actual git projects but makes file writes really slow
when in my home directory (it recurses through all of the nodes - quite a
few of them if you have node_modules installed).

In this PR I'm updating the behaviour to only refresh git in git projects

## Why

To speed up saving files in not git projects

## AC

- [x] I've tested that it's fast on non-git project trees
- [x] I've tested that this still updates the icons for git project trees