### PR TITLE
Feat/empty directory icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ let g:nvim_tree_icons = {
     \ 'folder': {
     \   'default': "",
     \   'open': "",
+    \    empty = "",
+    \    empty_open = "",
     \   'symlink': "",
     \   }
     \ }

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -287,6 +287,7 @@ NvimTreeSymlink
 NvimTreeFolderName
 NvimTreeRootFolder
 NvimTreeFolderIcon
+NvimTreeEmptyFolderName
 NvimTreeExecFile
 NvimTreeSpecialFile
 NvimTreeImageFile

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -107,6 +107,8 @@ You can set icons for:
       \ 'folder': {
       \   'default': "",
       \   'open': "",
+      \    empty = "",
+      \    empty_open = "",
       \   'symlink': "",
       \  }
       \ }

--- a/lua/lib/colors.lua
+++ b/lua/lib/colors.lua
@@ -51,6 +51,7 @@ end
 local function get_links()
   return {
     FolderName = 'Directory',
+    EmptyFolderName = 'Directory',
     Normal = 'Normal',
     EndOfBuffer = 'EndOfBuffer',
     CursorLine = 'CursorLine',

--- a/lua/lib/config.lua
+++ b/lua/lib/config.lua
@@ -16,6 +16,8 @@ function M.get_icon_state()
     folder_icons = {
       default = "",
       open = "",
+      empty = "",
+      empty_open = "",
       symlink = "",
     }
   }

--- a/lua/lib/fs.lua
+++ b/lua/lib/fs.lua
@@ -54,6 +54,7 @@ function M.create(node)
   if not ans or #ans == 0 then return end
 
   if not ans:match('/') then
+    node.open = true
     return create_file(add_into..ans)
   end
 

--- a/lua/lib/lib.lua
+++ b/lua/lib/lib.lua
@@ -92,6 +92,7 @@ end
 
 function M.unroll_dir(node)
   node.open = not node.open
+  if node.children_initial then node.children_initial = false end
   if #node.entries > 0 then
     renderer.draw(M.Tree, true)
   else

--- a/lua/lib/lib.lua
+++ b/lua/lib/lib.lua
@@ -92,7 +92,7 @@ end
 
 function M.unroll_dir(node)
   node.open = not node.open
-  if node.children_initial then node.children_initial = false end
+  if node.has_children then node.has_children = false end
   if #node.entries > 0 then
     renderer.draw(M.Tree, true)
   else

--- a/lua/lib/populate.lua
+++ b/lua/lib/populate.lua
@@ -25,7 +25,7 @@ local function dir_new(cwd, name)
     match_name = path_to_matching_str(name),
     match_path = path_to_matching_str(absolute_path),
     open = false,
-    children_initial = has_children,
+    has_children = has_children,
     entries = {}
   }
 end

--- a/lua/lib/populate.lua
+++ b/lua/lib/populate.lua
@@ -16,7 +16,7 @@ local function dir_new(cwd, name)
   local absolute_path = cwd..'/'..name
   local stat = luv.fs_stat(absolute_path)
   local handle = luv.fs_opendir(absolute_path, nil, 1)
-  local children = luv.fs_readdir(handle)
+  local child = luv.fs_readdir(handle)
   luv.fs_closedir(handle)
   return {
     name = name,
@@ -26,7 +26,7 @@ local function dir_new(cwd, name)
     match_name = path_to_matching_str(name),
     match_path = path_to_matching_str(absolute_path),
     open = false,
-    empty = children == nil,
+    has_children = child ~= nil,
     entries = {}
   }
 end

--- a/lua/lib/populate.lua
+++ b/lua/lib/populate.lua
@@ -15,9 +15,8 @@ local path_to_matching_str = require'lib.utils'.path_to_matching_str
 local function dir_new(cwd, name)
   local absolute_path = cwd..'/'..name
   local stat = luv.fs_stat(absolute_path)
