### PR TITLE
fix(view): Recreate tree buffer if deleted, and handle scenario where buffer already exists.

### DIFF
--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -12,6 +12,7 @@ local events = require'nvim-tree.events'
 local populate = pops.populate
 local refresh_entries = pops.refresh_entries
 
+local first_init_done = false
 local window_opts = config.window_options()
 
 local M = {}
@@ -41,7 +42,10 @@ function M.init(with_open, with_reload)
     M.Tree.loaded = true
   end
 
-  events._dispatch_ready()
+  if not first_init_done then
+    events._dispatch_ready()
+    first_init_done = true
+  end
 end
 
 local function get_node_at_line(line)

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -77,6 +77,24 @@ local function find_rogue_buffer()
   return nil
 end
 
+---Check if the tree buffer is valid. The buffer is only valid if it exists and
+---hasn't been deleted or wiped.
+---@return boolean
+local function is_buf_valid()
+  local success, valid = pcall(function ()
+    return (
+      a.nvim_buf_is_valid(M.View.bufnr)
+      and a.nvim_buf_get_var(M.View.bufnr, "nvim_tree_buffer_ready") == 1
+      )
+  end)
+
+  if not success then
+    return false
+  else
+    return valid
+  end
+end
+
 -- set user options and create tree buffer (should never be wiped)
 function M.setup()
   M.View.auto_resize = vim.g.nvim_tree_auto_resize or M.View.auto_resize
@@ -96,6 +114,8 @@ function M.setup()
       a.nvim_command("bw " .. bn)
     end
   end
+
+  a.nvim_buf_set_var(M.View.bufnr, "nvim_tree_buffer_ready", 1)
 
   for k, v in pairs(M.View.bufopts) do
     a.nvim_buf_set_option(M.View.bufnr, k, v)
@@ -153,7 +173,7 @@ local move_tbl = {
 }
 
 function M.open()
-  if not a.nvim_buf_is_valid(M.View.bufnr) then
+  if not is_buf_valid() then
     M.setup()
   end
 

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -88,7 +88,7 @@ end
 function M._wipe_rogue_buffer()
   local bn = find_rogue_buffer()
   if bn then
-    local win_ids = a.nvim_eval("win_findbuf(" .. bn .. ")")
+    local win_ids = vim.fn.win_findbuf(bn)
     for _, id in ipairs(win_ids) do
       a.nvim_win_close(id, true)
     end

--- a/plugin/tree.vim
+++ b/plugin/tree.vim
@@ -25,6 +25,7 @@ augroup NvimTree
   if get(g:, 'nvim_tree_tab_open') == 1
     au TabEnter * lua require'nvim-tree'.tab_change()
   endif
+  au SessionLoadPost * lua require'nvim-tree.view'._wipe_rogue_buffer()
 augroup end
 
 command! NvimTreeOpen lua require'nvim-tree'.open()


### PR DESCRIPTION
Fixes #296.

This makes the tree able to recover when the tree buffer gets deleted or wiped. It also tackles scenarios where the NvimTree buffer already exists before initialization, as a result of i.e. a session being loaded. This is what I believe is the root of the problems described in 296.