### PR TITLE
feat: auto close: avoid force user to press Enter key to exit

### DIFF
--- a/lua/tree.lua
+++ b/lua/tree.lua
@@ -154,7 +154,7 @@ end
 function M.on_leave()
   vim.defer_fn(function()
     if #api.nvim_list_wins() == 1 and lib.win_open() then
-      api.nvim_command(':qa!')
+      api.nvim_command(':silent qa!')
     end
   end, 50)
 end


### PR DESCRIPTION
with `let g:lua_tree_auto_close = 1`, while closing the tree when it's the last window,
neovim ask the user: "Press ENTER or type command to continue"

![image](https://user-images.githubusercontent.com/41882455/102087479-9735ea00-3e54-11eb-96c0-425039611bb2.png)


this patch should fixup the problem