### PR TITLE
feat: Option for grouping empty directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ let g:nvim_tree_width_allow_resize  = 1 "0 by default, will not resize the tree 
 let g:nvim_tree_disable_netrw = 0 "1 by default, disables netrw
 let g:nvim_tree_hijack_netrw = 0 "1 by default, prevents netrw from automatically opening when opening directories (but lets you keep its other utilities)
 let g:nvim_tree_add_trailing = 1 "0 by default, append a trailing slash to folder names
+let g:nvim_tree_group_empty = 1 " 0 by default, compact folders that only contain a single folder into one node in the file tree
 let g:nvim_tree_show_icons = {
     \ 'git': 1,
     \ 'folders': 0,

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -203,6 +203,11 @@ functionnalities.
 Can be 0 or 1. When 1, appends a trailing slash to folder names.
 0 by default.
 
+|g:nvim_tree_group_empty|                         *g:nvim_tree_group_empty*
+
+Can be 0 or 1. When 1, folders that contain only one folder are grouped
+together. 0 by default.
+
 ==============================================================================
 INFORMATIONS				        *nvim-tree-info*
 

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -95,7 +95,7 @@ function M.on_keypress(mode)
   if node.name == ".." then
     return lib.change_dir("..")
   elseif mode == "cd" and node.entries ~= nil then
-    return lib.change_dir(node.absolute_path)
+    return lib.change_dir(lib.get_last_group_node(node).absolute_path)
   elseif mode == "cd" then
     return
   end

--- a/lua/nvim-tree/fs.lua
+++ b/lua/nvim-tree/fs.lua
@@ -3,6 +3,7 @@ local luv = vim.loop
 local open_mode = luv.constants.O_CREAT + luv.constants.O_WRONLY + luv.constants.O_TRUNC
 
 local utils = require'nvim-tree.utils'
+local lib = require'nvim-tree.lib'
 local M = {}
 local clipboard = {
   move = {},
@@ -41,6 +42,7 @@ local function get_num_entries(iter)
 end
 
 function M.create(node)
+  node = lib.get_last_group_node(node)
   if node.name == '..' then return end
 
   local add_into
@@ -168,6 +170,7 @@ local function do_single_paste(source, dest, action_type, action_fn)
 end
 
 local function do_paste(node, action_type, action_fn)
+  node = lib.get_last_group_node(node)
   if node.name == '..' then return end
   local clip = clipboard[action_type]
   if #clip == 0 then return end
@@ -242,6 +245,7 @@ end
 
 function M.rename(with_sub)
   return function(node)
+    node = lib.get_last_group_node(node)
     if node.name == '..' then return end
 
     local namelen = node.name:len()

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -91,6 +91,7 @@ function M.get_node_at_cursor()
   return get_node_at_line(line)(M.Tree.entries)
 end
 
+-- If node is grouped, return the last node in the group. Otherwise, return the given node.
 function M.get_last_group_node(node)
   local next = node
   while next.group_next do

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -46,7 +46,7 @@ M.Tree = {
 
 function M.init(with_open, with_render)
   M.Tree.cwd = luv.cwd()
-  populate(M.Tree.entries, M.Tree.cwd, M.Tree)
+  populate(M.Tree.entries, M.Tree.cwd)
 
   local stat = luv.fs_stat(M.Tree.cwd)
   M.Tree.last_modified = stat.mtime.sec
@@ -91,13 +91,21 @@ function M.get_node_at_cursor()
   return get_node_at_line(line)(M.Tree.entries)
 end
 
+function M.get_last_group_node(node)
+  local next = node
+  while next.group_next do
+    next = next.group_next
+  end
+  return next
+end
+
 function M.unroll_dir(node)
   node.open = not node.open
   if node.has_children then node.has_children = false end
   if #node.entries > 0 then
     renderer.draw(M.Tree, true)
   else
-    populate(node.entries, node.link_to or node.absolute_path)
+    populate(node.entries, node.link_to or node.absolute_path, node)
     renderer.draw(M.Tree, true)
   end
 end
@@ -113,7 +121,7 @@ end
 
 -- TODO update only entries where directory has changed
 local function refresh_nodes(node)
-  refresh_entries(node.entries, node.absolute_path or node.cwd)
+  refresh_entries(node.entries, node.absolute_path or node.cwd, node)
   for _, entry in ipairs(node.entries) do
     if entry.entries and entry.open then
       refresh_nodes(entry)
@@ -159,7 +167,7 @@ function M.set_index_and_redraw(fname)
       if fname:match(entry.match_path..'/') ~= nil then
         if #entry.entries == 0 then
           reload = true
-          populate(entry.entries, entry.absolute_path)
+          populate(entry.entries, entry.absolute_path, entry)
         end
         if entry.open == false then
           reload = true

--- a/lua/nvim-tree/renderer.lua
+++ b/lua/nvim-tree/renderer.lua
@@ -252,17 +252,23 @@ local function update_draw_data(tree, depth, markers)
       local git_icon = get_git_icons(node, index, offset, #icon+1) or ""
       -- INFO: this is mandatory in order to keep gui attributes (bold/italics)
       local folder_hl = "NvimTreeFolderName"
+      local name = node.name
+      local next = node.group_next
+      while next do
+        name = name .. "/" .. next.name
+        next = next.group_next
+      end
       if not has_children then folder_hl = "NvimTreeEmptyFolderName" end
-      set_folder_hl(index, offset, #icon, #node.name+#git_icon, folder_hl)
+      set_folder_hl(index, offset, #icon, #name+#git_icon, folder_hl)
       if git_hl then
-        set_folder_hl(index, offset, #icon, #node.name+#git_icon, git_hl)
+        set_folder_hl(index, offset, #icon, #name+#git_icon, git_hl)
       end
       index = index + 1
       if node.open then
-        table.insert(lines, padding..icon..git_icon..node.name..(vim.g.nvim_tree_add_trailing == 1 and '/' or ''))
+        table.insert(lines, padding..icon..git_icon..name..(vim.g.nvim_tree_add_trailing == 1 and '/' or ''))
         update_draw_data(node, depth + 2, markers)
       else
-        table.insert(lines, padding..icon..git_icon..node.name..(vim.g.nvim_tree_add_trailing == 1 and '/' or ''))
+        table.insert(lines, padding..icon..git_icon..name..(vim.g.nvim_tree_add_trailing == 1 and '/' or ''))
       end
     elseif node.link_to then
       local icon = get_symlink_icon()


### PR DESCRIPTION
Fixes #191.
This adds an option `g:nvim_tree_group_empty` (disabled by default) that compacts dirs that only contain 1 dir / symlink dir, into one node in the file tree.

![2021-03-25-012655_maim](https://user-images.githubusercontent.com/2786478/112401165-34cd6f00-8d0a-11eb-8e16-4e059de56867.png)

