### PR TITLE
feat: hijack cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ let g:nvim_tree_add_trailing = 1 "0 by default, append a trailing slash to folde
 let g:nvim_tree_group_empty = 1 " 0 by default, compact folders that only contain a single folder into one node in the file tree
 let g:nvim_tree_lsp_diagnostics = 1 "0 by default, will show lsp diagnostics in the signcolumn. See :help nvim_tree_lsp_diagnostics
 let g:nvim_tree_disable_window_picker = 1 "0 by default, will disable the window picker.
+let g:nvim_tree_hijack_cursor = 0 "1 by default, when moving cursor in the tree, will position the cursor at the start of the file on the current line
 let g:nvim_tree_window_picker_exclude = {
     \   'filetype': [
     \     'packer',

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -287,6 +287,12 @@ selectable. The default table is
     }
 <
 
+|g:nvim_tree_hijack_cursor|               *g:nvim_tree_hijack_cursor*
+
+Can be 0 or 1. 1 by default.
+When 1, moving cursor in the tree will position the cursor at the start 
+of the file on the current line.
+
 ==============================================================================
 INFORMATIONS				        *nvim-tree-info*
 

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -194,6 +194,15 @@ function M.reset_highlight()
   renderer.render_hl(view.View.bufnr)
 end
 
+function M.place_cursor_on_node()
+  local node = lib.get_node_at_cursor()
+  if not node then return end
+  local line = api.nvim_get_current_line()
+  local cursor = api.nvim_win_get_cursor(0)
+  local idx = vim.fn.stridx(line, node.name)
+  api.nvim_win_set_cursor(0, {cursor[1], idx})
+end
+
 view.setup()
 colors.setup()
 vim.defer_fn(M.on_enter, 1)

--- a/plugin/tree.vim
+++ b/plugin/tree.vim
@@ -26,6 +26,9 @@ augroup NvimTree
     au TabEnter * lua require'nvim-tree'.tab_change()
   endif
   au SessionLoadPost * lua require'nvim-tree.view'._wipe_rogue_buffer()
+  if get(g:, 'nvim_tree_hijack_cursor', 1) == 1
+    au CursorMoved NvimTree lua require'nvim-tree'.place_cursor_on_node()
+  endif
 augroup end
 
 command! NvimTreeOpen lua require'nvim-tree'.open()


### PR DESCRIPTION
this feat allows to hijack the cursor to set the cursor on the start of the filename for each line. If you wish to disable it, set `let g:nvim_tree_hijack_cursor=0`