### PR TITLE
feat: preserve the file tree buffer

### DIFF
--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -269,7 +269,6 @@ end
 
 local function create_buf()
   local options = {
-    -- bufhidden = 'wipe';
     buftype = 'nofile';
     modifiable = false;
   }

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -239,6 +239,10 @@ function M.open_file(mode, filename)
 end
 
 function M.change_dir(foldername)
+  if vim.fn.expand(foldername) == M.Tree.cwd then
+    return
+  end
+
   api.nvim_command('cd '..foldername)
   M.Tree.entries = {}
   M.init(false, M.Tree.bufnr ~= nil)
@@ -265,7 +269,7 @@ end
 
 local function create_buf()
   local options = {
-    bufhidden = 'wipe';
+    -- bufhidden = 'wipe';
     buftype = 'nofile';
     modifiable = false;
   }
@@ -291,7 +295,6 @@ function M.close()
     return vim.cmd ':q!'
   end
   api.nvim_win_close(M.Tree.winnr(), true)
-  M.Tree.bufnr = nil
 end
 
 function M.set_target_win()
@@ -300,7 +303,11 @@ end
 
 function M.open()
   M.set_target_win()
-  create_buf()
+
+  if not M.buf_exists() then
+    create_buf()
+  end
+
   create_win()
   api.nvim_win_set_buf(M.Tree.winnr(), M.Tree.bufnr)
 
@@ -367,6 +374,13 @@ function M.win_focus(winnr)
   end
 
   api.nvim_set_current_win(wnr)
+end
+
+function M.buf_exists()
+  return ( M.Tree.bufnr
+    and vim.fn.bufexists(M.Tree.bufnr) == 1
+    and vim.fn.bufname(M.Tree.bufnr) == M.Tree.buf_name
+    )
 end
 
 function M.toggle_ignored()

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -275,6 +275,7 @@ local function create_buf()
 
   M.Tree.bufnr = api.nvim_create_buf(false, true)
   api.nvim_buf_set_name(M.Tree.bufnr, M.Tree.buf_name)
+  api.nvim_buf_set_var(M.Tree.bufnr, "nvim_tree_buffer_ready", 1)
 
   for opt, val in pairs(options) do
     api.nvim_buf_set_option(M.Tree.bufnr, opt, val)
@@ -376,10 +377,20 @@ function M.win_focus(winnr)
 end
 
 function M.buf_exists()
-  return ( M.Tree.bufnr
-    and vim.fn.bufexists(M.Tree.bufnr) == 1
-    and vim.fn.bufname(M.Tree.bufnr) == M.Tree.buf_name
+  local status, exists = pcall(function ()
+    return (
+      M.Tree.bufnr ~= nil
+      and vim.api.nvim_buf_is_valid(M.Tree.bufnr)
+      and vim.api.nvim_buf_get_var(M.Tree.bufnr, "nvim_tree_buffer_ready") == 1
+      and vim.fn.bufname(M.Tree.bufnr) == M.Tree.buf_name
     )
+  end)
+
+  if not status then
+    return false
+  else
+    return exists
+  end
 end
 
 function M.toggle_ignored()


### PR DESCRIPTION
This makes it so that the file tree buffer is only created if a previously created buffer cannot be found.

- What does this solve?
  - When the tree window is closed, the tree buffer is wiped. When the tree window is opened again, the tree buffer is recreated and the state of the previous tree is lost. All previously opened folders are now closed.