### PR TITLE
fix(view): Don't create a new empty buffer on every open.

### DIFF
--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -130,7 +130,7 @@ local move_tbl = {
 }
 
 function M.open()
-  a.nvim_command("vnew")
+  a.nvim_command("vsp")
   local move_to = move_tbl[M.View.side]
   a.nvim_command("wincmd "..move_to)
   a.nvim_command("vertical resize "..M.View.width)


### PR DESCRIPTION
Fixes #301.

Calling `vnew` creates a new empty buffer every time the tree opens. The window then changes to the correct buffer only a couple lines later, leaving the unused, unneeded, empty buffer behind.