### PR TITLE
Improve icon fetching by file extension

### DIFF
--- a/lua/nvim-tree/populate.lua
+++ b/lua/nvim-tree/populate.lua
@@ -46,7 +46,7 @@ local function file_new(cwd, name)
     name = name,
     absolute_path = absolute_path,
     executable = is_exec,
-    extension = vim.fn.fnamemodify(name, ':e') or "",
+    extension = string.match(name, "%.(.*)") or "",
     match_name = path_to_matching_str(name),
     match_path = path_to_matching_str(absolute_path),
   }

--- a/lua/nvim-tree/populate.lua
+++ b/lua/nvim-tree/populate.lua
@@ -46,7 +46,7 @@ local function file_new(cwd, name)
     name = name,
     absolute_path = absolute_path,
     executable = is_exec,
-    extension = string.match(name, "%.(.*)") or "",
+    extension = string.match(name, ".?[^.]+%.(.*)") or "",
     match_name = path_to_matching_str(name),
     match_path = path_to_matching_str(absolute_path),
   }

--- a/lua/nvim-tree/renderer.lua
+++ b/lua/nvim-tree/renderer.lua
@@ -58,11 +58,14 @@ if icon_state.show_file_icon then
   get_file_icon = function(fname, extension, line, depth)
     local icon, hl_group = web_devicons.get_icon(fname, extension)
 
-    if icon then
+    if icon and hl_group ~= "DevIconDefault" then
       if hl_group then
         table.insert(hl, { hl_group, line, depth, depth + #icon + 1 })
       end
       return icon.." "
+    elseif string.match(extension, "%.(.*)") then
+      -- If there are more extensions to the file, try to grab the icon for them recursively
+      return get_file_icon(fname, string.match(extension, "%.(.*)"), line, depth)
     else
       return #icon_state.icons.default > 0 and icon_state.icons.default.." " or ""
     end


### PR DESCRIPTION
This adds the support for different icons when dealing with files that have multiple extensions (like `users.test.js`).

The motivation for this is based on [this issue from nvim-web-devicons](https://github.com/kyazdani42/nvim-web-devicons/issues/36).

Given this sample config file for [nvim-web-devicons](https://github.com/kyazdani42/nvim-web-devicons):
```lua
require("nvim-web-devicons").setup {
  override = {
    ["test.js"] = {
      icon = "ﭧ",
      color = "#cbcb41",
      name = "JsTest"
    },
    ["spec.js"] = {
      icon = "",
      color = "#cbcb41",
      name = "JsSpec"
    },
    ["test.lua"] = {
      icon = "ﭧ",
      color = "#51a0cf",
      name = "LuaTest"
    },
    ["spec.lua"] = {
      icon = "",
      color = "#51a0cf",
      name = "LuaSpec"
    }
  },
  default = true
}
```

## Original behavior
![image](https://user-images.githubusercontent.com/41878330/120249594-cc42c700-c251-11eb-8e6f-0e076ceba091.png)

## New behavior
![image](https://user-images.githubusercontent.com/41878330/120249628-e41a4b00-c251-11eb-83a6-99a210103dae.png)
