### PR TITLE
add event API

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+insert_final_newline = true
+end_of_line = lf
+
+[*.lua]
+indent_style = space
+indent_size = 2

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -436,6 +436,7 @@ For example, registering a handler for when a node is renamed is done like this:
 ==============================================================================
 Lua module: nvim-tree.events                           *nvim-tree.events*
 
+                                     *nvim-tree.events.on_node_renamed()*
 on_node_renamed({handler})
                 Registers a handler for when a node is renamed.
                 • Note: A node can either be a file or a directory.
@@ -444,12 +445,15 @@ on_node_renamed({handler})
                     {handler}    (function) Handler function, with the
                                  signature `function(payload)`.
 
+                                     *nvim-tree.events.on_file_created()*
 on_file_created({handler})
                 Registers a handler for when a file is created.
 
                 Parameters: ~
                     {handler}    (function) Handler function, with the
                                  signature `function(payload)`.
+
+                                     *nvim-tree.events.on_file_removed()*
 on_file_removed({handler})
                 Registers a handler for when a file is removed.
 
@@ -457,6 +461,7 @@ on_file_removed({handler})
                     {handler}    (function) Handler function, with the
                                  signature `function(payload)`.
 
+                                   *nvim-tree.events.on_folder_created()*
 on_folder_created({handler})
                 Registers a handler for when a folder is created.
 
@@ -464,6 +469,7 @@ on_folder_created({handler})
                     {handler}    (function) Handler function, with the
                                  signature `function(payload)`.
 
+                                   *nvim-tree.events.on_folder_removed()*
 on_folder_removed({handler})
                 Registers a handler for when a folder is removed.
 

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1,6 +1,6 @@
 *nvim-tree.lua* A file explorer written in lua
 
-Minimum version of neovim: 0.4.0
+Minimum version of neovim: 0.5.0
 
 Author: Yazdani Kiyan <yazdani.kiyan@protonmail.com>
 
@@ -404,3 +404,69 @@ NvimTreeFileNew
 NvimTreeFileDeleted
 
  vim:tw=78:ts=8:noet:ft=help:norl:
+
+==============================================================================
+EVENTS                  						        *nvim-tree-events*
+
+|nvim_tree_events|	                			        *nvim_tree_events*
+
+nvim-tree will dispatch events whenever an action is made. These events can be
+subscribed to through handler functions. This allows for even further
+customization of nvim-tree.
+
+A handler for an event is just a function which receives one argument -
+the payload of the event. The payload is different for each event type. Refer
+to |nvim_tree_registering_handlers| for more information.
+<
+
+|nvim_tree_registering_handlers|	           	*nvim_tree_registering_handlers*
+
+Handlers are registered by calling the `on_*` functions available in the
+`require('nvim-tree.events')` module. See |nvim-tree.events|.
+
+
+For example, registering a handler for when a node is renamed is done like this: >
+
+    local events = require('nvim-tree.events')
+
+    events.on_node_renamed(function(data)
+        print("Node renamed from " .. data.old_name .. " to " ..  data.new_name)
+    end)
+
+==============================================================================
+Lua module: nvim-tree.events                            *nvim-tree.events*
+
+on_node_renamed({handler})
+                Registers a handler for when a node is renamed.
+                • Note: A node can either be a file or a directory.
+
+                Parameters: ~
+                    {handler}    (function) Handler function, with the
+                                 signature `function(payload)`.
+
+on_file_created({handler})
+                Registers a handler for when a file is created.
+
+                Parameters: ~
+                    {handler}    (function) Handler function, with the
+                                 signature `function(payload)`.
+on_file_removed({handler})
+                Registers a handler for when a file is removed.
+
+                Parameters: ~
+                    {handler}    (function) Handler function, with the
+                                 signature `function(payload)`.
+
+on_folder_created({handler})
+                Registers a handler for when a folder is created.
+
+                Parameters: ~
+                    {handler}    (function) Handler function, with the
+                                 signature `function(payload)`.
+
+on_folder_removed({handler})
+                Registers a handler for when a folder is removed.
+
+                Parameters: ~
+                    {handler}    (function) Handler function, with the
+                                 signature `function(payload)`.

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -406,9 +406,9 @@ NvimTreeFileDeleted
  vim:tw=78:ts=8:noet:ft=help:norl:
 
 ==============================================================================
-EVENTS                  						        *nvim-tree-events*
+EVENTS                                                 *nvim-tree-events*
 
-|nvim_tree_events|	                			        *nvim_tree_events*
+|nvim_tree_events|                                     *nvim_tree_events*
 
 nvim-tree will dispatch events whenever an action is made. These events can be
 subscribed to through handler functions. This allows for even further
@@ -419,7 +419,7 @@ the payload of the event. The payload is different for each event type. Refer
 to |nvim_tree_registering_handlers| for more information.
 <
 
