### PR TITLE
feat(diagnostics): More responsive and configurable diagnostics signs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ let g:nvim_tree_icons = {
     \   'empty_open': "",
     \   'symlink': "",
     \   'symlink_open': "",
+    \   },
+    \   'lsp': {
+    \     'hint': "",
+    \     'info': "",
+    \     'warning': "",
+    \     'error': "",
     \   }
     \ }
 

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -229,7 +229,7 @@ together. 0 by default.
 
 Can be 0 or 1. When 1, will show nvim-lsp diagnostics in the signcolumn
 of the tree highlighted by diagnostic severity.
-Code will be executed on `BufWritePost`. 0 by default.
+Code will be executed on `LspDiagnosticsChanged`. 0 by default.
 
 ==============================================================================
 INFORMATIONS				        *nvim-tree-info*

--- a/lua/nvim-tree/config.lua
+++ b/lua/nvim-tree/config.lua
@@ -21,7 +21,13 @@ function M.get_icon_state()
       empty_open = "",
       symlink = "",
       symlink_open = "",
-    }
+    },
+    lsp = {
+      hint = "",
+      info = "",
+      warning = "",
+      error = "",
+    },
   }
 
   local user_icons = vim.g.nvim_tree_icons
@@ -41,6 +47,11 @@ function M.get_icon_state()
     for key, val in pairs(user_icons.folder or {}) do
       if icons.folder_icons[key] then
         icons.folder_icons[key] = val
+      end
+    end
+    for key, val in pairs(user_icons.lsp or {}) do
+      if icons.lsp[key] then
+        icons.lsp[key] = val
       end
     end
   end

--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -33,7 +33,7 @@ local signs = {}
 
 local function add_sign(linenr, severity)
   local buf = view.View.bufnr
-  if not vim.fn.bufexists(buf) or not vim.fn.bufloaded(buf) then return end
+  if not a.nvim_buf_is_valid(buf) or not a.nvim_buf_is_loaded(buf) then return end
   local sign_name = sign_names[severity][1]
   table.insert(signs, vim.fn.sign_place(1, 'NvimTreeDiagnosticSigns', sign_name, buf, { lnum = linenr+1 }))
 end
@@ -63,7 +63,7 @@ function M.update()
     signs = {}
   end
   for bufname, severity in pairs(buffer_severity) do
-    if 1 <= severity and severity <= 4 then
+    if 0 < severity and severity < 5 then
       local node, line = utils.find_node(nodes, function(node)
         return node.absolute_path == bufname
       end)

--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -1,14 +1,16 @@
 local a = vim.api
 local utils = require'nvim-tree.utils'
 local view = require'nvim-tree.view'
+local config = require'nvim-tree.config'
+local icon_state = config.get_icon_state()
 local get_diagnostics = vim.lsp.diagnostic.get_all
 
 local M = {}
 
-local function get_highest_severity(diagnostics)
-  local severity = 0
+local function get_lowest_severity(diagnostics)
+  local severity = math.huge
   for _, v in ipairs(diagnostics) do
-    if v.severity > severity then
+    if v.severity < severity then
       severity = v.severity
     end
   end
@@ -16,15 +18,16 @@ local function get_highest_severity(diagnostics)
 end
 
 local sign_names = {
-  { "NvimTreeSignHint", "NvimTreeLspDiagnosticsHint" },
-  { "NvimTreeSignInformation", "NvimTreeLspDiagnosticsInformation" },
-  { "NvimTreeSignWarning", "NvimTreeLspDiagnosticsWarning" },
   { "NvimTreeSignError", "NvimTreeLspDiagnosticsError" },
+  { "NvimTreeSignWarning", "NvimTreeLspDiagnosticsWarning" },
+  { "NvimTreeSignInformation", "NvimTreeLspDiagnosticsInformation" },
+  { "NvimTreeSignHint", "NvimTreeLspDiagnosticsHint" },
 }
 
-for _, v in ipairs(sign_names) do
-  vim.fn.sign_define(v[1], { text="⚠", texthl=v[2]})
-end
+vim.fn.sign_define(sign_names[1][1], { text=icon_state.icons.lsp.error, texthl=sign_names[1][2]})
+vim.fn.sign_define(sign_names[2][1], { text=icon_state.icons.lsp.warning, texthl=sign_names[2][2]})
+vim.fn.sign_define(sign_names[3][1], { text=icon_state.icons.lsp.info, texthl=sign_names[3][2]})
+vim.fn.sign_define(sign_names[4][1], { text=icon_state.icons.lsp.hint, texthl=sign_names[4][2]})
 
 local signs = {}
 
@@ -39,10 +42,12 @@ function M.update()
   local buffer_severity = {}
 
   for buf, diagnostics in pairs(get_diagnostics()) do
-    local bufname = a.nvim_buf_get_name(buf)
-    if not buffer_severity[bufname] then
-      local severity = get_highest_severity(diagnostics)
-      buffer_severity[bufname] = severity
+    if a.nvim_buf_is_valid(buf) then
+      local bufname = a.nvim_buf_get_name(buf)
+      if not buffer_severity[bufname] then
+        local severity = get_lowest_severity(diagnostics)
+        buffer_severity[bufname] = severity
+      end
     end
   end
 
