### PR TITLE
feat/fix: add rename cmd, fix rename error

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ let g:nvim_tree_bindings = {
     \ 'create':          'a',
     \ 'remove':          'd',
     \ 'rename':          'r',
+    \ 'full_rename':     '<C-r>',
     \ 'cut':             'x',
     \ 'copy':            'c',
     \ 'paste':           'p',
@@ -114,6 +115,7 @@ highlight NvimTreeFolderIcon guibg=blue
 - type `a` to add a file. Adding a directory requires leaving a leading `/` at the end of the path.
   > you can add multiple directories by doing foo/bar/baz/f and it will add foo bar and baz directories and f as a file
 - type `r` to rename a file
+- type `<C-r>` to rename a file and omit the filename on input
 - type `x` to add/remove file/directory to cut clipboard
 - type `c` to add/remove file/directory to copy clipboard
 - type `p` to paste from clipboard. Cut clipboard has precedence over copy (will prompt for confirmation)

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -211,6 +211,7 @@ INFORMATIONS				        *nvim-tree-info*
 
 - type 'a' to add a file
 - type 'r' to rename a file
+- type `<C-r>` to rename a file and omit the filename on input
 - type 'x' to add/remove file/directory to cut clipboard
 - type 'c' to add/remove file/directory to copy clipboard
 - type 'p' to paste from clipboard. Cut clipboard has precedence over copy

--- a/lua/lib/config.lua
+++ b/lua/lib/config.lua
@@ -67,6 +67,7 @@ function M.get_bindings()
     create          = keybindings.create or 'a',
     remove          = keybindings.remove or 'd',
     rename          = keybindings.rename or 'r',
+    full_rename     = keybindings.full_rename or '<C-r>',
     cut             = keybindings.cut or 'x',
     copy            = keybindings.copy or 'c',
     paste           = keybindings.paste or 'p',

--- a/lua/lib/lib.lua
+++ b/lua/lib/lib.lua
@@ -272,6 +272,7 @@ local function set_mappings()
     [bindings.create] = 'on_keypress("create")';
     [bindings.remove] = 'on_keypress("remove")';
     [bindings.rename] = 'on_keypress("rename")';
+    [bindings.full_rename] = 'on_keypress("full_rename")';
     [bindings.preview] = 'on_keypress("preview")';
     [bindings.cut] = 'on_keypress("cut")';
     [bindings.copy] = 'on_keypress("copy")';

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -65,7 +65,8 @@ end
 local keypress_funcs = {
   create = fs.create,
   remove = fs.remove,
-  rename = fs.rename,
+  rename = fs.rename(false),
+  full_rename = fs.rename(true),
   copy = fs.copy,
   cut = fs.cut,
   paste = fs.paste,


### PR DESCRIPTION
- add <C-r> binding to omit the filename on rename (option is
  full_rename).
- call `silent! write!` on rename to avoid the `overwrite existing file`
  error when saving the buffer.