### PR TITLE
open file with relative path when possible

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -80,7 +80,7 @@ local keypress_funcs = {
   close = function() M.close() end,
   preview = function(node)
     if node.entries ~= nil or node.name == '..' then return end
-    return lib.open_file('preview', node.absolute_path)
+    return lib.open_file('preview', node.relative_path)
   end,
 }
 
@@ -102,11 +102,11 @@ function M.on_keypress(mode)
   end
 
   if node.link_to and not node.entries then
-    lib.open_file(mode, node.link_to)
+    lib.open_file(mode, node.relative_path)
   elseif node.entries ~= nil then
     lib.unroll_dir(node)
   else
-    lib.open_file(mode, node.absolute_path)
+    lib.open_file(mode, node.relative_path)
   end
 end
 

--- a/lua/nvim-tree/populate.lua
+++ b/lua/nvim-tree/populate.lua
@@ -41,10 +41,12 @@ end
 
 local function file_new(cwd, name)
   local absolute_path = utils.path_join({cwd, name})
+  local relative_path = utils.path_relative(absolute_path, luv.cwd())
   local is_exec = luv.fs_access(absolute_path, 'X')
   return {
     name = name,
     absolute_path = absolute_path,
+    relative_path = relative_path,
     executable = is_exec,
     extension = string.match(name, ".?[^.]+%.(.*)") or "",
     match_name = path_to_matching_str(name),
@@ -62,6 +64,8 @@ local function link_new(cwd, name)
   --- I dont know if this is needed, because in my understanding, there isnt hard links in windows, but just to be sure i changed it.
   local absolute_path = utils.path_join({ cwd, name })
   local link_to = luv.fs_realpath(absolute_path)
+  -- if links to a file outside cwd, relative_path equals absolute_path
+  local relative_path = utils.path_relative(link_to, luv.cwd())
   local stat = luv.fs_stat(absolute_path)
   local open, entries
   if (link_to ~= nil) and luv.fs_stat(link_to).type == 'directory' then
@@ -77,6 +81,7 @@ local function link_new(cwd, name)
   return {
     name = name,
     absolute_path = absolute_path,
+    relative_path = relative_path,
     link_to = link_to,
     last_modified = last_modified,
     open = open,


### PR DESCRIPTION
nvim-tree currently opens file with its absolute path, so ctrl-g and echo expand('%') can return a really long path that's hard to read.

This PR make nvim-tree open/preview file with its relative path. It works for both files and links.
If the current file links to a another file which is outside current working directory, nvim-tree opens the file with its absolute path.

Should fix https://github.com/kyazdani42/nvim-tree.lua/issues/482