### PR TITLE
Change filesystem actions to be immediate, minor changes to UX

### DIFF
--- a/lua/nvim-tree/fs.lua
+++ b/lua/nvim-tree/fs.lua
@@ -19,9 +19,14 @@ local function refresh_tree()
   vim.api.nvim_command(":NvimTreeRefresh")
 end
 
+local function get_user_input()
+  return vim.fn.nr2char(vim.fn.getchar())
+end
+
 local function create_file(file)
   if luv.fs_access(file, "r") ~= false then
-    local ans = vim.fn.input(file..' already exists, overwrite ? y/n: ')
+    print(file..' already exists. Overwrite? y/n')
+    local ans = get_user_input()
     clear_prompt()
     if ans ~= "y" then
       return
@@ -29,14 +34,13 @@ local function create_file(file)
   end
   luv.fs_open(file, "w", open_mode, vim.schedule_wrap(function(err, fd)
     if err then
-      api.nvim_err_writeln('Could not create file '..file)
+      api.nvim_err_writeln('Couldn\'t create file '..file)
     else
       -- FIXME: i don't know why but libuv keeps creating file with executable permissions
       -- this is why we need to chmod to default file permissions
       luv.fs_chmod(file, 420)
       luv.fs_close(fd)
       events._dispatch_file_created(file)
-      api.nvim_out_write('File '..file..' was properly created\n')
       refresh_tree()
     end
   end))
@@ -164,8 +168,10 @@ local function do_single_paste(source, dest, action_type, action_fn)
   local dest_stats = luv.fs_stat(dest)
   local should_process = true
   local should_rename = false
+
   if dest_stats then
-    local ans = vim.fn.input(dest..' already exists, overwrite ? y/n/r(ename): ')
+    print(dest..' already exists. Overwrite? y/n/r(ename)')
+    local ans = get_user_input()
     clear_prompt()
     should_process = ans:match('^y')
     should_rename = ans:match('^r')
@@ -206,12 +212,6 @@ local function do_paste(node, action_type, action_fn)
     msg = clip[1].absolute_path
   end
 
-  local ans = vim.fn.input(action_type..' '..msg..' to '..destination..'? y/n: ')
-  clear_prompt()
-  if not ans:match('^y') then
-    return api.nvim_out_write('Canceled.\n')
-  end
-
   for _, entry in ipairs(clip) do
     local dest = utils.path_join({destination, entry.name })
     do_single_paste(entry.absolute_path, dest, action_type, action_fn)
@@ -237,7 +237,8 @@ end
 function M.remove(node)
   if node.name == '..' then return end
 
-  local ans = vim.fn.input("Remove " ..node.name.. " ? y/n: ")
+  print("Remove " ..node.name.. " ? y/n: ")
+  local ans = get_user_input()
   clear_prompt()
   if ans:match('^y') then
     if node.entries ~= nil then
@@ -246,14 +247,12 @@ function M.remove(node)
         return api.nvim_err_writeln('Could not remove '..node.name)
       end
       events._dispatch_folder_removed(node.absolute_path)
-      api.nvim_out_write(node.name..' has been removed\n')
     else
       local success = luv.fs_unlink(node.absolute_path)
       if not success then
         return api.nvim_err_writeln('Could not remove '..node.name)
       end
       events._dispatch_file_removed(node.absolute_path)
-      api.nvim_out_write(node.name..' has been removed\n')
       clear_buffer(node.absolute_path)
     end
     refresh_tree()

--- a/lua/nvim-tree/fs.lua
+++ b/lua/nvim-tree/fs.lua
@@ -237,7 +237,7 @@ end
 function M.remove(node)
   if node.name == '..' then return end
 
-  print("Remove " ..node.name.. " ? y/n: ")
+  print("Remove " ..node.name.. " ? y/n")
   local ans = get_user_input()
   clear_prompt()
   if ans:match('^y') then


### PR DESCRIPTION
I was a little bothered that the filesystem actions needed you to press `<cr>` after every command. When overwriting files, it's `y<cr>` or `r<cr>` or `n<cr>`. You get it. I thought it would be a lot nicer to have the actions execute instantly, so I made those changes.

I've also made some minor changes to the UX, just to simplify the experience. I didn't think there needed to be text saying a file was created, since you just told the plugin to do it, and you can see it in the tree view. Same with removing files. You can see the feedback in the tree, so the text felt unneeded.

Additionally, asking if I wanted to copy a file/folder after I told it to paste said file/folder felt a bit "extra", so I got rid of it.

If there are any changes you want, I'd be happy to make them :)

And if you don't like this idea, just go ahead and close the pr ;)

Thanks for the great work!