### PR TITLE
feat: Option for excluding buffers from the window picker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ let g:nvim_tree_add_trailing = 1 "0 by default, append a trailing slash to folde
 let g:nvim_tree_group_empty = 1 " 0 by default, compact folders that only contain a single folder into one node in the file tree
 let g:nvim_tree_lsp_diagnostics = 1 "0 by default, will show lsp diagnostics in the signcolumn. See :help nvim_tree_lsp_diagnostics
 let g:nvim_tree_disable_window_picker = 1 "0 by default, will disable the window picker.
+let g:nvim_tree_window_picker_exclude = {
+    \   'filetype': [
+    \     'packer'
+    \     'qf',
+    \   ],
+    \   'buftype': [
+    \     'terminal'
+    \   ]
+    \ }
+" Dictionary of buffer option names mapped to a list of option values that
+" indicates to the window picker that the buffer's window should not be
+" selectable.
 let g:nvim_tree_special_files = [ 'README.md', 'Makefile', 'MAKEFILE' ] " List of filenames that gets highlighted with NvimTreeSpecialFile
 let g:nvim_tree_show_icons = {
     \ 'git': 1,

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -267,6 +267,20 @@ window from which you last opened NvimTree.
 A string of chars used as identifiers by the window picker.
 `"ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"` by default.
 
+|g:nvim_tree_window_picker_exclude|          *g:nvim_tree_window_picker_exclude*
+
+Dictionary of buffer option names mapped to a list of option values that
+indicates to the window picker that the buffer's window should not be
+selectable. The default table is
+>
+    {
+      filetype = {
+        "packer",
+        "qf"
+      }
+    }
+<
+
 ==============================================================================
 INFORMATIONS				        *nvim-tree-info*
 

--- a/lua/nvim-tree/config.lua
+++ b/lua/nvim-tree/config.lua
@@ -83,4 +83,16 @@ function M.window_options()
   return opts
 end
 
+function M.window_picker_exclude()
+  if type(vim.g.nvim_tree_window_picker_exclude) == "table" then
+    return vim.g.nvim_tree_window_picker_exclude
+  end
+  return {
+    filetype = {
+      "packer",
+      "qf"
+    }
+  }
+end
+
 return M

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -224,8 +224,17 @@ function M.pick_window()
   local tabpage = api.nvim_get_current_tabpage()
   local win_ids = api.nvim_tabpage_list_wins(tabpage)
   local tree_winid = view.View.tabpages[tabpage]
+  local exclude = config.window_picker_exclude()
 
   local selectable = vim.tbl_filter(function (id)
+    local bufid = api.nvim_win_get_buf(id)
+    for option, v in pairs(exclude) do
+      local ok, option_value = pcall(api.nvim_buf_get_option, bufid, option)
+      if ok and vim.tbl_contains(v, option_value) then
+        return false
+      end
+    end
+
     local win_config = api.nvim_win_get_config(id)
     return id ~= tree_winid and win_config.focusable
   end, win_ids)


### PR DESCRIPTION
Fixes #400.

Adds a new option `g:nvim_tree_window_picker_exclude`, that lets you exclude certain buffers from the window picker.

Example:

```vim
let g:nvim_tree_window_picker_exclude = {
    \   'filetype': [
    \     'packer'
    \     'qf',
    \   ],
    \   'buftype': [
    \     'terminal'
    \   ]
    \ }
" Dictionary of buffer option names mapped to a list of option values that
" indicates to the window picker that the buffer's window should not be
" selectable.
```