### PR TITLE
fix(view): Rename rogue buffer.

### DIFF
--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -94,6 +94,7 @@ function M._wipe_rogue_buffer()
       end
     end
 
+    a.nvim_buf_set_name(bn, "")
     vim.schedule(function ()
       pcall(a.nvim_buf_delete, bn, {})
     end)


### PR DESCRIPTION
Setting the buffer name in `setup` might fail because `_wipe_rogue_buffer` is not synchronous:

https://github.com/kyazdani42/nvim-tree.lua/blob/983963779d6696c5b6b4aa14f874d85f00941b4e/lua/nvim-tree/view.lua#L119-L120

Rename the rogue buffer synchronously so that this doesn't happen.