### PR TITLE
feat: add statusline winhighlight to explorer tree

### DIFF
--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -22,7 +22,15 @@ M.View = {
     signcolumn = 'yes',
     foldmethod = 'manual',
     foldcolumn = '0',
-    winhl = 'EndOfBuffer:NvimTreeEndOfBuffer,Normal:NvimTreeNormal,CursorLine:NvimTreeCursorLine,VertSplit:NvimTreeVertSplit,SignColumn:NvimTreeNormal'
+    winhl = table.concat({
+      'EndOfBuffer:NvimTreeEndOfBuffer',
+      'Normal:NvimTreeNormal',
+      'CursorLine:NvimTreeCursorLine',
+      'VertSplit:NvimTreeVertSplit',
+      'SignColumn:NvimTreeNormal',
+      'StatusLine:NvimTreeStatusLine',
+      'StatusLineNC:NvimTreeStatuslineNC'
+    }, ',')
   },
   bufopts = {
     swapfile = false,


### PR DESCRIPTION
This a small PR to add the ability to highlight the statusline differently in the nvim-tree buffer using `NvimTreeStatusLine` and `NvimTreeStatusLineNC` similar to the other `winhighlight` for other highlight groups.

NOTE: I converted the highlights to a table and concat them for readability sake so the line isn't so long and hard to read. Happy to change it back if this is undesirable 🤷🏿‍♂️ 