### PR TITLE
fix: escape filename before opening it

### DIFF
--- a/lua/lib/lib.lua
+++ b/lua/lib/lib.lua
@@ -210,7 +210,7 @@ function M.open_file(mode, filename)
   end
 
   if type(ecmd) == 'string' then
-      api.nvim_command(string.format('%s %s', ecmd, filename))
+      api.nvim_command(string.format('%s %s', ecmd, vim.fn.fnameescape(filename)))
   else
       ecmd()
   end


### PR DESCRIPTION
I have a weird case where I need to open a file with `$` in its filename. ex. `$layout.svelte`, if we don't escape it, it will open a buffer with `.svelte` as its filename instead of `$layout.svelte`