-  local handle = luv.fs_opendir(absolute_path, nil, 1)
-  local child = luv.fs_readdir(handle)
-  luv.fs_closedir(handle)
+  local handle = luv.fs_scandir(absolute_path)
+  local has_children = luv.fs_scandir_next(handle) ~= nil
   return {
     name = name,
     absolute_path = absolute_path,
@@ -26,7 +25,7 @@ local function dir_new(cwd, name)
     match_name = path_to_matching_str(name),
     match_path = path_to_matching_str(absolute_path),
     open = false,
-    has_children = child ~= nil,
+    children_initial = has_children,
     entries = {}
   }
 end

--- a/lua/lib/populate.lua
+++ b/lua/lib/populate.lua
@@ -15,6 +15,9 @@ local path_to_matching_str = require'lib.utils'.path_to_matching_str
 local function dir_new(cwd, name)
   local absolute_path = cwd..'/'..name
   local stat = luv.fs_stat(absolute_path)
+  local handle = luv.fs_opendir(absolute_path, nil, 1)
+  local children = luv.fs_readdir(handle)
+  luv.fs_closedir(handle)
   return {
     name = name,
     absolute_path = absolute_path,
@@ -23,6 +26,7 @@ local function dir_new(cwd, name)
     match_name = path_to_matching_str(name),
     match_path = path_to_matching_str(absolute_path),
     open = false,
+    empty = children == nil,
     entries = {}
   }
 end

--- a/lua/lib/renderer.lua
+++ b/lua/lib/renderer.lua
@@ -16,14 +16,22 @@ local set_folder_hl = function(line, depth, git_icon_len, _, hl_group)
 end
 
 if icon_state.show_folder_icon then
-  get_folder_icon = function(open, is_symlink)
+  get_folder_icon = function(open, is_symlink, is_empty)
     local n = ""
     if is_symlink then
       n = icon_state.icons.folder_icons.symlink
     elseif open then
-      n = icon_state.icons.folder_icons.open
+      if is_empty then
+        n = icon_state.icons.folder_icons.empty_open
+      else
+        n = icon_state.icons.folder_icons.open
+      end
     else
-      n = icon_state.icons.folder_icons.default
+      if is_empty then
+        n = icon_state.icons.folder_icons.empty
+      else
+        n = icon_state.icons.folder_icons.default
+      end
     end
     return n.." "
   end
@@ -230,7 +238,7 @@ local function update_draw_data(tree, depth, markers)
     local git_hl = get_git_hl(node)
 
     if node.entries then
