### PR TITLE
feat: add option to hide root dir path

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ let g:nvim_tree_indent_markers = 1 "0 by default, this option shows indent marke
 let g:nvim_tree_hide_dotfiles = 1 "0 by default, this option hides files and folders starting with a dot `.`
 let g:nvim_tree_git_hl = 1 "0 by default, will enable file highlight for git attributes (can be used without the icons).
 let g:nvim_tree_highlight_opened_files = 1 "0 by default, will enable folder and file icon highlight for opened files/directories.
+let g:nvim_tree_hide_root_folder = 1 "0 by default, will hide the current working directory on top of the tree"
 let g:nvim_tree_root_folder_modifier = ':~' "This is the default. See :help filename-modifiers for more options
 let g:nvim_tree_tab_open = 1 "0 by default, will open the tree when entering a new tab and the tree was previously open
 let g:nvim_tree_auto_resize = 0 "1 by default, will resize the tree to its saved width when opening a file

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -240,6 +240,12 @@ Can be `0` or `1`. When `1`, will hide dotfiles, files or folders which start
 with the `.` character.
 Default is 0
 
+|g:nvim_tree_hide_root_folder|							*g:nvim_tree_hide_root_folder*
+
+Can be `0` or `1`. When `1`, will hide the path of the current working
+directory on top of the tree.
+Default is 0
+
 |g:nvim_tree_root_folder_modifier|		     *g:nvim_tree_root_folder_modifier*
 
 In what format to show root folder. See `:help filename-modifiers` for
@@ -485,6 +491,7 @@ applied.
 
 NvimTreeSymlink
 NvimTreeFolderName
+NvimTreeHideRootFolder
 NvimTreeRootFolder
 NvimTreeFolderIcon
 NvimTreeEmptyFolderName

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -150,8 +150,14 @@ function M.on_keypress(mode)
     return keypress_funcs[mode](node)
   end
 
+	local hide_root_folder = vim.g.nvim_tree_hide_root_folder or 0;
+
   if node.name == ".." then
-    return lib.change_dir("..")
+		if hide_root_folder == 1 then
+			return lib.unroll_dir(node);
+		else
+			return lib.change_dir("..")
+		end
   elseif mode == "cd" and node.entries ~= nil then
     return lib.change_dir(lib.get_last_group_node(node).absolute_path)
   elseif mode == "cd" then
@@ -204,7 +210,7 @@ function M.on_enter()
   if is_dir then
     lib.Tree.cwd = vim.fn.expand(bufname)
   end
-  local netrw_disabled = hijack_netrw == 1 or disable_netrw == 1
+	local netrw_disabled = hijack_netrw == 1 or disable_netrw == 1
   local lines = not is_dir and api.nvim_buf_get_lines(bufnr, 0, -1, false) or {}
   local buf_has_content = #lines > 1 or (#lines == 1 and lines[1] ~= "")
   local should_open = vim.g.nvim_tree_auto_open == 1

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -58,8 +58,14 @@ function M.redraw()
   renderer.draw(M.Tree, true)
 end
 
+local hide_root_folder = vim.g.nvim_tree_hide_root_folder;
 local function get_node_at_line(line)
   local index = 2
+
+	if hide_root_folder == 1 then
+		index = 1
+	end
+
   local function iter(entries)
     for _, node in ipairs(entries) do
       if index == line then
@@ -112,7 +118,7 @@ function M.get_node_at_cursor()
     local help_text = get_node_at_line(line+1)(help_lines)
     return {name = help_text}
   else
-    if line == 1 and M.Tree.cwd ~= "/" then
+    if line == 1 and M.Tree.cwd ~= "/" and hide_root_folder ~= 1 then
       return { name = ".." }
     end
 
@@ -207,7 +213,7 @@ end
 
 function M.set_index_and_redraw(fname)
   local i
-  if M.Tree.cwd == '/' then
+  if M.Tree.cwd == '/' and hide_root_folder ~= 1 then
     i = 0
   else
     i = 1

--- a/lua/nvim-tree/renderer.lua
+++ b/lua/nvim-tree/renderer.lua
@@ -288,16 +288,17 @@ local special = vim.g.nvim_tree_special_files or {
 }
 
 local root_folder_modifier = vim.g.nvim_tree_root_folder_modifier or ':~'
+local hide_root_folder = vim.g.nvim_tree_hide_root_folder or 0;
 
 local function update_draw_data(tree, depth, markers)
-  if tree.cwd and tree.cwd ~= '/' then
-    local root_name = utils.path_join({
-      utils.path_remove_trailing(vim.fn.fnamemodify(tree.cwd, root_folder_modifier)),
-      ".."
-    })
-    table.insert(lines, root_name)
-    table.insert(hl, {'NvimTreeRootFolder', index, 0, string.len(root_name)})
-    index = 1
+  if tree.cwd and tree.cwd ~= '/' and hide_root_folder ~= 1 then
+		local root_name = utils.path_join({
+			utils.path_remove_trailing(vim.fn.fnamemodify(tree.cwd, root_folder_modifier)),
+			".."
+		})
+		table.insert(lines, root_name)
+		table.insert(hl, {'NvimTreeRootFolder', index, 0, string.len(root_name)})
+		index = 1
   end
 
   for idx, node in ipairs(tree.entries) do


### PR DESCRIPTION
Hi @kyazdani42 ,

This pull request adds a configuration option: `let g:nvim_tree_hide_root_folder`, which when enabled hides the path of the root folder on top of the tree like so:

```lua
let g:nvim_tree_hide_root_folder = 0; --default
```

![Screenshot from 2021-09-24 00-23-17 (1)](https://user-images.githubusercontent.com/29272343/134592466-ee50e9bd-8a14-43ca-8c7d-09c086f11f07.png)

```lua
let g:nvim_tree_hide_root_folder = 1;
```

![Screenshot from 2021-09-24 00-23-17 (3)](https://user-images.githubusercontent.com/29272343/134592607-adb99d42-b54b-4086-975a-56672ac7b699.png)

The intention is to allow for a more minimalistic ui, and for me personally tmux already shows the current directory so this information is sort of redundant.

Thanks for the aaaawsome plugin and cheers,

Jim

