### PR TITLE
Add dir_up function to expose navigating up one directory

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -105,6 +105,19 @@ function M.on_keypress(mode)
   end
 end
 
+function M.dir_up()
+    local node = lib.get_node_at_cursor()
+    if not node then
+        return lib.change_dir('..')
+    else
+        local newdir = vim.fn.fnamemodify(node.absolute_path, ':h')
+        if newdir == lib.Tree.cwd then
+            lib.change_dir('..')
+        end
+        lib.set_index_and_redraw(newdir)
+    end
+end
+
 function M.refresh()
   lib.refresh_tree()
 end


### PR DESCRIPTION
Just a suggestion. I like to use the '-' key to open the tree, then inside the tree, to use '-' to quickly navigate up through the directory structure. I couldn't figure out how to do that second part without adding a function to the main package. If there's a better way to do this, I'd love to hear it. Thanks