### PR TITLE
Fix error caused by broken symlinks

### DIFF
--- a/lua/nvim-tree/populate.lua
+++ b/lua/nvim-tree/populate.lua
@@ -65,7 +65,7 @@ local function link_new(cwd, name)
   local absolute_path = utils.path_join({ cwd, name })
   local link_to = luv.fs_realpath(absolute_path)
   -- if links to a file outside cwd, relative_path equals absolute_path
-  local relative_path = utils.path_relative(link_to, luv.cwd())
+  local relative_path = link_to ~= nil and utils.path_relative(link_to, luv.cwd()) or nil
   local stat = luv.fs_stat(absolute_path)
   local open, entries
   if (link_to ~= nil) and luv.fs_stat(link_to).type == 'directory' then


### PR DESCRIPTION
Closes #493

When a symbolic link points to an invalid path, the value of `link_to`
equals `nil`. This value makes `utils.path_relative` throw an error,
since it expects a string as the first argument