### PR TITLE
refactor: `open_file`

### DIFF
--- a/lua/nvim-tree/config.lua
+++ b/lua/nvim-tree/config.lua
@@ -73,11 +73,11 @@ function M.window_options()
   if vim.g.nvim_tree_side == 'right' then
     opts.open_command = 'h'
     opts.preview_command = 'l'
-    opts.split_command = 'nosplitright'
+    opts.split_command = 'aboveleft'
   else
     opts.open_command = 'l'
     opts.preview_command = 'h'
-    opts.split_command = 'splitright'
+    opts.split_command = 'belowright'
   end
 
   return opts

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -235,7 +235,7 @@ function M.open_file(mode, filename)
     if not target_winid or not vim.tbl_contains(win_ids, target_winid) then
       -- Target is invalid, or window does not exist in current tabpage: create
       -- new window
-      api.nvim_command("belowright vsp")
+      api.nvim_command(window_opts.split_command .. " vsp")
       target_winid = api.nvim_get_current_win()
       M.Tree.target_winid = target_winid
 

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -252,7 +252,7 @@ function M.open_file(mode, filename)
 
     local cmd
     if do_split then
-      cmd = string.format("%ssplit", vertical and "vertical " or "")
+      cmd = string.format("%ssplit ", vertical and "vertical " or "")
     else
       cmd = "edit "
     end

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -218,7 +218,7 @@ function M.open_file(mode, filename)
   local win_ids = api.nvim_tabpage_list_wins(tabpage)
   local target_winid = M.Tree.target_winid
   local do_split = mode == "split" or mode == "vsplit"
-  local vertical = mode == "vsplit" or window_opts.split_command == "splitright"
+  local vertical = mode == "vsplit" or (window_opts.split_command == "splitright" and mode ~= "split")
 
   -- Check if filename is already open in a window
   local found = false

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -218,7 +218,7 @@ function M.open_file(mode, filename)
   local win_ids = api.nvim_tabpage_list_wins(tabpage)
   local target_winid = M.Tree.target_winid
   local do_split = mode == "split" or mode == "vsplit"
-  local vertical = mode == "vsplit" or (window_opts.split_command == "splitright" and mode ~= "split")
+  local vertical = mode ~= "split"
 
   -- Check if filename is already open in a window
   local found = false


### PR DESCRIPTION
Fixes #341.

@kyazdani42 Please take a look at this when you have time. While I was implementing the window picker I had to interact with the `open_file` function, and I noticed that it was strangely obscure. It has some hard to read, 150+ character long, chained ternary expressions, and variables that change type depending on several conditions.

I refactored the function, focusing on improving the readability of the logic flow, and avoiding the long chained ternary expressions. I did this while carefully trying to ensure that the behavior is exactly the same as before, while also fixing some of the oddities, like i.e. those described in 341.

One thing I *did* change was what windows its allowed to interact with. Specifically I don't think it should interact with windows outside the current tabpage. That's sort of the point of tabpages: they're completely separate window layouts. This actually fixes a problem that exists with the current implementation: if you try to open a file that is already open in another tabpage, nothing happens.