### PR TITLE
Remove duplicate 'nvim-tree-options' tag.

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -97,7 +97,7 @@ function.
 <
 
 As options are currently being migrated, configuration of global options in
-*nvim-tree-options* should be done BEFORE the setup call.
+|nvim-tree-options| should be done BEFORE the setup call.
 
 Here is a list of the options available in the setup call:
 - |disable_netrw|: completely disable netrw


### PR DESCRIPTION
Currently when running `:helptags ALL` there is a `E154: Duplicating tag "nvim-tree-options"` error. This change fixes it.