-      local icon = get_folder_icon(node.open, node.link_to ~= nil)
+      local icon = get_folder_icon(node.open, node.link_to ~= nil, node.empty)
       local git_icon = get_git_icons(node, index, offset, #icon+1) or ""
       -- INFO: this is mandatory in order to keep gui attributes (bold/italics)
       set_folder_hl(index, offset, #icon, #node.name+#git_icon, 'NvimTreeFolderName')

--- a/lua/lib/renderer.lua
+++ b/lua/lib/renderer.lua
@@ -238,10 +238,13 @@ local function update_draw_data(tree, depth, markers)
     local git_hl = get_git_hl(node)
 
     if node.entries then
-      local icon = get_folder_icon(node.open, node.link_to ~= nil, #node.entries ~= 0 or node.children_initial)
+      local has_children = #node.entries ~= 0 or node.has_children
+      local icon = get_folder_icon(node.open, node.link_to ~= nil, has_children)
       local git_icon = get_git_icons(node, index, offset, #icon+1) or ""
       -- INFO: this is mandatory in order to keep gui attributes (bold/italics)
-      set_folder_hl(index, offset, #icon, #node.name+#git_icon, 'NvimTreeFolderName')
+      local folder_hl = "NvimTreeFolderName"
+      if not has_children then folder_hl = "NvimTreeEmptyFolderName" end
+      set_folder_hl(index, offset, #icon, #node.name+#git_icon, folder_hl)
       if git_hl then
         set_folder_hl(index, offset, #icon, #node.name+#git_icon, git_hl)
       end

--- a/lua/lib/renderer.lua
+++ b/lua/lib/renderer.lua
@@ -16,21 +16,21 @@ local set_folder_hl = function(line, depth, git_icon_len, _, hl_group)
 end
 
 if icon_state.show_folder_icon then
-  get_folder_icon = function(open, is_symlink, is_empty)
+  get_folder_icon = function(open, is_symlink, has_children)
     local n = ""
     if is_symlink then
       n = icon_state.icons.folder_icons.symlink
     elseif open then
-      if is_empty then
-        n = icon_state.icons.folder_icons.empty_open
-      else
+      if has_children then
         n = icon_state.icons.folder_icons.open
+      else
+        n = icon_state.icons.folder_icons.empty_open
       end
     else
-      if is_empty then
-        n = icon_state.icons.folder_icons.empty
-      else
+      if has_children then
         n = icon_state.icons.folder_icons.default
+      else
+        n = icon_state.icons.folder_icons.empty
       end
     end
     return n.." "
@@ -238,7 +238,8 @@ local function update_draw_data(tree, depth, markers)
     local git_hl = get_git_hl(node)
 
     if node.entries then
-      local icon = get_folder_icon(node.open, node.link_to ~= nil, node.empty)
+      local icon = get_folder_icon(node.open, node.link_to ~= nil, #node.entries ~= 0 or node.has_children)
+      if node.has_children then node.has_children = nil end
       local git_icon = get_git_icons(node, index, offset, #icon+1) or ""
       -- INFO: this is mandatory in order to keep gui attributes (bold/italics)
       set_folder_hl(index, offset, #icon, #node.name+#git_icon, 'NvimTreeFolderName')

--- a/lua/lib/renderer.lua
+++ b/lua/lib/renderer.lua
@@ -238,8 +238,7 @@ local function update_draw_data(tree, depth, markers)
     local git_hl = get_git_hl(node)
 
     if node.entries then
-      local icon = get_folder_icon(node.open, node.link_to ~= nil, #node.entries ~= 0 or node.has_children)
-      if node.has_children then node.has_children = nil end
+      local icon = get_folder_icon(node.open, node.link_to ~= nil, #node.entries ~= 0 or node.children_initial)
       local git_icon = get_git_icons(node, index, offset, #icon+1) or ""
       -- INFO: this is mandatory in order to keep gui attributes (bold/italics)
       set_folder_hl(index, offset, #icon, #node.name+#git_icon, 'NvimTreeFolderName')


### PR DESCRIPTION
## Description

This PR adds the ability to show a separate icon for when a folder is empty. There are options for both open and closed empty directories, and like the other icons they are configurable (by way of `folder.empty` and `folder.empty_open` in `nvim_tree_icons`). Getting this feature to work required adding a single check to see if there is at least one item inside a given directory when first being populated in order to have the correct fullness-icon before the directory is opened.

This feature also required making it such that a directory is automatically set to be open/expanded when a new file or directory is created within it. Though I doubt this will be much of a intrusion to basically anyone.

Upon merging, this will close #204 

## Screenshots

Here is an example of how the feature looks with the default icons:

![image](https://user-images.githubusercontent.com/21961037/108352944-8b003d00-71b5-11eb-8ebb-3749896a7da8.png)

And here is an example with custom icons:

![image](https://user-images.githubusercontent.com/21961037/108307869-abf86c00-717c-11eb-8d69-e43da4de61af.png)

Notice the difference in icons next to `components` and `models`.

## Todo

- [x] Add ability to show empty folder icons
- [x] Make folders update their icons when necessary
- [x] Add icon information to the documentation
- [x] Add highlight groups for empty directories
   (not entirely sure if this one is really necessary, but I'll list it here anyway)

:heart: 