### PR TITLE
fix (lsp diagnostics highlight): find_node index, bufnr

### DIFF
--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -14,7 +14,7 @@ local function get_severity(diagnostics)
 end
 
 local function highlight_node(node, linenr)
-  local buf = require'nvim-tree.lib'.Tree.bufnr
+  local buf = require'nvim-tree.view'.View.bufnr
   if not vim.fn.bufexists(buf) or not vim.fn.bufloaded(buf) then return end
   local line = a.nvim_buf_get_lines(buf, linenr, linenr+1, false)[1]
   local starts_at = vim.fn.stridx(line, node.name)

--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -76,8 +76,9 @@ function M.find_node(nodes, fn)
       local n, idx = M.find_node(node.entries, fn)
       i = i + idx
       if n then return n, i end
+    else
+      i = i + 1
     end
-    i = i + 1
   end
   return nil, i
 end


### PR DESCRIPTION
When at least one root file with lsp diagnostics problems is present and at least one  folder with more then 0 child nodes is expanded - NvimTree would  throw an error:

```
Error executing vim.schedule lua callback: ...lua/nvim-tree/diagnostics.lua:23: Column value outside range
```

This happens because:
* `bufnr` was taken from the `lib.Tree` instead of `view.View`.
* wrong `linenr` being passed  to `highlight_node` from `find_node` where every step of recursion would produce + 1 index offset for each child node without highlight.

