### PR TITLE
add option to make width a percentage of "&columns"

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Plug 'kyazdani42/nvim-tree.lua'
 
 ```vim
 let g:nvim_tree_side = 'right' "left by default
-let g:nvim_tree_width = 40 "30 by default
+let g:nvim_tree_width = 40 "30 by default, can be width_in_columns or 'width_in_percent%'
 let g:nvim_tree_ignore = [ '.git', 'node_modules', '.cache' ] "empty by default
 let g:nvim_tree_gitignore = 1 "0 by default
 let g:nvim_tree_auto_open = 1 "0 by default, opens the tree when typing `vim $DIR` or `vim`

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -54,7 +54,10 @@ OPTIONS				                  *nvim-tree-options*
 
 |g:nvim_tree_width|				*g:nvim_tree_width*
 
-width of the window (default to 30)
+width of the window, can be *width_in_columns* or *'width_in_percent%'*
+>
+    let g:nvim_tree_width = 30 " indicates width of 30 columns
+    let g:nvim_tree_width = '30%' " indicates width of 30% of '&columns'
 
 |g:nvim_tree_side|				*g:nvim_tree_side*
 

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -202,12 +202,23 @@ function M.focus(winnr, open_if_closed)
   a.nvim_set_current_win(wnr)
 end
 
+local function get_width()
+  if type(M.View.width) == "string" then
+    if vim.endswith(M.View.width, "%") then
+      local width_as_number = tonumber(M.View.width:match('[^%d]*([%d%.]+)%%'))
+      local percent_as_decimal = width_as_number / 100
+      return math.floor(vim.o.columns * percent_as_decimal)
+    end
+  end
+  return M.View.width
+end
+
 function M.resize()
   if not a.nvim_win_is_valid(M.get_winnr()) then
     return
   end
 
-  a.nvim_win_set_width(M.get_winnr(), M.View.width)
+  a.nvim_win_set_width(M.get_winnr(), get_width())
 end
 
 local move_tbl = {
@@ -225,7 +236,7 @@ function M.open()
   a.nvim_command("vsp")
   local move_to = move_tbl[M.View.side]
   a.nvim_command("wincmd "..move_to)
-  a.nvim_command("vertical resize "..M.View.width)
+  a.nvim_command("vertical resize "..get_width())
   local winnr = a.nvim_get_current_win()
   local tabpage = a.nvim_get_current_tabpage()
   M.View.tabpages[tabpage] = vim.tbl_extend("force", M.View.tabpages[tabpage] or {help = false}, {winnr = winnr})

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -203,14 +203,13 @@ function M.focus(winnr, open_if_closed)
 end
 
 local function get_width()
-  if type(M.View.width) == "string" then
-    if vim.endswith(M.View.width, "%") then
-      local width_as_number = tonumber(M.View.width:match('[^%d]*([%d%.]+)%%'))
-      local percent_as_decimal = width_as_number / 100
-      return math.floor(vim.o.columns * percent_as_decimal)
-    end
+  if type(M.View.width) == "number" then
+    return M.View.width
+  elseif type(M.View.width) == "string" and vim.endswith(M.View.width, "%") then
+    local width_as_number = tonumber(M.View.width:sub(0, -2))
+    local percent_as_decimal = width_as_number / 100
+    return math.floor(vim.o.columns * percent_as_decimal)
   end
-  return M.View.width
 end
 
 function M.resize()

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -205,11 +205,10 @@ end
 local function get_width()
   if type(M.View.width) == "number" then
     return M.View.width
-  elseif type(M.View.width) == "string" and vim.endswith(M.View.width, "%") then
-    local width_as_number = tonumber(M.View.width:sub(0, -2))
-    local percent_as_decimal = width_as_number / 100
-    return math.floor(vim.o.columns * percent_as_decimal)
   end
+  local width_as_number = tonumber(M.View.width:sub(0, -2))
+  local percent_as_decimal = width_as_number / 100
+  return math.floor(vim.o.columns * percent_as_decimal)
 end
 
 function M.resize()


### PR DESCRIPTION
Allows nvim_tree_width to accept a string, that will determine whether or not it's a percentage of width of entire editor in columns.
Following @sindrets proposal from the previous pull request.