@@ -58,7 +63,7 @@ function M.update()
     signs = {}
   end
   for bufname, severity in pairs(buffer_severity) do
-    if severity > 0 then
+    if 1 <= severity and severity <= 4 then
       local node, line = utils.find_node(nodes, function(node)
         return node.absolute_path == bufname
       end)

--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -18,7 +18,9 @@ local function highlight_node(node, linenr)
   if not vim.fn.bufexists(buf) or not vim.fn.bufloaded(buf) then return end
   local line = a.nvim_buf_get_lines(buf, linenr, linenr+1, false)[1]
   local starts_at = vim.fn.stridx(line, node.name)
-  a.nvim_buf_add_highlight(buf, -1, 'NvimTreeLspDiagnostics', linenr, starts_at, -1)
+  if starts_at ~= -1 then
+    a.nvim_buf_add_highlight(buf, -1, 'NvimTreeLspDiagnostics', linenr, starts_at, -1)
+  end
 end
 
 
@@ -26,10 +28,12 @@ function M.update()
   local buffer_severity = {}
 
   for buf, diagnostics in pairs(get_diagnostics()) do
-    local bufname = a.nvim_buf_get_name(buf)
-    if not buffer_severity[bufname] then
-      local severity = get_severity(diagnostics)
-      buffer_severity[bufname] = severity
+    if a.nvim_buf_is_valid(buf) then
+      local bufname = a.nvim_buf_get_name(buf)
+      if not buffer_severity[bufname] then
+        local severity = get_severity(diagnostics)
+        buffer_severity[bufname] = severity
+      end
     end
   end
 

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -28,10 +28,6 @@ function M.init(with_open, with_reload)
   git.update_gitignore_map_sync()
   populate(M.Tree.entries, M.Tree.cwd)
 
-  if vim.g.nvim_tree_lsp_diagnostics == 1 then
-    diagnostics.update()
-  end
-
   local stat = luv.fs_stat(M.Tree.cwd)
   M.Tree.last_modified = stat.mtime.sec
 

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -4,6 +4,7 @@ local luv = vim.loop
 local renderer = require'nvim-tree.renderer'
 local config = require'nvim-tree.config'
 local git = require'nvim-tree.git'
+local diagnostics = require'nvim-tree.diagnostics'
 local pops = require'nvim-tree.populate'
 local utils = require'nvim-tree.utils'
 local populate = pops.populate
@@ -50,6 +51,10 @@ function M.init(with_open, with_render)
   git.update_gitignore_map_sync()
   populate(M.Tree.entries, M.Tree.cwd)
 
+  if vim.g.nvim_tree_lsp_diagnostics == 1 then
+    diagnostics.update()
+  end
+
   local stat = luv.fs_stat(M.Tree.cwd)
   M.Tree.last_modified = stat.mtime.sec
 
@@ -61,6 +66,8 @@ function M.init(with_open, with_render)
     renderer.draw(M.Tree, true)
     M.Tree.loaded = true
   end
+
+  vim.g.nvim_tree_ready = 1
 end
 
 local function get_node_at_line(line)
@@ -135,6 +142,11 @@ function M.unroll_dir(node)
     git.git_root(node.absolute_path)
     git.update_gitignore_map_sync()
     populate(node.entries, node.link_to or node.absolute_path, node)
+
+    if vim.g.nvim_tree_lsp_diagnostics == 1 then
+      diagnostics.update()
+    end
+
     renderer.draw(M.Tree, true)
   end
 end
@@ -171,6 +183,11 @@ function M.refresh_tree()
     git.reload_roots()
     refresh_git(M.Tree)
   end
+
+  if vim.g.nvim_tree_lsp_diagnostics == 1 then
+    diagnostics.update()
+  end
+
   if M.win_open() then
     renderer.draw(M.Tree, true)
   else

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -43,8 +43,6 @@ function M.init(with_open, with_reload)
     renderer.draw(M.Tree, true)
     M.Tree.loaded = true
   end
-
-  vim.g.nvim_tree_ready = 1
 end
 
 local function get_node_at_line(line)

--- a/plugin/tree.vim
+++ b/plugin/tree.vim
@@ -14,7 +14,7 @@ augroup NvimTree
   endif
   au BufWritePost * lua require'nvim-tree'.refresh()
   if get(g:, 'nvim_tree_lsp_diagnostics', 0) == 1
-    au BufWritePost * lua require'nvim-tree.diagnostics'.update()
+    au User LspDiagnosticsChanged lua require'nvim-tree.diagnostics'.update()
   endif
   au BufEnter * lua require'nvim-tree'.buf_enter()
   if get(g:, 'nvim_tree_auto_close') == 1


### PR DESCRIPTION
This makes the diagnostic signs in the tree more responsive by using the `LspDiagnosticsChanged` auto command event rather than `BufWritePost`, as well as updating diagnostics where it made sense (`unroll_dir`, `refresh`). It also adds configurable icons for the four types of diagnostics.

```lua
lsp = {
  hint = "",
  info = "",
  warning = "",
  error = "",
},
```

I also fixed an error where diagnostics were sorted by highest severity. As far as I can tell, the severity property works kind of backwards in that severity 1 is `error`, and severity 4 is `hint`. This seemed consistent across all the language servers I tested.