### PR TITLE
Execute action in target window if possible (fixes #171)

### DIFF
--- a/lua/lib/lib.lua
+++ b/lua/lib/lib.lua
@@ -20,6 +20,7 @@ M.Tree = {
   win_width_allow_resize = vim.g.nvim_tree_width_allow_resize,
   loaded = false,
   bufnr = nil,
+  target_winid = nil,
   winnr = function()
     for _, i in ipairs(api.nvim_list_wins()) do
       if api.nvim_buf_get_name(api.nvim_win_get_buf(i)):match('.*/'..M.Tree.buf_name..'$') then
@@ -189,17 +190,47 @@ local function check_and_open_split()
 end
 
 function M.open_file(mode, filename)
+  local target_winnr = api.nvim_eval(string.format('win_id2win(%d)', M.Tree.target_winid))
+  local target_bufnr = target_winnr > 0 and api.nvim_eval(string.format('winbufnr(%d)', M.Tree.target_winid))
+  local splitcmd = window_opts.split_command == 'splitright' and 'vsplit' or 'split'
+  local ecmd = target_bufnr and string.format('%dwindo %s', target_winnr, mode == 'preview' and 'edit' or mode) or (mode == 'preview' and 'edit' or mode)
+
   api.nvim_command('noautocmd wincmd '..window_opts.open_command)
-  if mode == 'preview' then
-    check_and_open_split()
-    api.nvim_command(string.format("edit %s", filename))
-    api.nvim_command('noautocmd wincmd '..window_opts.preview_command)
-  else
-    if mode == 'edit' then
-      check_and_open_split()
+
+  local found = false
+  for _, win in ipairs(api.nvim_list_wins()) do
+    if filename == api.nvim_buf_get_name(api.nvim_win_get_buf(win)) then
+      found = true
+      ecmd = function() M.win_focus(win) end
     end
-    api.nvim_command(string.format("%s %s", mode, filename))
   end
+
+  if not found and (mode == 'edit' or mode == 'preview') then
+    if target_bufnr then
+      if api.nvim_buf_get_option(target_bufnr, 'modified') then
+        ecmd = string.format('%dwindo %s', target_winnr, splitcmd)
+      end
+    else
+      ecmd = splitcmd
+    end
+  end
+
+  if type(ecmd) == 'string' then
+      api.nvim_command(string.format('%s %s', ecmd, filename))
+  else
+      ecmd()
+  end
+
+  if mode == 'preview' then
+    if not found then M.set_target_win() end
+    M.win_focus()
+    return
+  end
+
+  if found then
+    return
+  end
+
   if not M.Tree.win_width_allow_resize then
     local cur_win = api.nvim_get_current_win()
     M.win_focus()
@@ -296,7 +327,12 @@ function M.close()
   M.Tree.bufnr = nil
 end
 
+function M.set_target_win()
+  M.Tree.target_winid = api.nvim_eval(string.format('win_getid(bufwinnr(%d))', api.nvim_get_current_buf()))
+end
+
 function M.open()
+  M.set_target_win()
   create_buf()
   create_win()
   api.nvim_win_set_buf(M.Tree.winnr(), M.Tree.bufnr)

--- a/lua/lib/lib.lua
+++ b/lua/lib/lib.lua
@@ -190,8 +190,8 @@ local function check_and_open_split()
 end
 
 function M.open_file(mode, filename)
-  local target_winnr = api.nvim_eval(string.format('win_id2win(%d)', M.Tree.target_winid))
-  local target_bufnr = target_winnr > 0 and api.nvim_eval(string.format('winbufnr(%d)', M.Tree.target_winid))
+  local target_winnr = vim.fn.win_id2win(M.Tree.target_winid)
+  local target_bufnr = target_winnr > 0 and vim.fn.winbufnr(M.Tree.target_winid)
   local splitcmd = window_opts.split_command == 'splitright' and 'vsplit' or 'split'
   local ecmd = target_bufnr and string.format('%dwindo %s', target_winnr, mode == 'preview' and 'edit' or mode) or (mode == 'preview' and 'edit' or mode)
 
@@ -328,7 +328,7 @@ function M.close()
 end
 
 function M.set_target_win()
-  M.Tree.target_winid = api.nvim_eval(string.format('win_getid(bufwinnr(%d))', api.nvim_get_current_buf()))
+  M.Tree.target_winid = vim.fn.win_getid(vim.fn.bufwinnr(api.nvim_get_current_buf()))
 end
 
 function M.open()

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -33,6 +33,8 @@ function M.open(cb)
     function()
       if not lib.win_open() then
         lib.open()
+      else
+        lib.set_target_win()
       end
       pcall(cb)
     end


### PR DESCRIPTION
Hi, this is for your consideration. If you don't buy my arguments, I understand.

I think this addresses the concern in issue #171 and maybe a few others

Rationale: I prefer somewhat different semantics than the existing code when opening a node, as described below. To me, this is more intuitive and more or less follows what NERD_Tree does (as I recall -- been a while since I used it). For example, some things that are better in my view with this approach:

* If I start nvim-tree from the leftmost window while that buffer is modified, the default edit command would fail to open the file. With this approach, if the window contains a modified buffer, it will split automatically.

* if I open nvim-tree from the rightmost window, when I open a node it will replace my leftmost buffer, which i most likely didn't want to change.

With this approach, we open files in the window from which the tree was opened, if possible. I call this window the target. If the buffer in the target window is modified, then execute the configured split (split or vsplit) relative to the target. If the target is unmodified, open the selected node in the target, hiding original the buffer. Other windows are untouched. If the selected node is already visible in a window, don't do any of the foregoing; instead, just jump to that window. If the target has been closed, the preserve the original semantics, except that the modified check is still done.
