### PR TITLE
fix: Gitignore rules not being applied on new nodes.

### DIFF
--- a/lua/nvim-tree/config.lua
+++ b/lua/nvim-tree/config.lua
@@ -64,6 +64,12 @@ function M.get_icon_state()
   }
 end
 
+function M.use_git()
+  return M.get_icon_state().show_git_icon
+      or vim.g.nvim_tree_git_hl == 1
+      or vim.g.nvim_tree_gitignore == 1
+end
+
 function M.nvim_tree_callback(callback_name)
   return string.format(":lua require'nvim-tree'.on_keypress('%s')<CR>", callback_name)
 end

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -152,12 +152,10 @@ end
 function M.refresh_tree()
   if vim.v.exiting ~= vim.NIL then return end
 
+  local use_git = config.use_git()
+  if use_git then git.reload_roots() end
   refresh_nodes(M.Tree)
-
-  if config.get_icon_state().show_git_icon or vim.g.nvim_tree_git_hl == 1 then
-    git.reload_roots()
-    refresh_git(M.Tree)
-  end
+  if use_git then refresh_git(M.Tree) end
 
   if vim.g.nvim_tree_lsp_diagnostics == 1 then
     diagnostics.update()


### PR DESCRIPTION
Fixes #412.

Reload git roots before refreshing nodes so that the gitignore map is
updated, and ignore rules are applied correctly on refresh_entries.