### PR TITLE
Feature: add the possibility to not focus tree on TabEnter when g:nvim_tree_tab_open=1

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -46,7 +46,7 @@ function M.tab_change()
       if bufname:match("Neogit") ~= nil or bufname:match("--graph") ~= nil then
         return
       end
-      view.open()
+      view.open({ focus_tree = false })
     end
   end)
 end

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -264,7 +264,8 @@ local function set_local(opt, value)
   vim.cmd(cmd)
 end
 
-function M.open()
+function M.open(options)
+	options = options or { focus_tree = true }
   if not is_buf_valid() then
     M.setup()
   end
@@ -282,6 +283,9 @@ function M.open()
     set_local(k, v)
   end
   vim.cmd ":wincmd ="
+	if not options.focus_tree then
+		vim.cmd("wincmd p")
+	end
 end
 
 function M.close()


### PR DESCRIPTION
Following me opening https://github.com/kyazdani42/nvim-tree.lua/issues/544, I had a look inside the code (lua seems very cool), and tried the following thing to allow to not autofocus the tree when `g:nvim_tree_tab_open` is set to 1 and a new tab is opened.

I added an `option.focus_tree` (that defaults to true to keep default behaviour of the method) to `open()` in the view module that, if set to `false`, will trigger a `wincmd p` after the tree's window has been opened.

Then in `tab_change()` (I checked: `tab_change` is _only_ call on the `TabEnter` autocmd),  `open` is called with the `focus_tree` option set to false.

This way when auto-opening the tree in new tabs, the document of the new tab is automatically focused instead of the tree.

If you want to make that behaviour parametrised, no problem, I'll add an option to it!

I hope this contribution is valuable!