### PR TITLE
Gitignore: fix ignoring directories

### DIFF
--- a/lua/nvim-tree/populate.lua
+++ b/lua/nvim-tree/populate.lua
@@ -103,6 +103,8 @@ local function gen_ignore_check()
 
   local function add_toignore(content)
     for s in content:gmatch("[^\r\n]+") do
+      -- Trim trailing / from directories.
+      s = s:gsub("/+$", "")
       ignore_list[s] = true
     end
   end


### PR DESCRIPTION
If you have build/ or /build in your .gitignore,
the ls-files command will print directories as build/.