### PR TITLE
fix 'system_open' keypress callback

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -118,7 +118,7 @@ local keypress_funcs = {
         }
       elseif _config.is_macos then
         _config.system_open.cmd = 'open'
-      elseif _config.is_linux then
+      elseif _config.is_unix then
         _config.system_open.cmd = 'xdg-open'
       else
         require'nvim-tree.utils'.echo_warning("Cannot open file with system application. Unrecognized platform.")

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -134,7 +134,7 @@ local keypress_funcs = {
     }
     table.insert(process.args, node.link_to or node.absolute_path)
     process.handle, process.pid = luv.spawn(process.cmd,
-      { args = process.args, stdio = { nil, nil, process.stderr }},
+      { args = process.args, stdio = { nil, nil, process.stderr }, detached = true },
       function(code)
         process.stderr:read_stop()
         process.stderr:close()
@@ -156,6 +156,7 @@ local keypress_funcs = {
         if data then process.errors = process.errors .. data end
       end
     )
+    luv.unref(process.handle)
   end,
 }
 

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -145,6 +145,7 @@ local keypress_funcs = {
         end
       end
     )
+    table.remove(process.args)
     if not process.handle then
       error("\n" .. process.pid .. "\nNvimTree system_open: failed to spawn process using '" .. process.cmd .. "'.")
       return


### PR DESCRIPTION
I found two issues in the ```system_open``` keypress callback (at least on linux).

The first one was easy, the functions was using an undefined flag ```_config.is_linux``` (that was always returning false) instead of the correct flag ```_config.is_unix```.

The second issue I didn't quite understand yet. From the 'xdg-open' error message I manage to realize that the table ```process.args``` was persisting its state throughout the callback calls, and each time the current file path was being appended to it, causing errors after the first call.

I don't know why this table is not redefined after each call, but I could solve the issue removing the file path from the end of the table right after spawn the process.