### PR TITLE
add `edit_file`/`toggle_dir` callbacks

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -108,6 +108,18 @@ function M.on_keypress(mode)
     return
   end
 
+  if mode == "toggle_dir" then
+    if not node.entries then return end
+
+    if node.open then
+      lib.close_node(node)
+    elseif node.entries ~= nil then
+      lib.unroll_dir(node)
+    end
+
+    return
+  end
+
   if node.link_to and not node.entries then
     lib.open_file(mode, node.link_to)
   elseif node.entries ~= nil then

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -108,6 +108,7 @@ function M.on_keypress(mode)
     return
   end
 
+  -- open/close a directory (ignore files)
   if mode == "toggle_dir" then
     if not node.entries then return end
 
@@ -120,6 +121,18 @@ function M.on_keypress(mode)
     return
   end
 
+  -- open a file (ignore directories)
+  if mode == "edit_file" then
+    if node.link_to and not node.entries then
+      lib.open_file(mode, node.link_to)
+    elseif not node.entries then
+      lib.open_file(mode, node.absolute_path)
+    end
+
+    return
+  end
+
+  -- open a file, symlink, or directory
   if node.link_to and not node.entries then
     lib.open_file(mode, node.link_to)
   elseif node.entries ~= nil then


### PR DESCRIPTION
After switching from Nerdtree, I've missed their `mousemode = 3` option which allows toggling directories with a single-click and opening files with a double-click. You can bind `<LeftRelease>` to get single-click directory toggling, or `<2-LeftMouse>` for double-click, but you can't mix-and-match.

This PR adds two new callbacks, `edit_file` and `toggle_dir`; they're both similar to the existing `edit` callback, with a key difference:

- `edit_file` only opens files, ignoring directories
- `toggle_dir` only toggles directories, ignoring files

With these new callbacks, you can mimic Nerdtree's `mousemode = 3` with the following bindings:

```lua
g.nvim_tree_bindings = {
  { key = {'<CR>', 'o'}, cb = tree_cb('edit') },           -- Enter/o behave as before
  { key = '<2-LeftMouse>', cb = tree_cb('edit_file') },    -- Open files on double-click
  { key = '<LeftRelease>', cb = tree_cb('toggle_dir') },   -- Toggle dirs on single-click
}
```

This is just the first implementation I threw together, please feel free to suggest alternatives, or close out if this doesn't seem like a useful addition.

Thanks for your work on this plugin, I'm really enjoying it!