### PR TITLE
feat: g:lua_tree_ignore support *.extension

### DIFF
--- a/lua/lib/populate.lua
+++ b/lua/lib/populate.lua
@@ -74,6 +74,7 @@ local function gen_ignore_check()
 
   return function(path)
     idx = path:match(".+()%.%w+$")
+    local ignore_extension
     if idx then
         ignore_extension = ignore_list['*'..string.sub(path, idx)]
     end

--- a/lua/lib/populate.lua
+++ b/lua/lib/populate.lua
@@ -73,9 +73,13 @@ local function gen_ignore_check()
   end
 
   return function(path)
+    idx = path:match(".+()%.%w+$")
+    if idx then
+        ignore_extension = ignore_list['*'..string.sub(path, idx)]
+    end
     local ignore_path = not M.show_ignored and ignore_list[path] == true
     local ignore_dotfiles = not M.show_dotfiles and path:sub(1, 1) == '.'
-    return ignore_path or ignore_dotfiles
+    return ignore_extension or ignore_path or ignore_dotfiles
   end
 end
 


### PR DESCRIPTION
For example, I don't want to display `*.pyc` files in python project. Now I can achieve it by adding `*.pyc` to the `g:lua_tree_ignore`.

This is a simple but small change implementation.