### PR TITLE
Apply `NvimTreeOpenedFile` highlight to filename instead of icon

### DIFF
--- a/lua/nvim-tree/renderer.lua
+++ b/lua/nvim-tree/renderer.lua
@@ -302,7 +302,7 @@ local function update_draw_data(tree, depth, markers)
 
       if vim.g.nvim_tree_highlight_opened_files then
         if vim.fn.bufloaded(node.absolute_path) > 0 then
-          table.insert(hl, {'NvimTreeOpenedFile', index, offset, offset+#icon })
+          table.insert(hl, {'NvimTreeOpenedFile', index, offset+#icon+#git_icons, offset+#icon+#git_icons+#node.name })
         end
       end
 


### PR DESCRIPTION
Using a bold highlight is not visible when applied to the icon alone. I feel like this highlight makes more sense when applied to the filename text. Thoughts?