### PR TITLE
Don't do `git status -u` if repo is configured not to show untracked files

### DIFF
--- a/lua/lib/git.lua
+++ b/lua/lib/git.lua
@@ -6,7 +6,11 @@ local roots = {}
 local not_git = 'not a git repo'
 
 local function update_root_status(root)
-  local status = vim.fn.systemlist('cd "'..root..'" && git status --porcelain=v1 -u')
+  local untracked = ' -u'
+  if vim.fn.trim(vim.fn.system('git config --type=bool status.showUntrackedFiles')) == 'false' then
+    untracked = ''
+  end
+  local status = vim.fn.systemlist('cd "'..root..'" && git status --porcelain=v1'..untracked)
   roots[root] = {}
 
   for _, v in pairs(status) do


### PR DESCRIPTION
Some git use cases, specifically, in my case, where $HOME is a git worktree
with a bare git repo somewhere else, really get bogged down if you do `git
status -u`. It was making the plugin unusable when `GIT_WORK_TREE=$HOME`
environment variable is set as such. This overcomes that issue.
