### PR TITLE
fix: guarantee order of buffer options

### DIFF
--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -35,11 +35,11 @@ M.View = {
     }, ',')
   },
   bufopts = {
-    swapfile = false,
-    buftype = 'nofile';
-    modifiable = false;
-    filetype = 'NvimTree';
-    bufhidden = 'hide';
+    { name = 'swapfile', val = false },
+    { name = 'buftype', val = 'nofile' },
+    { name = 'modifiable', val = false },
+    { name = 'filetype', val = 'NvimTree' },
+    { name = 'bufhidden', val = 'hide' }
   },
   bindings = {
     { key = {"<CR>", "o", "<2-LeftMouse>"}, cb = M.nvim_tree_callback("edit") },
@@ -129,8 +129,8 @@ function M.setup()
     a.nvim_buf_set_name(M.View.bufnr, 'NvimTree')
   end
 
-  for k, v in pairs(M.View.bufopts) do
-    vim.bo[M.View.bufnr][k] = v
+  for _, opt in ipairs(M.View.bufopts) do
+    vim.bo[M.View.bufnr][opt.name] = opt.val
   end
 
   vim.cmd "au! BufWinEnter * lua require'nvim-tree.view'._prevent_buffer_override()"


### PR DESCRIPTION
Hello! I've run into a small issue with nvim-tree caused by the fact that currently, the order in which buffer options are set isn't fixed because of `pairs`. Specifically, setting `filetype` before `buftype` can cause issues for `FileType` event listeners that rely on checking `buftype`. This small PR switches to `ipairs` to make sure that the options are set in a predictable order. Let me know if this is OK!