### PR TITLE
fix: if open_on_setup set to false, don't start nvim-tree on open dir

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -305,10 +305,14 @@ function M.open_on_directory()
     return
   end
 
+  local should_open = _config.open_on_setup
+
   if view.win_open() and #api.nvim_list_wins() > 1 then
     view.close()
   end
-  M.hijack_current_window()
+  if should_open then
+    M.hijack_current_window()
+  end
   vim.api.nvim_buf_delete(buf, { force = true })
   lib.change_dir(bufname)
   lib.set_index_and_redraw(bufname)


### PR DESCRIPTION
fix #659 

## Summary

Make so that if `open_on_setup` set to false, doing `nvim .` won't start neovim with nvim-tree opened.

## Rationale

assumed [from the documentation][doc-link], it is expected to not open `nvim-tree` on open directory (command `nvim .`):
```
- |open_on_setup|: will automatically open the tree when running setup if current
  buffer is a directory, is empty or is unnamed.
```

## Demo

**All demo below is with minimal setup config, only option `open_on_setup` is set to `false`.**

Current behavior on `nvim-tree` latest `master` on https://github.com/kyazdani42/nvim-tree.lua/commit/f8b5eb0bd84744a1434bae83692d6c7eb8dcb91a:

https://user-images.githubusercontent.com/25895873/135146649-0c07733a-2043-462d-bc05-704bad5c156e.mov

New behavior introduced by this PR:

https://user-images.githubusercontent.com/25895873/135146669-f4e5bba3-b9f1-4edf-9df7-5eec4a4ea12e.mov



