### PR TITLE
Revert "feat: reset old window when leaving the tree"

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -194,20 +194,6 @@ function M.reset_highlight()
   renderer.render_hl(view.View.bufnr)
 end
 
-local old_win = nil
-
-function M.save_previous_buf()
-  vim.cmd "wincmd p"
-  old_win = api.nvim_get_current_win()
-  vim.cmd "wincmd p"
-end
-
-function M.set_previous_buf()
-  if old_win then
-    api.nvim_set_current_win(old_win)
-  end
-end
-
 view.setup()
 colors.setup()
 vim.defer_fn(M.on_enter, 1)

--- a/plugin/tree.vim
+++ b/plugin/tree.vim
@@ -17,8 +17,6 @@ augroup NvimTree
     au User LspDiagnosticsChanged lua require'nvim-tree.diagnostics'.update()
   endif
   au BufEnter * lua require'nvim-tree'.buf_enter()
-  au BufEnter NvimTree lua require'nvim-tree'.save_previous_buf()
-  au BufLeave NvimTree lua require'nvim-tree'.set_previous_buf()
   if get(g:, 'nvim_tree_auto_close') == 1
     au WinClosed * lua require'nvim-tree'.on_leave()
   endif


### PR DESCRIPTION
Fixes #416, #418, #419.

This reverts commit be184bd94e558b302461b359d02ed1b01f7154a1.

@kyazdani42 I still don't fully understand what this commit is supposed to accomplish, but it is certainly not working correctly, and it's currently causing all sorts of strange behavior. I think we should revert this until we can figure out a better way to do it.