### PR TITLE
Use platform path separator when setting tree index.

### DIFF
--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -189,7 +189,7 @@ function M.set_index_and_redraw(fname)
         return i
       end
 
-      if fname:match(entry.match_path..'/') ~= nil then
+      if fname:match(entry.match_path..utils.path_separator) ~= nil then
         if #entry.entries == 0 then
           reload = true
           populate(entry.entries, entry.absolute_path, entry)


### PR DESCRIPTION
Find file on windows doesn't work when using hard coded path separator '/'. 
Updated `set_tree_index_and_redraw` to use `utils.path_separator`.
