### PR TITLE
[Readme] Use correct example for special files

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ let g:nvim_tree_window_picker_exclude = {
 " Dictionary of buffer option names mapped to a list of option values that
 " indicates to the window picker that the buffer's window should not be
 " selectable.
-let g:nvim_tree_special_files = [ 'README.md', 'Makefile', 'MAKEFILE' ] " List of filenames that gets highlighted with NvimTreeSpecialFile
+let g:nvim_tree_special_files = { 'README.md': 1, 'Makefile': 1, 'MAKEFILE': 1 } " List of filenames that gets highlighted with NvimTreeSpecialFile
 let g:nvim_tree_show_icons = {
     \ 'git': 1,
     \ 'folders': 0,


### PR DESCRIPTION
With the original example I couldn't get it to work except for when you use `let g:nvim_tree_special_files = []`.

This would probably fix #410