### PR TITLE
Add close_node action to close parent directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ let g:lua_tree_bindings = {
     \ 'edit_vsplit':     '<C-v>',
     \ 'edit_split':      '<C-x>',
     \ 'edit_tab':        '<C-t>',
+    \ 'close_node':      ['<S-CR>', '<BS>'],
     \ 'toggle_ignored':  'I',
     \ 'toggle_dotfiles': 'H',
     \ 'refresh':         'R',
@@ -108,6 +109,7 @@ highlight LuaTreeFolderIcon guibg=blue
 - move around like in any vim buffer
 - `<CR>` on `..` will cd in the above directory
 - `<C-]>` will cd in the directory under the cursor
+- `<BS>` will close current opened directory or parent
 - type `a` to add a file. Adding a directory requires leaving a leading `/` at the end of the path.
   > you can add multiple directories by doing foo/bar/baz/f and it will add foo bar and baz directories and f as a file
 - type `r` to rename a file

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -183,6 +183,7 @@ INFORMATIONS				        *nvim-tree-info*
 - move around like in any vim buffer
 - '<CR>' on '..' will cd in the above directory
 - typing '<C-]>' will cd in the directory under the cursor
+- typing '<BS>' will close current opened directory or parent
 
 - type 'a' to add a file
 - type 'r' to rename a file
@@ -219,6 +220,7 @@ default keybindings will be applied to undefined keys.
         \ edit_vsplit:   '<c-v>',
         \ edit_split:    '<c-x>',
         \ edit_tab:      '<c-t>',
+        \ close_node:    ['<s-cr>', '<bs>'],
         \ cd:            '<c-]>',
         \ preview:       '<Tab>',
         \ create:        'a',

--- a/lua/lib/config.lua
+++ b/lua/lib/config.lua
@@ -55,6 +55,7 @@ function M.get_bindings()
     edit_vsplit     = keybindings.edit_vsplit or '<C-v>',
     edit_split      = keybindings.edit_split or '<C-x>',
     edit_tab        = keybindings.edit_tab or '<C-t>',
+    close_node      = keybindings.close_node or {'<S-CR>', '<BS>'},
     preview         = keybindings.preview or '<Tab>',
     toggle_ignored  = keybindings.toggle_ignored or 'I',
     toggle_dotfiles = keybindings.toggle_dotfiles or 'H',

--- a/lua/tree.lua
+++ b/lua/tree.lua
@@ -65,6 +65,7 @@ local keypress_funcs = {
   copy = fs.copy,
   cut = fs.cut,
   paste = fs.paste,
+  close_node = lib.close_node,
   toggle_ignored = lib.toggle_ignored,
   toggle_dotfiles = lib.toggle_dotfiles,
   refresh = lib.refresh_tree,


### PR DESCRIPTION
Introduce `close_node` action and keybinding <kbd>Backspace</kbd> to close current opened directory, or parent.
Fixes #105 

This works great for h/j/k/l movement:
```vim
let g:lua_tree_bindings = {
\ 'close_node': 'h',
\ 'edit': 'l',
\ }
```