### PR TITLE
Added new option, respect_buf_cwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ let g:nvim_tree_disable_window_picker = 1 "0 by default, will disable the window
 let g:nvim_tree_hijack_cursor = 0 "1 by default, when moving cursor in the tree, will position the cursor at the start of the file on the current line
 let g:nvim_tree_icon_padding = ' ' "one space by default, used for rendering the space between the icon and the filename. Use with caution, it could break rendering if you set an empty string depending on your font.
 let g:nvim_tree_update_cwd = 1 "0 by default, will update the tree cwd when changing nvim's directory (DirChanged event). Behaves strangely with autochdir set.
+let g:nvim_tree_respect_buf_cwd = 1 "0 by default, will change cwd of nvim-tree to that of new buffer's when opening nvim-tree.
 let g:nvim_tree_window_picker_exclude = {
     \   'filetype': [
     \     'packer',

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -316,6 +316,11 @@ Can be 0 or 1. 0 by default.
 Will update the tree cwd when changing nvim's directory (DirChanged event).
 WARNING: Behaves strangely with autochdir set.
 
+|g:nvim_tree_respect_buf_cwd|             *g:nvim_tree_respect_buf_cwd*
+
+Can be 0 or 1. 0 by default.
+will change cwd of nvim-tree to that of new buffer's when opening nvim-tree
+
 ==============================================================================
 INFORMATIONS				        *nvim-tree-info*
 

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -319,7 +319,7 @@ WARNING: Behaves strangely with autochdir set.
 |g:nvim_tree_respect_buf_cwd|             *g:nvim_tree_respect_buf_cwd*
 
 Can be 0 or 1. 0 by default.
-will change cwd of nvim-tree to that of new buffer's when opening nvim-tree
+Will change cwd of nvim-tree to that of new buffer's when opening nvim-tree.
 
 ==============================================================================
 INFORMATIONS				        *nvim-tree-info*

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -466,8 +466,10 @@ function M.open()
 
   view.open()
 
-  if M.Tree.loaded then
-    M.change_dir(vim.fn.getcwd())
+  local cwd = vim.fn.getcwd()
+  local respect_buf_cwd = vim.g.nvim_tree_respect_buf_cwd or 0
+  if M.Tree.loaded or (respect_buf_cwd == 1 and cwd ~= M.Tree.cwd) then
+    M.change_dir(cwd)
   end
   renderer.draw(M.Tree, not M.Tree.loaded)
   M.Tree.loaded = true


### PR DESCRIPTION
Added a new option that respect the current buffer's cwd. Nvim-tree changes its cwd to that of buffer's when this option is enabled and nvim-tree is opened.

This ensures that the cwd of nvim-tree is same as that of buffer's.