### PR TITLE
Fix: wrong dictionary format example for empty & empty_open on doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ let g:nvim_tree_icons = {
     \ 'folder': {
     \   'default': "",
     \   'open': "",
-    \    empty = "",
-    \    empty_open = "",
+    \   'empty': "",
+    \   'empty_open': "",
     \   'symlink': "",
     \   }
     \ }

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -95,21 +95,21 @@ You can set icons for:
 - Symlinks. If an icon is not provided, the `default` icon is used.
 >
   let g:nvim_tree_icons = {
-      \ 'default': '',
-      \ 'symlink': '',
+      \ 'default':      '',
+      \ 'symlink':      '',
       \ 'git': {
-      \   'unstaged': "✗",
-      \   'staged': "✓",
-      \   'unmerged': "",
-      \   'renamed': "➜",
-      \   'untracked': "★"
+      \   'unstaged':   "✗",
+      \   'staged':     "✓",
+      \   'unmerged':   "",
+      \   'renamed':    "➜",
+      \   'untracked':  "★"
       \   },
       \ 'folder': {
-      \   'default': "",
-      \   'open': "",
-      \   'empty': "",
+      \   'default':    "",
+      \   'open':       "",
+      \   'empty':      "",
       \   'empty_open': "",
-      \   'symlink': "",
+      \   'symlink':    "",
       \  }
       \ }
 

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -107,8 +107,8 @@ You can set icons for:
       \ 'folder': {
       \   'default': "",
       \   'open': "",
-      \    empty = "",
-      \    empty_open = "",
+      \   'empty': "",
+      \   'empty_open': "",
       \   'symlink': "",
       \  }
       \ }


### PR DESCRIPTION
There is some wrong example on `g:nvim_tree_icons` dictionary value for folder `empty` & `empty_open`.
I guess that example is for lua.