### PR TITLE
Avoid intro screen cleared

### DIFF
--- a/lua/lib/colors.lua
+++ b/lua/lib/colors.lua
@@ -62,6 +62,7 @@ local function get_links()
     FileMerge = 'NvimTreeGitMerge',
     FileStaged = 'NvimTreeGitStaged',
     FileDeleted = 'NvimTreeGitDeleted',
+    Popup = 'Normal',
   }
 end
 

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -130,7 +130,6 @@ function M.on_enter()
   local should_open = vim.g.nvim_tree_auto_open == 1 and
     (bufname == '' or is_dir) and
     not vim.tbl_contains(ft_ignore, buftype)
-  colors.setup()
   lib.init(should_open, should_open)
 end
 

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -212,6 +212,7 @@ function M.xdg_open()
   end))
 end
 
+colors.setup()
 vim.defer_fn(M.on_enter, 1)
 
 return M

--- a/plugin/tree.vim
+++ b/plugin/tree.vim
@@ -6,8 +6,6 @@ set cpo&vim
 let g:loaded_netrw = 1
 let g:loaded_netrwPlugin = 1
 
-lua require'nvim-tree'.reset_highlight()
-
 augroup NvimTree
   au BufWritePost * lua require'nvim-tree'.refresh()
   au BufEnter * lua require'nvim-tree'.buf_enter()

--- a/plugin/tree.vim
+++ b/plugin/tree.vim
@@ -7,6 +7,7 @@ let g:loaded_netrw = 1
 let g:loaded_netrwPlugin = 1
 
 hi def link NvimTreePopup Normal
+lua require'nvim-tree'.reset_highlight()
 
 augroup NvimTree
   au BufWritePost * lua require'nvim-tree'.refresh()

--- a/plugin/tree.vim
+++ b/plugin/tree.vim
@@ -6,7 +6,6 @@ set cpo&vim
 let g:loaded_netrw = 1
 let g:loaded_netrwPlugin = 1
 
-hi def link NvimTreePopup Normal
 lua require'nvim-tree'.reset_highlight()
 
 augroup NvimTree


### PR DESCRIPTION
This solves #193 as I posed.
I try to avoid `colors.setup()` being deferred by moving it into `plugin/tree.vim`.