-|nvim_tree_registering_handlers|	           	*nvim_tree_registering_handlers*
+|nvim_tree_registering_handlers|                *nvim_tree_registering_handlers*
 
 Handlers are registered by calling the `on_*` functions available in the
 `require('nvim-tree.events')` module. See |nvim-tree.events|.
@@ -434,7 +434,7 @@ For example, registering a handler for when a node is renamed is done like this:
     end)
 
 ==============================================================================
-Lua module: nvim-tree.events                            *nvim-tree.events*
+Lua module: nvim-tree.events                           *nvim-tree.events*
 
 on_node_renamed({handler})
                 Registers a handler for when a node is renamed.

--- a/lua/nvim-tree/events.lua
+++ b/lua/nvim-tree/events.lua
@@ -3,56 +3,56 @@ local M = {}
 local global_handlers = {}
 
 local Event = {
-    NodeRenamed = 'NodeRenamed',
-    FileCreated = 'FileCreated',
-    FileRemoved = 'FileRemoved',
-    FolderCreated = 'FolderCreated',
-    FolderRemoved = 'FolderRemoved',
+  NodeRenamed = 'NodeRenamed',
+  FileCreated = 'FileCreated',
+  FileRemoved = 'FileRemoved',
+  FolderCreated = 'FolderCreated',
+  FolderRemoved = 'FolderRemoved',
 }
 
 local function get_handlers(event_name)
-    return global_handlers[event_name] or {}
+  return global_handlers[event_name] or {}
 end
 
 local function register_handler(event_name, handler)
-    local handlers = get_handlers(event_name)
-    table.insert(handlers, handler)
-    global_handlers[event_name] = handlers
+  local handlers = get_handlers(event_name)
+  table.insert(handlers, handler)
+  global_handlers[event_name] = handlers
 end
 
 
 local function dispatch(event_name, payload)
-    for _, handler in ipairs(get_handlers(event_name)) do
-        local success, error = pcall(handler, payload)
-        if not success then
-            vim.api.nvim_err_writeln('Handler for event ' .. event_name .. ' errored. ' .. vim.inspect(error))
-        end
+  for _, handler in pairs(get_handlers(event_name)) do
+    local success, error = pcall(handler, payload)
+    if not success then
+      vim.api.nvim_err_writeln('Handler for event ' .. event_name .. ' errored. ' .. vim.inspect(error))
     end
+  end
 end
 
 --@private
 function M._dispatch_node_renamed(old_name, new_name)
-    dispatch(Event.NodeRenamed, {old_name=old_name, new_name=new_name})
+  dispatch(Event.NodeRenamed, {old_name=old_name, new_name=new_name})
 end
 
 --@private
 function M._dispatch_file_removed(fname)
-    dispatch(Event.FileRemoved, {fname=fname})
+  dispatch(Event.FileRemoved, {fname=fname})
 end
 
 --@private
 function M._dispatch_file_created(fname)
-    dispatch(Event.FileCreated, {fname=fname})
+  dispatch(Event.FileCreated, {fname=fname})
 end
 
 --@private
 function M._dispatch_folder_created(folder_name)
-    dispatch(Event.FolderCreated, {folder_name=folder_name})
+  dispatch(Event.FolderCreated, {folder_name=folder_name})
 end
 
 --@private
 function M._dispatch_folder_removed(folder_name)
-    dispatch(Event.FolderRemoved, {folder_name=folder_name})
+  dispatch(Event.FolderRemoved, {folder_name=folder_name})
 end
 
 --Registers a handler for the NodeRenamed event.
@@ -60,35 +60,35 @@ end
 --  - old_name (string) Absolute path to the old node location.
 --  - new_name (string) Absolute path to the new node location.
 function M.on_node_renamed(handler)
-    register_handler(Event.NodeRenamed, handler)
+  register_handler(Event.NodeRenamed, handler)
 end
 
 --Registers a handler for the FileCreated event.
 --@param handler (function) Handler with the signature function(payload), where payload is a table containing:
 --  - fname (string) Absolute path to the created file.
 function M.on_file_created(handler)
-    register_handler(Event.FileCreated, handler)
+  register_handler(Event.FileCreated, handler)
 end
 
 --Registers a handler for the FileRemoved event.
 --@param handler (function) Handler with the signature function(payload), where payload is a table containing:
 --  - fname (string) Absolute path to the removed file.
 function M.on_file_removed(handler)
-    register_handler(Event.FileRemoved, handler)
+  register_handler(Event.FileRemoved, handler)
 end
 
 --Registers a handler for the FolderCreated event.
 --@param handler (function) Handler with the signature function(payload), where payload is a table containing:
 --  - folder_name (string) Absolute path to the created folder.
 function M.on_folder_created(handler)
