### PR TITLE
fix(doc) neovim required version

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -7,7 +7,7 @@ Author: Yazdani Kiyan <yazdani.kiyan@protonmail.com>
 ==============================================================================
 INTRODUCTION                                       *nvim-tree-introduction*
 
-This file explorer requires neovim `nightly (>= 0.5.0)`
+This file explorer requires `neovim >= 0.5.0`
 
 ==============================================================================
 QUICK START                                        *nvim-tree-quickstart*


### PR DESCRIPTION
Now that nvim 0.5 is stable (and nightly >= 0.6), replace **neovim nightly (>= 0.5.0)**  by **neovim >= 0.5.0** in doc