### PR TITLE
feat(help ui): allow custom names to be provided for custom keybinds

### DIFF
--- a/lua/nvim-tree/renderer.lua
+++ b/lua/nvim-tree/renderer.lua
@@ -376,13 +376,15 @@ function M.draw_help()
   for _, b in pairs(bindings) do
     local cb = b.cb
     local key = b.key
+    local name
     if cb:sub(1,35) == view.nvim_tree_callback('test'):sub(1,35) then
-      cb = cb:match("'[^']+'[^']*$")
-      cb = cb:match("'[^']+'")
-      table.insert(processed, {key, cb, true})
+      name = cb:match("'[^']+'[^']*$")
+      name = name:match("'[^']+'")
+      table.insert(processed, {key, name, true})
     else
-      cb = '"' .. cb .. '"'
-      table.insert(processed, {key, cb, false})
+      name = (b.name ~= nil) and b.name or cb
+      name = '"' .. name .. '"'
+      table.insert(processed, {key, name, false})
     end
   end
   table.sort(processed, function(a,b)

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -142,7 +142,7 @@ function M.setup()
   if vim.g.nvim_tree_disable_default_keybindings == 1 then
     M.View.bindings = user_mappings
   else
-    ok, result = pcall(vim.fn.extend, M.View.bindings, user_mappings)
+    local ok, result = pcall(vim.fn.extend, M.View.bindings, user_mappings)
     if not ok then
       -- TODO: remove this in a few weeks
       warn_wrong_mapping()


### PR DESCRIPTION
Allows users to provide a name for a custom keybinding, instead of displaying the full callback string (which is often quite long)

- allows users to pass a `name` key when defining a custom binding
- defaults to the `cb` string when `name` is not present
- `name` key is ignored for built in callbacks