### PR TITLE
add option to use width as percentage

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ let g:nvim_tree_highlight_opened_files = 1 "0 by default, will enable folder and
 let g:nvim_tree_root_folder_modifier = ':~' "This is the default. See :help filename-modifiers for more options
 let g:nvim_tree_tab_open = 1 "0 by default, will open the tree when entering a new tab and the tree was previously open
 let g:nvim_tree_width_allow_resize  = 1 "0 by default, will not resize the tree when opening a file
+let g:nvim_tree_width_as_percent = 1 "0 by default, will treat g:nvim_tree_width as percentage of editor width
 let g:nvim_tree_disable_netrw = 0 "1 by default, disables netrw
 let g:nvim_tree_hijack_netrw = 0 "1 by default, prevents netrw from automatically opening when opening directories (but lets you keep its other utilities)
 let g:nvim_tree_add_trailing = 1 "0 by default, append a trailing slash to folder names

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -221,6 +221,12 @@ Can be 0 or 1. When 1, it will not resize the tree to it's original width
 when opening a new file.
 Default is 0
 
+|g:nvim_tree_width_as_percent|				*g:nvim_tree_width_as_percent*
+
+Can be `0` or `1`. When `1`, it will consider the tree width to be a percentage of
+the editor's and expect *g:nvim_tree_width* to be any value from *0-100*.
+Default is 0
+
 |g:nvim_tree_hijack_netrw|		             *g:nvim_tree_hijack_netrw*
 
 Can be 0 or 1. When 1, disable netrw buffers when nvim-tree start but keeps

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -226,9 +226,9 @@ function M.open()
   a.nvim_command("wincmd "..move_to)
 
   local width
-  if (vim.g.nvim_tree_width_as_percent == true) then
-    local percentAsDecimal = M.View.width/100
-    width = math.floor( vim.o.columns * percentAsDecimal )
+  if vim.g.nvim_tree_width_as_percent == 1 then
+    local percent_as_decimal = M.View.width / 100
+    width = math.floor(vim.o.columns * percent_as_decimal)
   else
     width = M.View.width
   end

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -224,7 +224,16 @@ function M.open()
   a.nvim_command("vsp")
   local move_to = move_tbl[M.View.side]
   a.nvim_command("wincmd "..move_to)
-  a.nvim_command("vertical resize "..M.View.width)
+
+  local width
+  if (vim.g.nvim_tree_width_as_percent == true) then
+    local percentAsDecimal = M.View.width/100
+    width = math.floor( vim.o.columns * percentAsDecimal )
+  else
+    width = M.View.width
+  end
+  a.nvim_command("vertical resize "..width)
+
   local winnr = a.nvim_get_current_win()
   M.View.tabpages[a.nvim_get_current_tabpage()] = winnr
   for k, v in pairs(M.View.winopts) do


### PR DESCRIPTION
adds option to use nvim_tree_width as a percentage (reads the width as a percentage and converts to decimal, multiply to vim total columns)