### PR TITLE
fix file icon length

### DIFF
--- a/lua/lib/renderer.lua
+++ b/lua/lib/renderer.lua
@@ -42,7 +42,7 @@ if icon_state.show_file_icon then
 
     if icon then
       if hl_group then
-        table.insert(hl, { hl_group, line, depth, depth + #icon })
+        table.insert(hl, { hl_group, line, depth, depth + #icon + 1 })
       end
       return icon.." "
     else


### PR DESCRIPTION
This PR fixes the inconsistency in how we calculate the length of folder icon and file icon. 
Length of folder icon was calculated after a space is appended, and length of file icon was calculated without any space appended.
It is fixed by adding one after `#icon` for file icons.

This PR should fix #160 


