### PR TITLE
feat: show default file icon when nvim-devicon is not installed

### DIFF
--- a/lua/nvim-tree/colors.lua
+++ b/lua/nvim-tree/colors.lua
@@ -79,7 +79,7 @@ local function get_links()
 end
 
 function M.setup()
-  if config.get_icon_state().show_file_icon then
+  if config.get_icon_state().show_file_icon and config.get_icon_state().has_devicons then
     require'nvim-web-devicons'.setup()
   end
   local higlight_groups = get_hl_groups()

--- a/lua/nvim-tree/config.lua
+++ b/lua/nvim-tree/config.lua
@@ -60,10 +60,11 @@ function M.get_icon_state()
 
   local has_devicons = pcall(require, 'nvim-web-devicons')
   return {
-    show_file_icon = show_icons.files == 1 and has_devicons,
+    show_file_icon = show_icons.files == 1,
     show_folder_icon = show_icons.folders == 1,
     show_git_icon = show_icons.git == 1,
     show_folder_arrows = show_icons.folder_arrows == 1,
+    has_devicons = has_devicons,
     icons = icons
   }
 end

--- a/lua/nvim-tree/renderer/init.lua
+++ b/lua/nvim-tree/renderer/init.lua
@@ -56,24 +56,29 @@ end
 
 local get_file_icon = function() return "" end
 if icon_state.show_file_icon then
-  local web_devicons = require'nvim-web-devicons'
+  if icon_state.has_devicons then
+    local web_devicons = require'nvim-web-devicons'
 
-  get_file_icon = function(fname, extension, line, depth)
-    local icon, hl_group = web_devicons.get_icon(fname, extension)
+    get_file_icon = function(fname, extension, line, depth)
+      local icon, hl_group = web_devicons.get_icon(fname, extension)
 
-    if icon and hl_group ~= "DevIconDefault" then
-      if hl_group then
-        table.insert(hl, { hl_group, line, depth, depth + #icon + 1 })
+      if icon and hl_group ~= "DevIconDefault" then
+        if hl_group then
+          table.insert(hl, { hl_group, line, depth, depth + #icon + 1 })
+        end
+        return icon..icon_padding
+      elseif string.match(extension, "%.(.*)") then
+        -- If there are more extensions to the file, try to grab the icon for them recursively
+        return get_file_icon(fname, string.match(extension, "%.(.*)"), line, depth)
+      else
+        return #icon_state.icons.default > 0 and icon_state.icons.default..icon_padding or ""
       end
-      return icon..icon_padding
-    elseif string.match(extension, "%.(.*)") then
-      -- If there are more extensions to the file, try to grab the icon for them recursively
-      return get_file_icon(fname, string.match(extension, "%.(.*)"), line, depth)
-    else
+    end
+  else
+    get_file_icon = function() 
       return #icon_state.icons.default > 0 and icon_state.icons.default..icon_padding or ""
     end
   end
-
 end
 
 local get_symlink_icon = function() return icon_state.icons.symlink end


### PR DESCRIPTION
Hello @kyazdani42
This is related to #689.