### PR TITLE
Honor the 'hidden' option when deciding whether to split the target window

### DIFF
--- a/lua/lib/lib.lua
+++ b/lua/lib/lib.lua
@@ -183,12 +183,6 @@ function M.set_index_and_redraw(fname)
   end
 end
 
-local function check_and_open_split()
-  if #api.nvim_list_wins() == 1 then
-    api.nvim_command("vnew")
-  end
-end
-
 function M.open_file(mode, filename)
   local target_winnr = vim.fn.win_id2win(M.Tree.target_winid)
   local target_bufnr = target_winnr > 0 and vim.fn.winbufnr(M.Tree.target_winid)

--- a/lua/lib/lib.lua
+++ b/lua/lib/lib.lua
@@ -207,7 +207,7 @@ function M.open_file(mode, filename)
 
   if not found and (mode == 'edit' or mode == 'preview') then
     if target_bufnr then
-      if api.nvim_buf_get_option(target_bufnr, 'modified') then
+      if not vim.o.hidden and api.nvim_buf_get_option(target_bufnr, 'modified') then
         ecmd = string.format('%dwindo %s', target_winnr, splitcmd)
       end
     else


### PR DESCRIPTION
- Honor `hidden` setting when deciding whether to split window
- Remove unused `check_and_open_split()`

Refer to [this comment](https://github.com/kyazdani42/nvim-tree.lua/pull/174#issuecomment-761575598)
