### PR TITLE
Fix error when attempting to read from a restricted directory

### DIFF
--- a/lua/lib/populate.lua
+++ b/lua/lib/populate.lua
@@ -16,7 +16,7 @@ local function dir_new(cwd, name)
   local absolute_path = cwd..'/'..name
   local stat = luv.fs_stat(absolute_path)
   local handle = luv.fs_scandir(absolute_path)
-  local has_children = luv.fs_scandir_next(handle) ~= nil
+  local has_children = handle and luv.fs_scandir_next(handle) ~= nil
   return {
     name = name,
     absolute_path = absolute_path,


### PR DESCRIPTION
I noticed that trying to inspect if a directory was empty, it would error when the user did not have read permissions. This is not a situation that comes up too often, but obviously should be fixed anyway.

The error was coming from the fact that `luv.fs_scandir()` returns `nil` if the specified directory is not readable by the user. `luv.fs_scandir_next()` then assumes that the provided handler is of type `uv_req`, hense the error.