### PR TITLE
Set nowait on mappings to avoid timeout for conflicting mappings.

### DIFF
--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -132,7 +132,7 @@ function M.setup()
       vim.g.nvim_tree_bindings or {}
     )
     for key, cb in pairs(M.View.bindings) do
-      a.nvim_buf_set_keymap(M.View.bufnr, 'n', key, cb, { noremap = true, silent = true })
+      a.nvim_buf_set_keymap(M.View.bufnr, 'n', key, cb, { noremap = true, silent = true, nowait = true })
     end
   end
 


### PR DESCRIPTION
I'm using `vim-surround` which has binds like `cS`, and when I want to copy a file within the tree it waits for the timeout. Nowait fixes that.