### PR TITLE
feat(config): add notify to nvim_tree_window_picker_exclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ let g:nvim_tree_respect_buf_cwd = 1 "0 by default, will change cwd of nvim-tree 
 let g:nvim_tree_refresh_wait = 500 "1000 by default, control how often the tree can be refreshed, 1000 means the tree can be refresh once per 1000ms.
 let g:nvim_tree_window_picker_exclude = {
     \   'filetype': [
+    \     'notify',
     \     'packer',
     \     'qf'
     \   ],

--- a/lua/nvim-tree/config.lua
+++ b/lua/nvim-tree/config.lua
@@ -98,6 +98,7 @@ function M.window_picker_exclude()
   end
   return {
     filetype = {
+      "notify",
       "packer",
       "qf"
     }


### PR DESCRIPTION
With https://github.com/rcarriga/nvim-notify/ becoming more and more popular it's likely that issue like https://github.com/rcarriga/nvim-notify/issues/18 will pop up more often. I therefore propose adding that plugin's filetype to default `nvim_tree_window_picker_exclude`.