-    register_handler(Event.FolderCreated, handler)
+  register_handler(Event.FolderCreated, handler)
 end
 
 --Registers a handler for the FolderRemoved event.
 --@param handler (function) Handler with the signature function(payload), where payload is a table containing:
 --  - folder_name (string) Absolute path to the removed folder.
 function M.on_folder_removed(handler)
-    register_handler(Event.FolderRemoved, handler)
+  register_handler(Event.FolderRemoved, handler)
 end
 
 return M

--- a/lua/nvim-tree/events.lua
+++ b/lua/nvim-tree/events.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-local handlers = {}
+local global_handlers = {}
 
 local Event = {
     NodeRenamed = 'NodeRenamed',
@@ -11,11 +11,13 @@ local Event = {
 }
 
 local function get_handlers(event_name)
-    return handlers[event_name] or {}
+    return global_handlers[event_name] or {}
 end
 
 local function register_handler(event_name, handler)
-    handlers[event_name] = table.insert(get_handlers(event_name), handler)
+    local handlers = get_handlers(event_name)
+    table.insert(handlers, handler)
+    global_handlers[event_name] = handlers
 end
 
 

--- a/lua/nvim-tree/events.lua
+++ b/lua/nvim-tree/events.lua
@@ -1,0 +1,92 @@
+local M = {}
+
+local handlers = {}
+
+local Event = {
+    NodeRenamed = 'NodeRenamed',
+    FileCreated = 'FileCreated',
+    FileRemoved = 'FileRemoved',
+    FolderCreated = 'FolderCreated',
+    FolderRemoved = 'FolderRemoved',
+}
+
+local function get_handlers(event_name)
+    return handlers[event_name] or {}
+end
+
+local function register_handler(event_name, handler)
+    handlers[event_name] = table.insert(get_handlers(event_name), handler)
+end
+
+
+local function dispatch(event_name, payload)
+    for _, handler in ipairs(get_handlers(event_name)) do
+        local success, error = pcall(handler, payload)
+        if not success then
+            vim.api.nvim_err_writeln('Handler for event ' .. event_name .. ' errored. ' .. vim.inspect(error))
+        end
+    end
+end
+
+--@private
+function M._dispatch_node_renamed(old_name, new_name)
+    dispatch(Event.NodeRenamed, {old_name=old_name, new_name=new_name})
+end
+
+--@private
+function M._dispatch_file_removed(fname)
+    dispatch(Event.FileRemoved, {fname=fname})
+end
+
+--@private
+function M._dispatch_file_created(fname)
+    dispatch(Event.FileCreated, {fname=fname})
+end
+
+--@private
+function M._dispatch_folder_created(folder_name)
+    dispatch(Event.FolderCreated, {folder_name=folder_name})
+end
+
+--@private
+function M._dispatch_folder_removed(folder_name)
+    dispatch(Event.FolderRemoved, {folder_name=folder_name})
+end
+
+--Registers a handler for the NodeRenamed event.
+--@param handler (function) Handler with the signature function(payload), where payload is a table containing:
+--  - old_name (string) Absolute path to the old node location.
+--  - new_name (string) Absolute path to the new node location.
+function M.on_node_renamed(handler)
+    register_handler(Event.NodeRenamed, handler)
+end
+
+--Registers a handler for the FileCreated event.
+--@param handler (function) Handler with the signature function(payload), where payload is a table containing:
+--  - fname (string) Absolute path to the created file.
+function M.on_file_created(handler)
+    register_handler(Event.FileCreated, handler)
+end
+
+--Registers a handler for the FileRemoved event.
+--@param handler (function) Handler with the signature function(payload), where payload is a table containing:
+--  - fname (string) Absolute path to the removed file.
+function M.on_file_removed(handler)
+    register_handler(Event.FileRemoved, handler)
+end
+
+--Registers a handler for the FolderCreated event.
+--@param handler (function) Handler with the signature function(payload), where payload is a table containing:
+--  - folder_name (string) Absolute path to the created folder.
+function M.on_folder_created(handler)
+    register_handler(Event.FolderCreated, handler)
+end
+
+--Registers a handler for the FolderRemoved event.
+--@param handler (function) Handler with the signature function(payload), where payload is a table containing:
+--  - folder_name (string) Absolute path to the removed folder.
+function M.on_folder_removed(handler)
+    register_handler(Event.FolderRemoved, handler)
+end
+
+return M


### PR DESCRIPTION
Opening a WIP draft PR just to get a discussion going.

I think it'd be really neat being able to hook into the different actions nvim-tree does. For example - when renaming a node I'd like to inform my LSP client that a rename just happened:

```lua
local events = require'nvim-tree.events'
local typescript_ls = require'lsp.clients.typescript'

events.register_callback('renamed', function (old_fname, new_fname)
    typescript_ls.rename_file(old_fname, new_fname)
end)
```

I went with quite a vanilla event system where any amount of callbacks can be registered for any given event name.