### PR TITLE
add pick guard for focusable windows

### DIFF
--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -224,7 +224,8 @@ function M.pick_window()
   local tree_winid = view.View.tabpages[tabpage]
 
   local selectable = vim.tbl_filter(function (id)
-    return id ~= tree_winid
+    local win_config = api.nvim_win_get_config(id)
+    return id ~= tree_winid and win_config.focusable
   end, win_ids)
 
   -- If there are no selectable windows: return. If there's only 1, return it without picking.


### PR DESCRIPTION
Hey guys!
Thank you for the plugin!
I had small problem with having always to pick window by key, even if there is only one, like this:
<img width="944" alt="image" src="https://user-images.githubusercontent.com/21224705/119485693-0b5bae80-bd60-11eb-9eab-7127d8fc3f19.png">
i did small investigation and using `api.nvim_win_get_config(id)` func was able to discover that there are focusable and not focusable windows, like this:
<img width="1208" alt="image" src="https://user-images.githubusercontent.com/21224705/119486022-70170900-bd60-11eb-9c98-a8f39f8cb8a2.png">
so i've added this check which helped me, and i think make sense for someone else...