### PR TITLE
fix: don't populate git status when git unused

### DIFF
--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -11,6 +11,7 @@ local view = require'nvim-tree.view'
 local events = require'nvim-tree.events'
 local populate = pops.populate
 local refresh_entries = pops.refresh_entries
+local use_git = config.use_git()
 
 local first_init_done = false
 local window_opts = config.window_options()
@@ -28,7 +29,9 @@ function M.init(with_open, with_reload)
   if not M.Tree.cwd then
     M.Tree.cwd = luv.cwd()
   end
-  git.git_root(M.Tree.cwd)
+  if use_git then
+    git.git_root(M.Tree.cwd)
+  end
   populate(M.Tree.entries, M.Tree.cwd)
 
   local stat = luv.fs_stat(M.Tree.cwd)
@@ -130,7 +133,9 @@ function M.unroll_dir(node)
   if #node.entries > 0 then
     renderer.draw(M.Tree, true)
   else
-    git.git_root(node.absolute_path)
+    if use_git then
+      git.git_root(node.absolute_path)
+    end
     populate(node.entries, node.link_to or node.absolute_path, node)
 
     renderer.draw(M.Tree, true)
@@ -164,7 +169,6 @@ end
 function M.refresh_tree()
   if vim.v.exiting ~= vim.NIL then return end
 
-  local use_git = config.use_git()
   if use_git then git.reload_roots() end
   refresh_nodes(M.Tree)
   if use_git then vim.schedule(function() refresh_git(M.Tree) end) end

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -11,7 +11,6 @@ local view = require'nvim-tree.view'
 local events = require'nvim-tree.events'
 local populate = pops.populate
 local refresh_entries = pops.refresh_entries
-local use_git = config.use_git()
 
 local first_init_done = false
 local window_opts = config.window_options()
@@ -29,7 +28,7 @@ function M.init(with_open, with_reload)
   if not M.Tree.cwd then
     M.Tree.cwd = luv.cwd()
   end
-  if use_git then
+  if config.use_git() then
     git.git_root(M.Tree.cwd)
   end
   populate(M.Tree.entries, M.Tree.cwd)
@@ -133,7 +132,7 @@ function M.unroll_dir(node)
   if #node.entries > 0 then
     renderer.draw(M.Tree, true)
   else
-    if use_git then
+    if config.use_git() then
       git.git_root(node.absolute_path)
     end
     populate(node.entries, node.link_to or node.absolute_path, node)
@@ -169,6 +168,7 @@ end
 function M.refresh_tree()
   if vim.v.exiting ~= vim.NIL then return end
 
+  local use_git = config.use_git()
   if use_git then git.reload_roots() end
   refresh_nodes(M.Tree)
   if use_git then vim.schedule(function() refresh_git(M.Tree) end) end

--- a/lua/nvim-tree/populate.lua
+++ b/lua/nvim-tree/populate.lua
@@ -1,6 +1,7 @@
 local config = require'nvim-tree.config'
 local git = require'nvim-tree.git'
 local icon_config = config.get_icon_state()
+local use_git = config.use_git()
 
 local api = vim.api
 local luv = vim.loop
@@ -354,7 +355,9 @@ function M.populate(entries, cwd, parent_node)
     return
   end
 
-  vim.schedule(function() git.update_status(entries, cwd, parent_node) end)
+  if use_git then
+    vim.schedule(function() git.update_status(entries, cwd, parent_node) end)
+  end
 end
 
 return M

--- a/lua/nvim-tree/populate.lua
+++ b/lua/nvim-tree/populate.lua
@@ -1,7 +1,6 @@
 local config = require'nvim-tree.config'
 local git = require'nvim-tree.git'
 local icon_config = config.get_icon_state()
-local use_git = config.use_git()
 
 local api = vim.api
 local luv = vim.loop
@@ -355,7 +354,7 @@ function M.populate(entries, cwd, parent_node)
     return
   end
 
-  if use_git then
+  if config.use_git() then
     vim.schedule(function() git.update_status(entries, cwd, parent_node) end)
   end
 end


### PR DESCRIPTION
Attempts to fix #453

On large git repos, `git status` related commands are very slow. Do not populate git status when not set in configuration.

in nvim config:
```
vim.g.nvim_tree_gitignore = 0
vim.g.nvim_tree_git_hl = 0
vim.g.nvim_tree_show_icons = {
  git = 0,
}
```

When cd'd into my huge git repo:
```
$ time git -C . status --porcelain=v1 --ignored=matching
git -C . status --porcelain=v1 --ignored=matching  6.12s user 39.51s system 737% cpu 5.513 total
```

**Before fix**

![before_fix](https://user-images.githubusercontent.com/960708/125097052-118fc980-e119-11eb-8697-ab667acfd489.gif)

**After fix**

![after_fix](https://user-images.githubusercontent.com/960708/125097090-19e80480-e119-11eb-9d81-e33983f2c5b2.gif)