### PR TITLE
feat: Sort nodes sensibly

### DIFF
--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -83,6 +83,11 @@ function M.find_node(nodes, fn)
   return nil, i
 end
 
+---Create a shallow copy of a portion of a list.
+---@param t table
+---@param first integer First index, inclusive
+---@param last integer Last index, inclusive
+---@return table
 function M.tbl_slice(t, first, last)
   local slice = {}
   for i = first, last or #t, 1 do
@@ -135,7 +140,7 @@ local function split_merge(t, first, last, comparator)
   merge(t, first, mid, last, comparator)
 end
 
----Perform a stable merge sort on a given list.
+---Perform a merge sort on a given list.
 ---@param t any[]
 ---@param comparator function|nil
 function M.merge_sort(t, comparator)

--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -1,5 +1,5 @@
 local M = {}
-local uv = vim.loop -- or require("luv") ? i dont understand
+local uv = vim.loop
 local api = vim.api
 
 function M.path_to_matching_str(path)
@@ -81,6 +81,71 @@ function M.find_node(nodes, fn)
     end
   end
   return nil, i
+end
+
+function M.tbl_slice(t, first, last)
+  local slice = {}
+  for i = first, last or #t, 1 do
+    table.insert(slice, t[i])
+  end
+
+  return slice
+end
+
+local function merge(t, first, mid, last, comparator)
+  local n1 = mid - first + 1
+  local n2 = last - mid
+  local ls = M.tbl_slice(t, first, mid)
+  local rs = M.tbl_slice(t, mid + 1, last)
+  local i = 1
+  local j = 1
+  local k = first
+
+  while (i <= n1 and j <= n2) do
+    if comparator(ls[i], rs[j]) then
+      t[k] = ls[i]
+      i = i + 1
+    else
+      t[k] = rs[j]
+      j = j + 1
+    end
+    k = k + 1
+  end
+
+  while i <= n1 do
+    t[k] = ls[i]
+    i = i + 1
+    k = k + 1
+  end
+
+  while j <= n2 do
+    t[k] = rs[j]
+    j = j + 1
+    k = k + 1
+  end
+end
+
+local function split_merge(t, first, last, comparator)
+  if (last - first) < 1 then return end
+
+  local mid = math.floor((first + last) / 2)
+
+  split_merge(t, first, mid, comparator)
+  split_merge(t, mid + 1, last, comparator)
+  merge(t, first, mid, last, comparator)
+end
+
+---Perform a stable merge sort on a given list.
+---@param t any[]
+---@param comparator function|nil
+function M.merge_sort(t, comparator)
+  if not comparator then
+    comparator = function (a, b)
+      return a < b
+    end
+  end
+
+  split_merge(t, 1, #t, comparator)
 end
 
 return M


### PR DESCRIPTION
Currently nodes don't always appear in conventional order in the file tree, and they are sometimes inserted in the wrong position when multiple nodes are added. This is a limitation of how insertion of new nodes is currently implemented. Further, symlinks are "sorted" as a separate group as opposed to how it is conventionally done: treating symlinks as the type of file/folder it points to. I.e a symlink pointing to a folder should be sorted alongside other folders.

Proposed solution: sort folders when new nodes are added. This is reasonable and does not have much notable impact on performance with my current implementation. Lua's `table.sort` is backed by an unstable quick sort algorithm, so I opted to instead implement a stable merge sort. Running some tests i measured a ~6.2ms runtime while sorting a folder with 5000 nodes.

Example behavior on current master while toggling dotfiles:

https://user-images.githubusercontent.com/2786478/115632673-874d7b80-a308-11eb-9dca-f000039bcab8.mp4

`.editorconfig` and `.luacheckrc` are inserted at the wrong index and symlinks are sorted incorrectly.

Example behavior with this new implementation, while toggling dotfiles:

https://user-images.githubusercontent.com/2786478/115632839-e27f6e00-a308-11eb-9356-dc4809e5b0fe.mp4

All files retain their position in the tree after toggle and symlinks are sorted correctly.