### PR TITLE
feat: Help UI for keybindings

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -85,6 +85,7 @@ local keypress_funcs = {
 }
 
 function M.on_keypress(mode)
+  if view.is_help_ui() and mode ~= 'toggle_help' then return end
   local node = lib.get_node_at_cursor()
   if not node then return end
 

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -68,6 +68,7 @@ local keypress_funcs = {
   parent_node = lib.parent_node,
   toggle_ignored = lib.toggle_ignored,
   toggle_dotfiles = lib.toggle_dotfiles,
+  toggle_help = lib.toggle_help,
   refresh = lib.refresh_tree,
   first_sibling = function(node) lib.sibling(node, -math.huge) end,
   last_sibling = function(node) lib.sibling(node, math.huge) end,
@@ -196,6 +197,7 @@ function M.reset_highlight()
 end
 
 function M.place_cursor_on_node()
+  if view.is_help_ui then return end
   local node = lib.get_node_at_cursor()
   if not node or node.name == ".." then return end
   local line = api.nvim_get_current_line()

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -197,7 +197,6 @@ function M.reset_highlight()
 end
 
 function M.place_cursor_on_node()
-  if view.is_help_ui then return end
   local node = lib.get_node_at_cursor()
   if not node or node.name == ".." then return end
   local line = api.nvim_get_current_line()

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -223,7 +223,7 @@ end
 function M.pick_window()
   local tabpage = api.nvim_get_current_tabpage()
   local win_ids = api.nvim_tabpage_list_wins(tabpage)
-  local tree_winid = view.View.tabpages[tabpage]
+  local tree_winid = view.get_winnr(tabpage)
   local exclude = config.window_picker_exclude()
 
   local selectable = vim.tbl_filter(function (id)
@@ -423,7 +423,7 @@ end
 
 function M.set_target_win()
   local id = api.nvim_get_current_win()
-  local tree_id = view.View.tabpages[api.nvim_get_current_tabpage()]
+  local tree_id = view.get_winnr()
   if tree_id and id == tree_id then
     M.Tree.target_winid = 0
     return
@@ -514,6 +514,11 @@ end
 
 function M.toggle_dotfiles()
   pops.show_dotfiles = not pops.show_dotfiles
+  return M.refresh_tree()
+end
+
+function M.toggle_help()
+  view.toggle_help()
   return M.refresh_tree()
 end
 

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -95,14 +95,20 @@ end
 function M.get_node_at_cursor()
   local cursor = api.nvim_win_get_cursor(view.get_winnr())
   local line = cursor[1]
-  if line == 1 and M.Tree.cwd ~= "/" then
-    return { name = ".." }
-  end
+  if view.is_help_ui() then
+    local help_lines, _ = renderer.draw_help()
+    local help_text = get_node_at_line(line+1)(help_lines)
+    return {name = help_text}
+  else
+    if line == 1 and M.Tree.cwd ~= "/" then
+      return { name = ".." }
+    end
 
-  if M.Tree.cwd == "/" then
-    line = line + 1
+    if M.Tree.cwd == "/" then
+      line = line + 1
+    end
+    return get_node_at_line(line)(M.Tree.entries)
   end
-  return get_node_at_line(line)(M.Tree.entries)
 end
 
 -- If node is grouped, return the last node in the group. Otherwise, return the given node.

--- a/lua/nvim-tree/renderer.lua
+++ b/lua/nvim-tree/renderer.lua
@@ -386,14 +386,23 @@ function M.draw(tree, reload)
     hl = {{'NvimTreeRootFolder', 0, 0, string.len('HELP')}}
     local bindings = view.View.bindings
     local line_num = 1
+    local builtin
     for i, v in pairs(bindings) do
-      for w in v:gmatch("'[^']+'") do
-        v = w
+      if v:sub(1,35) == view.nvim_tree_callback('test'):sub(1,35) then
+        builtin = true
+        v = v:match("'[^']+'[^']*$")
+        v = v:match("'[^']+'")
+      else
+        builtin = false
+        v = '"' .. v .. '"'
       end
       local bind_string = string.format("%6s : %s",i,v)
       table.insert(lines,bind_string)
       local hl_len = math.max(6,#i)+2
       table.insert(hl,{'NvimTreeFolderName',line_num, 0, hl_len})
+      if not builtin then
+        table.insert(hl,{'NvimTreeFileRenamed',line_num,hl_len,-1})
+      end
       line_num = line_num + 1
     end
   end

--- a/lua/nvim-tree/renderer.lua
+++ b/lua/nvim-tree/renderer.lua
@@ -381,6 +381,22 @@ function M.draw(tree, reload)
     update_draw_data(tree, show_arrows and 2 or 0, {})
   end
 
+  if view.is_help_ui() then
+    lines = {'HELP'}
+    hl = {{'NvimTreeRootFolder', 0, 0, string.len('HELP')}}
+    local bindings = view.View.bindings
+    local line_num = 1
+    for i, v in pairs(bindings) do
+      for w in v:gmatch("'[^']+'") do
+        v = w
+      end
+      local bind_string = string.format("%6s : %s",i,v)
+      table.insert(lines,bind_string)
+      local hl_len = math.max(6,#i)+2
+      table.insert(hl,{'NvimTreeFolderName',line_num, 0, hl_len})
+      line_num = line_num + 1
+    end
+  end
   api.nvim_buf_set_option(view.View.bufnr, 'modifiable', true)
   api.nvim_buf_set_lines(view.View.bufnr, 0, -1, false, lines)
   M.render_hl(view.View.bufnr)

--- a/lua/nvim-tree/renderer.lua
+++ b/lua/nvim-tree/renderer.lua
@@ -366,24 +366,9 @@ end
 
 local M = {}
 
-function M.draw(tree, reload)
-  if not api.nvim_buf_is_loaded(view.View.bufnr) then return end
-  local cursor
-  if view.win_open() then
-    cursor = api.nvim_win_get_cursor(view.get_winnr())
-  end
-  if reload then
-    index = 0
-    lines = {}
-    hl = {}
-
-    local show_arrows = icon_state.show_folder_icon and icon_state.show_folder_arrows
-    update_draw_data(tree, show_arrows and 2 or 0, {})
-  end
-
-  if view.is_help_ui() then
-    lines = {'HELP'}
-    hl = {{'NvimTreeRootFolder', 0, 0, string.len('HELP')}}
+function M.draw_help()
+    local help_lines = {'HELP'}
+    local help_hl = {{'NvimTreeRootFolder', 0, 0, string.len('HELP')}}
     local bindings = view.View.bindings
     local processed = {}
     for i, v in pairs(bindings) do
@@ -405,13 +390,33 @@ function M.draw(tree, reload)
       v = val[2]
       builtin = val[3]
       local bind_string = string.format("%6s : %s",i,v)
-      table.insert(lines,bind_string)
+      table.insert(help_lines,bind_string)
       local hl_len = math.max(6,#i)+2
-      table.insert(hl,{'NvimTreeFolderName', num, 0, hl_len})
+      table.insert(help_hl,{'NvimTreeFolderName', num, 0, hl_len})
       if not builtin then
-        table.insert(hl,{'NvimTreeFileRenamed', num, hl_len, -1})
+        table.insert(help_hl,{'NvimTreeFileRenamed', num, hl_len, -1})
       end
     end
+    return help_lines, help_hl
+end
+
+function M.draw(tree, reload)
+  if not api.nvim_buf_is_loaded(view.View.bufnr) then return end
+  local cursor
+  if view.win_open() then
+    cursor = api.nvim_win_get_cursor(view.get_winnr())
+  end
+  if reload then
+    index = 0
+    lines = {}
+    hl = {}
+
+    local show_arrows = icon_state.show_folder_icon and icon_state.show_folder_arrows
+    update_draw_data(tree, show_arrows and 2 or 0, {})
+  end
+
+  if view.is_help_ui() then
+    lines, hl = M.draw_help()
   end
   api.nvim_buf_set_option(view.View.bufnr, 'modifiable', true)
   api.nvim_buf_set_lines(view.View.bufnr, 0, -1, false, lines)

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -3,11 +3,7 @@ local a = vim.api
 local M = {}
 
 function M.nvim_tree_callback(callback_name)
-  info = {
-    name = callback_name,
-    callback = string.format(":lua require'nvim-tree'.on_keypress('%s')<CR>", callback_name),
-  }
-  return info.callback
+  return string.format(":lua require'nvim-tree'.on_keypress('%s')<CR>", callback_name)
 end
 
 M.View = {

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -3,7 +3,11 @@ local a = vim.api
 local M = {}
 
 function M.nvim_tree_callback(callback_name)
-  return string.format(":lua require'nvim-tree'.on_keypress('%s')<CR>", callback_name)
+  info = {
+    name = callback_name,
+    callback = string.format(":lua require'nvim-tree'.on_keypress('%s')<CR>", callback_name),
+  }
+  return info.callback
 end
 
 M.View = {
@@ -75,6 +79,7 @@ M.View = {
     ["]c"]             = M.nvim_tree_callback("next_git_item"),
     ["-"]              = M.nvim_tree_callback("dir_up"),
     ["q"]              = M.nvim_tree_callback("close"),
+    ["?"]              = M.nvim_tree_callback("toggle_help")
   }
 }
 
@@ -171,7 +176,7 @@ end
 function M.win_open(opts)
   if opts and opts.any_tabpage then
     for _, v in pairs(M.View.tabpages) do
-      if  a.nvim_win_is_valid(v) then
+      if a.nvim_win_is_valid(v.winnr) then
         return true
       end
     end
@@ -226,7 +231,8 @@ function M.open()
   a.nvim_command("wincmd "..move_to)
   a.nvim_command("vertical resize "..M.View.width)
   local winnr = a.nvim_get_current_win()
-  M.View.tabpages[a.nvim_get_current_tabpage()] = winnr
+  local tabpage = a.nvim_get_current_tabpage()
+  M.View.tabpages[tabpage] = vim.tbl_extend("force", M.View.tabpages[tabpage] or {help = false}, {winnr = winnr})
   for k, v in pairs(M.View.winopts) do
     vim.wo[winnr][k] = v
   end
@@ -249,8 +255,31 @@ function M.close()
   a.nvim_win_hide(M.get_winnr())
 end
 
-function M.get_winnr()
-  return M.View.tabpages[a.nvim_get_current_tabpage()]
+--- Returns the window number for nvim-tree within the tabpage specified
+---@param tabpage number: (optional) the number of the chosen tabpage. Defaults to current tabpage.
+---@return number
+function M.get_winnr(tabpage)
+  tabpage = tabpage or a.nvim_get_current_tabpage()
+  local tabinfo = M.View.tabpages[tabpage]
+  if tabinfo ~= nil then
+    return tabinfo.winnr
+  end
+end
+
+--- Checks if nvim-tree is displaying the help ui within the tabpage specified
+---@param tabpage number: (optional) the number of the chosen tabpage. Defaults to current tabpage.
+---@return number
+function M.is_help_ui(tabpage)
+  tabpage = tabpage or a.nvim_get_current_tabpage()
+  local tabinfo = M.View.tabpages[tabpage]
+  if tabinfo ~= nil then
+    return tabinfo.help
+  end
+end
+
+function M.toggle_help(tabpage)
+  tabpage = tabpage or a.nvim_get_current_tabpage()
+  M.View.tabpages[tabpage].help = not M.View.tabpages[tabpage].help
 end
 
 return M


### PR DESCRIPTION
Initial commit includes:
- refactor `view.View.tabpages`
- refactor `view.get_winnr`
- add `view.is_help_ui`
- add basic help ui setup in `renderer.draw`

Resolves #456

TODO:
- [x] Sort keybindings
- [x] Handle custom bindings (those not of the form ":lua require'nvim-tree'.on_keypress(...)<CR>")

Current look for default keybindings:
![image](https://user-images.githubusercontent.com/35707277/123521381-28acd100-d6ae-11eb-91d7-1c3f53b4224b.png)
