### PR TITLE
feat(events): Add a `ready` event.

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -454,6 +454,14 @@ For example, registering a handler for when a node is renamed is done like this:
 ==============================================================================
 Lua module: nvim-tree.events                           *nvim-tree.events*
 
+                                     *nvim-tree.events.on_nvim_tree_ready()*
+on_nvim_tree_ready({handler})
+                Registers a handler for when NvimTree has been initialized.
+
+                Parameters: ~
+                    {handler}    (function) Handler function, with the
+                                 signature `function()`.
+
                                      *nvim-tree.events.on_node_renamed()*
 on_node_renamed({handler})
                 Registers a handler for when a node is renamed.

--- a/lua/nvim-tree/events.lua
+++ b/lua/nvim-tree/events.lua
@@ -3,6 +3,7 @@ local M = {}
 local global_handlers = {}
 
 local Event = {
+  Ready = 'Ready',
   NodeRenamed = 'NodeRenamed',
   FileCreated = 'FileCreated',
   FileRemoved = 'FileRemoved',
@@ -31,6 +32,11 @@ local function dispatch(event_name, payload)
 end
 
 --@private
+function M._dispatch_ready()
+  dispatch(Event.Ready)
+end
+
+--@private
 function M._dispatch_node_renamed(old_name, new_name)
   dispatch(Event.NodeRenamed, {old_name=old_name, new_name=new_name})
 end
@@ -53,6 +59,12 @@ end
 --@private
 function M._dispatch_folder_removed(folder_name)
   dispatch(Event.FolderRemoved, {folder_name=folder_name})
+end
+
+--Registers a handler for the Ready event.
+--@param handler (function) Handler with the signature `function()`
+function M.on_nvim_tree_ready(handler)
+  register_handler(Event.Ready, handler)
 end
 
 --Registers a handler for the NodeRenamed event.

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -7,6 +7,7 @@ local git = require'nvim-tree.git'
 local pops = require'nvim-tree.populate'
 local utils = require'nvim-tree.utils'
 local view = require'nvim-tree.view'
+local events = require'nvim-tree.events'
 local populate = pops.populate
 local refresh_entries = pops.refresh_entries
 
@@ -38,6 +39,8 @@ function M.init(with_open, with_reload)
     renderer.draw(M.Tree, true)
     M.Tree.loaded = true
   end
+
+  events._dispatch_ready()
 end
 
 local function get_node_at_line(line)


### PR DESCRIPTION
Adds a `ready` event that is dispatched after NvimTree has been initialized.

Related to discussion in #280.