### PR TITLE
chore(colors): Set highlight links for NvimTreeStatusLine

### DIFF
--- a/lua/nvim-tree/colors.lua
+++ b/lua/nvim-tree/colors.lua
@@ -71,6 +71,8 @@ local function get_links()
     LspDiagnosticsWarning = "LspDiagnosticsDefaultWarning",
     LspDiagnosticsInformation = "LspDiagnosticsDefaultInformation",
     LspDiagnosticsHint = "LspDiagnosticsDefaultHint",
+    StatusLine = "StatusLine",
+    StatusLineNC = "StatusLineNC",
   }
 end
 


### PR DESCRIPTION
This sets some default highlight links for the new `NvimTreeStatusLine` highlight groups so that vim doesn't fill the statusline with carrots.

Example with minimal rc:

Before:
![2021-04-20-234738_maim](https://user-images.githubusercontent.com/2786478/115468570-8eef2080-a233-11eb-8a5e-345d3d9fd541.png)

After:
![2021-04-20-234839_maim](https://user-images.githubusercontent.com/2786478/115468638-a8906800-a233-11eb-9089-c16236ac24b4.png)

fixes #332 
