### PR TITLE
Shift focus to previous window before closing tree

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -13,6 +13,7 @@ local M = {}
 
 function M.toggle()
   if view.win_open() then
+    vim.cmd "wincmd p"
     view.close()
   else
     if vim.g.nvim_tree_follow == 1 then
@@ -25,6 +26,7 @@ end
 
 function M.close()
   if view.win_open() then
+    vim.cmd "wincmd p"
     view.close()
     return true
   end


### PR DESCRIPTION
This is more of a fallback than anything - as in normal cases everything would work. 
This may save a few more use cases and doesn't really destroy any to my knowledge though (Tested out a few). 

I used lualine (evil line config, modified) and every time I closed it, it left the focus in the tree. Had to reopen and then select the normal window manually.

This was a simple solution I came up with.