### PR TITLE
feat: option to set path destination to parent folder when cursor is on a closed folder while creating files

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ let g:nvim_tree_icon_padding = ' ' "one space by default, used for rendering the
 let g:nvim_tree_symlink_arrow = ' >> ' " defaults to ' ➛ '. used as a separator between symlinks' source and target.
 let g:nvim_tree_update_cwd = 1 "0 by default, will update the tree cwd when changing nvim's directory (DirChanged event). Behaves strangely with autochdir set.
 let g:nvim_tree_respect_buf_cwd = 1 "0 by default, will change cwd of nvim-tree to that of new buffer's when opening nvim-tree.
+let g:nvim_tree_create_in_closed_folder = 0 "1 by default, sets the path destination of a file when cursor is on a closed folder. Sets to the parent folder when 0, and inside the folder when 1.
 let g:nvim_tree_refresh_wait = 500 "1000 by default, control how often the tree can be refreshed, 1000 means the tree can be refresh once per 1000ms.
 let g:nvim_tree_window_picker_exclude = {
     \   'filetype': [

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ let g:nvim_tree_icon_padding = ' ' "one space by default, used for rendering the
 let g:nvim_tree_symlink_arrow = ' >> ' " defaults to ' ➛ '. used as a separator between symlinks' source and target.
 let g:nvim_tree_update_cwd = 1 "0 by default, will update the tree cwd when changing nvim's directory (DirChanged event). Behaves strangely with autochdir set.
 let g:nvim_tree_respect_buf_cwd = 1 "0 by default, will change cwd of nvim-tree to that of new buffer's when opening nvim-tree.
-let g:nvim_tree_create_in_closed_folder = 0 "1 by default, sets the path destination of a file when cursor is on a closed folder. Sets to the parent folder when 0, and inside the folder when 1.
+let g:nvim_tree_create_in_closed_folder = 0 "1 by default, When creating files, sets the path of a file when cursor is on a closed folder to the parent folder when 0, and inside the folder when 1.
 let g:nvim_tree_refresh_wait = 500 "1000 by default, control how often the tree can be refreshed, 1000 means the tree can be refresh once per 1000ms.
 let g:nvim_tree_window_picker_exclude = {
     \   'filetype': [

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -349,6 +349,12 @@ WARNING: Behaves strangely with autochdir set.
 Can be 0 or 1. 0 by default.
 Will change cwd of nvim-tree to that of new buffer's when opening nvim-tree.
 
+|g:nvim_tree_create_in_closed_folder|     *g:nvim_tree_create_in_closed_folder*
+
+Can be 0 or 1. 1 by default.
+Creating a file when the cursor is on a closed folder will set the
+path to be inside the closed folder when 1, and on the parent folder when 0.
+
 ==============================================================================
 INFORMATIONS				        *nvim-tree-info*
 

--- a/lua/nvim-tree/fs.lua
+++ b/lua/nvim-tree/fs.lua
@@ -57,15 +57,14 @@ function M.create(node)
     }
   end
 
+  local node_is_open = (
+    vim.g.nvim_tree_create_in_closed_folder == 0
+    and node.open or false
+  )
+
   local add_into
-  if node.entries ~= nil then
+  if node.entries ~= nil and node_is_open then
     add_into = utils.path_add_trailing(node.absolute_path)
-    local create_in_closed_folder = vim.g.nvim_tree_create_in_closed_folder or 1
-    if create_in_closed_folder == 0 then
-      if node.open == false then
-        add_into = node.absolute_path:sub(0, -(#node.name + 1))
-      end
-    end
   else
     add_into = node.absolute_path:sub(0, -(#node.name + 1))
   end

--- a/lua/nvim-tree/fs.lua
+++ b/lua/nvim-tree/fs.lua
@@ -64,6 +64,13 @@ function M.create(node)
     add_into = node.absolute_path:sub(0, -(#node.name + 1))
   end
 
+  local create_in_closed_folder = vim.g.nvim_tree_create_in_closed_folder or 1
+  if create_in_closed_folder == 0 then
+    if node.open == false then
+      add_into = node.absolute_path:sub(0, -(#node.name + 1))
+    end
+  end
+
   local ans = vim.fn.input('Create file ', add_into)
   utils.clear_prompt()
   if not ans or #ans == 0 or luv.fs_access(ans, 'r') then return end

--- a/lua/nvim-tree/fs.lua
+++ b/lua/nvim-tree/fs.lua
@@ -57,10 +57,7 @@ function M.create(node)
     }
   end
 
-  local node_is_open = (
-    vim.g.nvim_tree_create_in_closed_folder == 0
-    and node.open or false
-  )
+  local node_is_open = vim.g.nvim_tree_create_in_closed_folder == 1 or node.open
 
   local add_into
   if node.entries ~= nil and node_is_open then

--- a/lua/nvim-tree/fs.lua
+++ b/lua/nvim-tree/fs.lua
@@ -60,15 +60,14 @@ function M.create(node)
   local add_into
   if node.entries ~= nil then
     add_into = utils.path_add_trailing(node.absolute_path)
+    local create_in_closed_folder = vim.g.nvim_tree_create_in_closed_folder or 1
+    if create_in_closed_folder == 0 then
+      if node.open == false then
+        add_into = node.absolute_path:sub(0, -(#node.name + 1))
+      end
+    end
   else
     add_into = node.absolute_path:sub(0, -(#node.name + 1))
-  end
-
-  local create_in_closed_folder = vim.g.nvim_tree_create_in_closed_folder or 1
-  if create_in_closed_folder == 0 then
-    if node.open == false then
-      add_into = node.absolute_path:sub(0, -(#node.name + 1))
-    end
   end
 
   local ans = vim.fn.input('Create file ', add_into)


### PR DESCRIPTION
a more thorough description of the feature in #622 
Seems like this is the first instance of an option for the `fs.lua` module, so I decided to go with directly adding the variable there.
This was the only name I could think of that made sense, but I'm not sure if it makes _enough_ sense, so please do help me think of a better name if so.

Please do tell me if there's anything that I should change! Thanks :)