### PR TITLE
fix: respect_buf_cwd #567

### DIFF
--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -464,9 +464,9 @@ end
 function M.open()
   M.set_target_win()
 
+  local cwd = vim.fn.getcwd()
   view.open()
 
-  local cwd = vim.fn.getcwd()
   local respect_buf_cwd = vim.g.nvim_tree_respect_buf_cwd or 0
   if M.Tree.loaded or (respect_buf_cwd == 1 and cwd ~= M.Tree.cwd) then
     M.change_dir(cwd)


### PR DESCRIPTION
moved the command to get cwd to before opening the file tree.
fixes execution of this config:
```
let g:nvim_tree_respect_buf_cwd = 1
```