### PR TITLE
Only renders the git icon if the icon is not empty

### DIFF
--- a/lua/nvim-tree/renderer.lua
+++ b/lua/nvim-tree/renderer.lua
@@ -231,8 +231,10 @@ if icon_state.show_git_icon then
       icons = git_icon_state.dirty
     end
     for _, v in ipairs(icons) do
-      table.insert(hl, { v.hl, line, depth+icon_len+#icon, depth+icon_len+#icon+#v.icon })
-      icon = icon..v.icon..icon_padding
+      if #v.icon > 0 then
+        table.insert(hl, { v.hl, line, depth+icon_len+#icon, depth+icon_len+#icon+#v.icon })
+        icon = icon..v.icon..icon_padding
+      end
     end
 
     return icon


### PR DESCRIPTION
This is mainly to avoid rendering a padding for a non-existent icon
making the nodes misaligned for no apparent reason

Fix issue #632