### PR TITLE
Use relative path when possible

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -80,7 +80,7 @@ local keypress_funcs = {
   close = function() M.close() end,
   preview = function(node)
     if node.entries ~= nil or node.name == '..' then return end
-    return lib.open_file('preview', node.absolute_path)
+    return lib.open_file('preview', node.filename_to_open)
   end,
 }
 
@@ -106,7 +106,7 @@ function M.on_keypress(mode)
   elseif node.entries ~= nil then
     lib.unroll_dir(node)
   else
-    lib.open_file(mode, node.absolute_path)
+    lib.open_file(mode, node.filename_to_open)
   end
 end
 

--- a/lua/nvim-tree/populate.lua
+++ b/lua/nvim-tree/populate.lua
@@ -42,11 +42,17 @@ end
 local function file_new(cwd, name)
   local absolute_path = utils.path_join({cwd, name})
   local is_exec = luv.fs_access(absolute_path, 'X')
-  local git_root = git.git_root(cwd)
   local filename_to_open = absolute_path
   
-  if vim.g.nvim_tree_load_git_file_relatively ~= nil and git_root ~= nil then
-    filename_to_open = utils.path_relative(absolute_path, git_root)
+  local root = function(d)
+    local git_root = git.git_root(d)
+    local cwd = luv.cwd()
+    
+    if git_root ~= nil then return git_root else return cwd end
+  end
+  
+  if vim.g.nvim_tree_load_git_file_relatively ~= nil then
+    filename_to_open = utils.path_relative(absolute_path, root(absolute_path))
   end
   
   return {

--- a/lua/nvim-tree/populate.lua
+++ b/lua/nvim-tree/populate.lua
@@ -42,6 +42,13 @@ end
 local function file_new(cwd, name)
   local absolute_path = utils.path_join({cwd, name})
   local is_exec = luv.fs_access(absolute_path, 'X')
+  local git_root = git.git_root(cwd)
+  local filename_to_open = absolute_path
+  
+  if vim.g.vim_tree_load_git_file_relatively ~= nil and git_root ~= nil then
+    filename_to_open = utils.path_relative(absolute_path, git_root)
+  end
+  
   return {
     name = name,
     absolute_path = absolute_path,
@@ -49,6 +56,7 @@ local function file_new(cwd, name)
     extension = string.match(name, ".?[^.]+%.(.*)") or "",
     match_name = path_to_matching_str(name),
     match_path = path_to_matching_str(absolute_path),
+    filename_to_open = filename_to_open
   }
 end
 

--- a/lua/nvim-tree/populate.lua
+++ b/lua/nvim-tree/populate.lua
@@ -45,7 +45,7 @@ local function file_new(cwd, name)
   local git_root = git.git_root(cwd)
   local filename_to_open = absolute_path
   
-  if vim.g.vim_tree_load_git_file_relatively ~= nil and git_root ~= nil then
+  if vim.g.nvim_tree_load_git_file_relatively ~= nil and git_root ~= nil then
     filename_to_open = utils.path_relative(absolute_path, git_root)
   end
   


### PR DESCRIPTION
Introduces a new variable: `vim_tree_load_git_file_relatively` to not impact previous behavior.  If non-nil then will attempt to use the absolute path, assuming within a Git project.  I couldn't find a way to do it otherwise and didn't want to spend too much time hacking this about.

Resolves https://github.com/kyazdani42/nvim-tree.lua/issues/482