### PR TITLE
fix: add missing icons for `default` and `symlink`

### DIFF
--- a/lua/nvim-tree/config.lua
+++ b/lua/nvim-tree/config.lua
@@ -3,8 +3,8 @@ local M = {}
 function M.get_icon_state()
   local show_icons = vim.g.nvim_tree_show_icons or { git = 1, folders = 1, files = 1, folder_arrows = 1 }
   local icons = {
-    default = "",
-    symlink = "",
+    default = '',
+    symlink = '',
     git_icons = {
       unstaged = "✗",
       staged = "✓",


### PR DESCRIPTION
I think those are missing as the docs say that those icons are present by default but it isn't. Below are the icons
![image](https://user-images.githubusercontent.com/24727447/134853192-969b2e1e-51fa-44d5-8ba6-0cd8aa5a3d68.png)
