### PR TITLE
feat: add mark capabilites

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ local list = {
   { key = "s",                            cb = tree_cb("system_open") },
   { key = "q",                            cb = tree_cb("close") },
   { key = "g?",                           cb = tree_cb("toggle_help") },
+  { key = 'm',                            cb = ":lua require'nvim-tree.marks'.toggle_mark()<cr>" },
+  { key = 'M',                            cb = ":lua require'nvim-tree.marks'.disable_all()<cr>" },
 }
 ```
 
@@ -282,6 +284,7 @@ You can toggle the help UI by pressing `g?`.
 - Git integration (icons and file highlight)
 - Lsp diagnostics integration (signs)
 - Indent markers
+- Marks (for bulk actions, see `:help nvim-tree.marks`)
 - Mouse support
 - It's fast
 

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -591,6 +591,8 @@ Defaults to:
       { key = "s",                            cb = tree_cb("system_open") },
       { key = "q",                            cb = tree_cb("close") },
       { key = "g?",                           cb = tree_cb("toggle_help") },
+      { key = 'm',                            cb = ":lua require'nvim-tree.marks'.toggle_mark()<cr>" },
+      { key = 'M',                            cb = ":lua require'nvim-tree.marks'.disable_all()<cr>" },
     }
 <
 
@@ -773,5 +775,36 @@ on_folder_removed({handler})
                 Parameters: ~
                     {handler}    (function) Handler function, with the
                                  signature `function(payload)`.
+
+==============================================================================
+MARKS                                                 *nvim-tree-marks*
+
+|nvim-tree.marks|                                     *nvim-tree.marks*
+
+You can toggle marks on file/folders to batch a function on multiple
+nodes with the `marks` module.
+
+>
+  local nvim_tree_marks = require "nvim-tree.marks"
+  local marks = nvim_tree_marks.get_marks()
+<
+
+toggle_mark()                                         *nvim-tree.marks.toggle_mark()*
+
+Toggle a mark on a file or folder under the cursor.
+Mapped to `m` by default.
+
+get_marks()                                           *nvim-tree.marks.get_marks()*
+
+Get the list of current marked files/folders.
+Returns a list of nodes.
+
+disable_all()                                         *nvim-tree.marks.disable_all()*
+
+Remove all marks currently enabled.
+Mapped to `M` by default.
+
+You can highlight |NvimTreeMarkedFile| to override the default highlight
+for files and folders with marks.
 
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/lua/nvim-tree/colors.lua
+++ b/lua/nvim-tree/colors.lua
@@ -47,7 +47,7 @@ local function get_hl_groups()
     GitRenamed = { fg = colors.purple },
     GitNew = { fg = colors.yellow },
 
-    WindowPicker = { gui = "bold", fg = "#ededed", bg = "#4493c8" }
+    WindowPicker = { gui = "bold", fg = "#ededed", bg = "#4493c8" },
   }
 end
 
@@ -73,6 +73,7 @@ local function get_links()
     StatusLine = "StatusLine",
     StatusLineNC = "StatusLineNC",
     SignColumn = 'NvimTreeNormal',
+    MarkedFile = "Visual"
   }
 end
 

--- a/lua/nvim-tree/marks.lua
+++ b/lua/nvim-tree/marks.lua
@@ -1,0 +1,52 @@
+local lib = require'nvim-tree.lib'
+local view = require'nvim-tree.view'
+local renderer = require'nvim-tree.renderer'
+
+local M = {}
+
+local function iterate_get_marks(node)
+  local marks = {}
+  for _, n in pairs(node.entries) do
+    if n.marked then
+      table.insert(marks, n)
+    end
+    if n.entries then
+      vim.fn.extend(marks, iterate_get_marks(n))
+    end
+  end
+  return marks
+end
+
+function M.get_marks()
+  return iterate_get_marks(lib.Tree)
+end
+
+function M.toggle_mark()
+  local node = lib.get_node_at_cursor()
+  if not node then
+    return
+  end
+
+  node.marked = not node.marked
+  if view.win_open() then
+    renderer.draw(lib.Tree, true)
+  end
+end
+
+local function iterate_toggle_off(node)
+  for _, n in pairs(node.entries) do
+    n.marked = false
+    if n.entries then
+      iterate_toggle_off(n)
+    end
+  end
+end
+
+function M.disable_all()
+  iterate_toggle_off(lib.Tree)
+  if view.win_open() then
+    renderer.draw(lib.Tree, true)
+  end
+end
+
+return M

--- a/lua/nvim-tree/renderer/init.lua
+++ b/lua/nvim-tree/renderer/init.lua
@@ -292,6 +292,7 @@ local function update_draw_data(tree, depth, markers)
     end
 
     local git_hl = get_git_hl(node)
+    local filename_start_at
 
     if node.entries then
       local has_children = #node.entries ~= 0 or node.has_children
@@ -310,10 +311,15 @@ local function update_draw_data(tree, depth, markers)
       if special[node.absolute_path] then
         folder_hl = "NvimTreeSpecialFolderName"
       end
+      filename_start_at = offset+#git_icon+#icon
       set_folder_hl(index, offset, #icon, #name+#git_icon, folder_hl)
       if git_hl then
         set_folder_hl(index, offset, #icon, #name+#git_icon, git_hl)
       end
+      if node.marked then
+        table.insert(hl, { 'NvimTreeMarkedFile', index, filename_start_at, -1 })
+      end
+
       index = index + 1
       if node.open then
         table.insert(lines, padding..icon..git_icon..name..(vim.g.nvim_tree_add_trailing == 1 and '/' or ''))
@@ -325,7 +331,8 @@ local function update_draw_data(tree, depth, markers)
       local icon = get_symlink_icon()
       local link_hl = git_hl or 'NvimTreeSymlink'
       local arrow = vim.g.nvim_tree_symlink_arrow or ' ➛ '
-      table.insert(hl, { link_hl, index, offset, -1 })
+      filename_start_at = offset
+      table.insert(hl, { link_hl, index, filename_start_at, -1 })
       table.insert(lines, padding..icon..node.name..arrow..node.link_to)
       index = index + 1
 
@@ -342,10 +349,11 @@ local function update_draw_data(tree, depth, markers)
       end
       table.insert(lines, padding..icon..git_icons..node.name)
 
+      filename_start_at = offset+#git_icons+#icon
       if node.executable then
-        table.insert(hl, {'NvimTreeExecFile', index, offset+#icon+#git_icons, -1 })
+        table.insert(hl, {'NvimTreeExecFile', index, filename_start_at, -1 })
       elseif picture[node.extension] then
-        table.insert(hl, {'NvimTreeImageFile', index, offset+#icon+#git_icons, -1 })
+        table.insert(hl, {'NvimTreeImageFile', index, filename_start_at, -1 })
       end
 
       if should_hl_opened_files then
@@ -364,6 +372,9 @@ local function update_draw_data(tree, depth, markers)
         table.insert(hl, {git_hl, index, offset+#icon+#git_icons, -1 })
       end
       index = index + 1
+    end
+    if not node.entries and node.marked then
+      table.insert(hl, { 'NvimTreeMarkedFile', index-1, filename_start_at, -1 })
     end
   end
 end

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -75,7 +75,9 @@ M.View = {
     { key = "-",                            cb = M.nvim_tree_callback("dir_up") },
     { key = "s",                            cb = M.nvim_tree_callback("system_open") },
     { key = "q",                            cb = M.nvim_tree_callback("close") },
-    { key = "g?",                           cb = M.nvim_tree_callback("toggle_help") }
+    { key = "g?",                           cb = M.nvim_tree_callback("toggle_help") },
+    { key = 'm',                            cb = ":lua require'nvim-tree.marks'.toggle_mark()<cr>" },
+    { key = 'M',                            cb = ":lua require'nvim-tree.marks'.disable_all()<cr>" },
   }
 }
 


### PR DESCRIPTION
this feature add marking capabilities in nvim-tree.
- Binding is `m` for toggle the mark of a node, `M` to disable all the current marks
- a new `NvimTreeMarkedFile` highlight group was added, green by default
- get the list of the marks with `require'nvim-tree.marks'.get_marks()` which will return a list of the tree nodes which you can do anything you want with.
- toggle a mark with `require'nvim-tree.marks'.toggle_mark()`
- disable all marks with `require'nvim-tree.marks'.disable_all()`

fixes #51 and #221 and #595

TODO:
- add example usage for moving multiple files.