### PR TITLE
Feature: open file/folder with default system application

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ highlight NvimTreeFolderIcon guibg=blue
 - type `]c` to go to next git item
 - type `[c` to go to prev git item
 - type `-` to navigate up to the parent directory of the current file/directory
+- type `s` to open a file with default system application or a folder with default file manager
 - if the file is a directory, `<CR>` will open the directory otherwise it will open the file in the buffer near the tree
 - if the file is a symlink, `<CR>` will follow the symlink (if the target is a file)
 - `<C-v>` will open the file in a vertical split
@@ -209,6 +210,7 @@ lua <<EOF
       { key = "[c",                           cb = tree_cb("prev_git_item") },
       { key = "]c",                           cb = tree_cb("next_git_item") },
       { key = "-",                            cb = tree_cb("dir_up") },
+      { key = "s",                            cb = tree_cb("system_open") },
       { key = "q",                            cb = tree_cb("close") },
       { key = "g?",                           cb = tree_cb("toggle_help") },
     }
@@ -236,16 +238,6 @@ This plugin is very fast because it uses the `libuv` `scandir` and `scandir_next
 ## Tips
 
 - You can edit the size of the tree during runtime with `:lua require'nvim-tree.view'.View.width = 50`
-- Open the node under the cursor with the OS default application (usually file explorer for folders):
-  ```lua
-  function NvimTreeOSOpen()
-    local lib = require "nvim-tree.lib"
-    local node = lib.get_node_at_cursor()
-    if node then
-      vim.fn.jobstart("open '" .. node.absolute_path .. "' &", {detach = true})
-    end
-  end
-  ```
 
 ## Screenshots
 

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -339,6 +339,7 @@ INFORMATIONS				        *nvim-tree-info*
 - type ']c' to go to next git item
 - type '[c' to go to prev git item
 - type '-' to navigate up one directory
+- type 's' to open a file with default system application or a folder with default file manager
 - type '<' to navigate to the previous sibling of current file/directory
 - type '>' to navigate to the next sibling of current file/directory
 - type 'J' to navigate to the first sibling of current file/directory
@@ -406,6 +407,7 @@ Default mappings:
         { key = "[c",                           cb = tree_cb("prev_git_item") },
         { key = "]c",                           cb = tree_cb("next_git_item") },
         { key = "-",                            cb = tree_cb("dir_up") },
+        { key = "s",                            cb = tree_cb("system_open") },
         { key = "q",                            cb = tree_cb("close") },
         { key = "g?",                           cb = tree_cb("toggle_help") },
       }

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -94,28 +94,28 @@ local keypress_funcs = {
     if vim.fn.has('win16') == 1 or vim.fn.has('win32') == 1 or vim.fn.has('win64') == 1 then
       system_command = 'start "" '
     elseif vim.fn.has('win32unix') == 1 then
-      system_command = 'cygstart '
+      if vim.fn.stridx(vim.fn.system('uname'), 'CYGWIN') ~= -1 then
+        system_command = 'cygstart '
+      else
+        system_command = 'start "" '
+      end
     elseif vim.fn.has('mac') == 1 or vim.fn.has('macunix') == 1 then
       system_command = 'open '
     elseif vim.fn.has('unix') == 1 then
       system_command = 'xdg-open '
-    end
-
-    if system_command == "" then
+    else
       vim.cmd('echohl ErrorMsg')
       vim.cmd('echomsg "NvimTree system_open: cannot open file with system application. Unsupported platform."')
       vim.cmd('echohl None')
       return
     end
 
-    local file_path = '"' .. vim.fn.substitute(node.absolute_path, '"', '\\\\"', 'g') .. '"'
-    local command_output = vim.fn.system(system_command .. file_path)
+    local command_output = vim.fn.system(system_command .. '"' .. vim.fn.substitute(node.absolute_path, '"', '\\\\"', 'g') .. '"')
 
     if vim.v.shell_error ~= 0 then
       vim.cmd('echohl ErrorMsg')
       vim.cmd(string.format('echomsg "NvimTree system_open: return code %d."', vim.v.shell_error))
-      command_output = vim.fn.substitute(command_output, '\n', '" | echomsg "', 'g')
-      vim.cmd('echomsg "' .. command_output .. '"')
+      vim.cmd('echomsg "' .. vim.fn.substitute(command_output, '\n', '" | echomsg "', 'g') .. '"')
       vim.cmd('echohl None')
     end
   end,

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -89,6 +89,36 @@ local keypress_funcs = {
     if node.entries ~= nil or node.name == '..' then return end
     return lib.open_file('preview', node.absolute_path)
   end,
+  system_open = function(node)
+    local system_command = ''
+    if vim.fn.has('win16') == 1 or vim.fn.has('win32') == 1 or vim.fn.has('win64') == 1 then
+      system_command = 'start "" '
+    elseif vim.fn.has('win32unix') == 1 then
+      system_command = 'cygstart '
+    elseif vim.fn.has('mac') == 1 or vim.fn.has('macunix') == 1 then
+      system_command = 'open '
+    elseif vim.fn.has('unix') == 1 then
+      system_command = 'xdg-open '
+    end
+
+    if system_command == "" then
+      vim.cmd('echohl ErrorMsg')
+      vim.cmd('echomsg "NvimTree system_open: cannot open file with system application. Unsupported platform."')
+      vim.cmd('echohl None')
+      return
+    end
+
+    local file_path = '"' .. vim.fn.substitute(node.absolute_path, '"', '\\\\"', 'g') .. '"'
+    local command_output = vim.fn.system(system_command .. file_path)
+
+    if vim.v.shell_error ~= 0 then
+      vim.cmd('echohl ErrorMsg')
+      vim.cmd(string.format('echomsg "NvimTree system_open: return code %d."', vim.v.shell_error))
+      command_output = vim.fn.substitute(command_output, '\n', '" | echomsg "', 'g')
+      vim.cmd('echomsg "' .. command_output .. '"')
+      vim.cmd('echohl None')
+    end
+  end,
 }
 
 function M.on_keypress(mode)

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -71,6 +71,7 @@ M.View = {
     { key = "[c",                           cb = M.nvim_tree_callback("prev_git_item") },
     { key = "]c",                           cb = M.nvim_tree_callback("next_git_item") },
     { key = "-",                            cb = M.nvim_tree_callback("dir_up") },
+    { key = "s",                            cb = M.nvim_tree_callback("system_open") },
     { key = "q",                            cb = M.nvim_tree_callback("close") },
     { key = "g?",                           cb = M.nvim_tree_callback("toggle_help") }
   }


### PR DESCRIPTION
This feature is equivalent to "reveal" in nerdtree or "execute_system" in defx.

Open a file with default system application by pressing `s`
Open a folder with system file manager by pressing `s`

Tested on Linux.
Should work also on MacOS, Windows, Windows Cygwin and systems using `xdg-open`, like FreeBSD.