### PR TITLE
Add nil check for link_to

### DIFF
--- a/lua/lib/populate.lua
+++ b/lua/lib/populate.lua
@@ -49,7 +49,7 @@ local function link_new(cwd, name)
   local absolute_path = cwd..'/'..name
   local link_to = luv.fs_realpath(absolute_path)
   local open, entries
-  if luv.fs_stat(link_to).type == 'directory' then
+  if (link_to ~= nil) and luv.fs_stat(link_to).type == 'directory' then
     open = false
     entries = {}
   end


### PR DESCRIPTION
I've been getting some errors on startup due to link_to being nil, so I figured I should add a nil check. Let me know if you have any suggestions.