### PR TITLE
change behaviour of rename

### DIFF
--- a/lua/lib/fs.lua
+++ b/lua/lib/fs.lua
@@ -241,7 +241,8 @@ end
 function M.rename(node)
   if node.name == '..' then return end
 
-  local abs_path = string.gsub(node.absolute_path, node.name, '')
+  local namelen = node.name:len()
+  local abs_path = node.absolute_path:sub(0, namelen * (-1) -1)
   local new_name = vim.fn.input("Rename " ..node.name.. " to ", abs_path)
   clear_prompt()
   if not new_name or #new_name == 0 then return end

--- a/lua/lib/fs.lua
+++ b/lua/lib/fs.lua
@@ -241,7 +241,8 @@ end
 function M.rename(node)
   if node.name == '..' then return end
 
-  local new_name = vim.fn.input("Rename " ..node.name.. " to ", node.absolute_path)
+  local abs_path = string.gsub(node.absolute_path, node.name, '')
+  local new_name = vim.fn.input("Rename " ..node.name.. " to ", abs_path)
   clear_prompt()
   if not new_name or #new_name == 0 then return end
 


### PR DESCRIPTION
Changes the behaviour of renaming a file or folder. This will remove the current filename from the absolute path, so it's not necessary to backspace the current name before typing in the new name.