### PR TITLE
Add "Open buffers only mode"

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ highlight NvimTreeFolderIcon guibg=blue
 - `<BS>` will close current opened directory or parent
 - type `a` to add a file. Adding a directory requires leaving a leading `/` at the end of the path.
   > you can add multiple directories by doing foo/bar/baz/f and it will add foo bar and baz directories and f as a file
+- type `b` to toggle opened buffers only mode
+  > This will filter the tree to show only the opened buffers and the folders which contain them. Press 'b' again to go back to showing all files and folders.
 - type `r` to rename a file
 - type `<C-r>` to rename a file and omit the filename on input
 - type `x` to add/remove file/directory to cut clipboard

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -58,6 +58,17 @@ similar to combination of |:NvimTreeToggle| and |:NvimTreeFindFile|
 
 Show the tree in "opened buffers only" mode.
 
+|:NvimTreeEditNextFile| 	                  *:NvimTreeEditNextFile*
+
+Edits the next file visible in the tree, moving from top to bottom. If the
+tree is currently focused, this will switch to the previously used window.
+This is is particularly useful in conjuction with the "opened buffers only"
+mode.
+
+|:NvimTreeEditPrevFile| 	                  *:NvimTreeEditPrevFile*
+
+Same as NvimTreeEditNextFile, but in reverse.
+
 |:NvimTreeClipboard|			          *:NvimTreeClipboard*
 
 Print clipboard content for both cut and copy

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -54,6 +54,10 @@ It will also open the leafs of the tree leading to the file in the buffer
 close the tree or change the cursor in the tree for the current bufname,
 similar to combination of |:NvimTreeToggle| and |:NvimTreeFindFile|
 
+|:NvimTreeBuffers| 	                          *:NvimTreeBuffers*
+
+Show the tree in "opened buffers only" mode.
+
 |:NvimTreeClipboard|			          *:NvimTreeClipboard*
 
 Print clipboard content for both cut and copy
@@ -479,6 +483,7 @@ INFORMATIONS				        *nvim-tree-info*
 - typing 'P' will move cursor to the parent directory
 
 - type 'a' to add a file
+- type 'b' to toggle opened buffers only mode
 - type 'r' to rename a file
 - type `<C-r>` to rename a file and omit the filename on input
 - type 'x' to add/remove file/directory to cut clipboard
@@ -530,6 +535,7 @@ Defaults to:
       { key = "H",                            cb = tree_cb("toggle_dotfiles") },
       { key = "R",                            cb = tree_cb("refresh") },
       { key = "a",                            cb = tree_cb("create") },
+      { key = "b",                            cb = tree_cb("toggle_open_buffers_only") },
       { key = "d",                            cb = tree_cb("remove") },
       { key = "r",                            cb = tree_cb("rename") },
       { key = "<C-r>",                        cb = tree_cb("full_rename") },

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -2,7 +2,6 @@ local luv = vim.loop
 local api = vim.api
 
 local lib = require'nvim-tree.lib'
-local populate = require'nvim-tree.populate'
 local config = require'nvim-tree.config'
 local colors = require'nvim-tree.colors'
 local renderer = require'nvim-tree.renderer'

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -2,6 +2,7 @@ local luv = vim.loop
 local api = vim.api
 
 local lib = require'nvim-tree.lib'
+local populate = require'nvim-tree.populate'
 local config = require'nvim-tree.config'
 local colors = require'nvim-tree.colors'
 local renderer = require'nvim-tree.renderer'
@@ -89,6 +90,7 @@ local keypress_funcs = {
   toggle_ignored = lib.toggle_ignored,
   toggle_dotfiles = lib.toggle_dotfiles,
   toggle_help = lib.toggle_help,
+  toggle_open_buffers_only = lib.toggle_open_buffers_only,
   refresh = lib.refresh_tree,
   first_sibling = function(node) lib.sibling(node, -math.huge) end,
   last_sibling = function(node) lib.sibling(node, math.huge) end,
@@ -269,6 +271,11 @@ function M.find_file(with_open)
   lib.set_index_and_redraw(filepath)
 end
 
+function M.show_open_buffers()
+  lib.toggle_open_buffers_only(true)
+  M.find_file(true)
+end
+
 function M.resize(size)
   view.View.width = size
   view.View.height = size
@@ -363,6 +370,7 @@ local function setup_vim_commands()
     command! NvimTreeClipboard lua require'nvim-tree'.print_clipboard()
     command! NvimTreeFindFile lua require'nvim-tree'.find_file(true)
     command! NvimTreeFindFileToggle lua require'nvim-tree'.toggle(true)
+    command! NvimTreeBuffers lua require'nvim-tree'.show_open_buffers()
     command! -nargs=1 NvimTreeResize lua require'nvim-tree'.resize(<args>)
   ]]
 end

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -370,6 +370,8 @@ local function setup_vim_commands()
     command! NvimTreeFindFile lua require'nvim-tree'.find_file(true)
     command! NvimTreeFindFileToggle lua require'nvim-tree'.toggle(true)
     command! NvimTreeBuffers lua require'nvim-tree'.show_open_buffers()
+    command! NvimTreeEditNextFile lua require'nvim-tree.lib'.edit_next_file(1)
+    command! NvimTreeEditPrevFile lua require'nvim-tree.lib'.edit_next_file(-1)
     command! -nargs=1 NvimTreeResize lua require'nvim-tree'.resize(<args>)
   ]]
 end

--- a/lua/nvim-tree/buffers.lua
+++ b/lua/nvim-tree/buffers.lua
@@ -1,0 +1,50 @@
+local M = {}
+
+local sep = "/"
+local is_windows = vim.fn.has('win32') == 1 or vim.fn.has('win32unix') == 1
+if is_windows == true then
+    sep = "\\"
+end
+
+local split_path = function(s)
+    local fields = {}
+
+    local pattern = string.format("([^%s]+)", sep)
+    string.gsub(s, pattern, function(c) fields[#fields + 1] = c end)
+
+    return fields
+end
+
+local append_paths_of_buffer = function (buf_number, path_set)
+    local buf_name = vim.api.nvim_buf_get_name(buf_number)
+    local path_parts = split_path(buf_name)
+    local parent_name = ""
+    for _, part in ipairs(path_parts) do
+        if parent_name:len() > 0 then
+            parent_name = parent_name .. sep .. part
+        else
+            if is_windows then
+                parent_name = part
+            else
+                parent_name = sep .. part
+            end
+        end
+        path_set[parent_name] = true
+    end
+end
+
+---Get a table of all open buffers, along with all parent paths of those buffers.
+---The paths are the keys of the table, and all the values are 'true'.
+M.get_open_buffer_paths = function ()
+    local path_set = {}
+    local bufs = vim.api.nvim_list_bufs()
+    for _, b in ipairs(bufs) do
+        if vim.api.nvim_buf_is_loaded(b) then
+            append_paths_of_buffer(b, path_set)
+        end
+    end
+    return path_set
+end
+
+--print(vim.inspect(M.get_open_buffer_paths()))
+return M

--- a/lua/nvim-tree/buffers.lua
+++ b/lua/nvim-tree/buffers.lua
@@ -3,47 +3,47 @@ local M = {}
 local sep = "/"
 local is_windows = vim.fn.has('win32') == 1 or vim.fn.has('win32unix') == 1
 if is_windows == true then
-    sep = "\\"
+  sep = "\\"
 end
 
-local split_path = function(s)
-    local fields = {}
+local function split_path(s)
+  local fields = {}
 
-    local pattern = string.format("([^%s]+)", sep)
-    string.gsub(s, pattern, function(c) fields[#fields + 1] = c end)
+  local pattern = string.format("([^%s]+)", sep)
+  string.gsub(s, pattern, function(c) fields[#fields + 1] = c end)
 
-    return fields
+  return fields
 end
 
-local append_paths_of_buffer = function (buf_number, path_set)
-    local buf_name = vim.api.nvim_buf_get_name(buf_number)
-    local path_parts = split_path(buf_name)
-    local parent_name = ""
-    for _, part in ipairs(path_parts) do
-        if parent_name:len() > 0 then
-            parent_name = parent_name .. sep .. part
-        else
-            if is_windows then
-                parent_name = part
-            else
-                parent_name = sep .. part
-            end
-        end
-        path_set[parent_name] = true
+local function append_paths_of_buffer(buf_number, path_set)
+  local buf_name = vim.api.nvim_buf_get_name(buf_number)
+  local path_parts = split_path(buf_name)
+  local parent_name = ""
+  for _, part in ipairs(path_parts) do
+    if parent_name:len() > 0 then
+      parent_name = parent_name .. sep .. part
+    else
+      if is_windows then
+        parent_name = part
+      else
+        parent_name = sep .. part
+      end
     end
+    path_set[parent_name] = true
+  end
 end
 
 ---Get a table of all open buffers, along with all parent paths of those buffers.
 ---The paths are the keys of the table, and all the values are 'true'.
 M.get_open_buffer_paths = function ()
-    local path_set = {}
-    local bufs = vim.api.nvim_list_bufs()
-    for _, b in ipairs(bufs) do
-        if vim.api.nvim_buf_is_loaded(b) then
-            append_paths_of_buffer(b, path_set)
-        end
+  local path_set = {}
+  local bufs = vim.api.nvim_list_bufs()
+  for _, b in ipairs(bufs) do
+    if vim.api.nvim_buf_is_loaded(b) then
+      append_paths_of_buffer(b, path_set)
     end
-    return path_set
+  end
+  return path_set
 end
 
 --print(vim.inspect(M.get_open_buffer_paths()))

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -174,7 +174,7 @@ local function refresh_nodes(node)
   end
 end
 
-local refresh_tree_internal = function ()
+local function refresh_tree_internal()
   if not M.Tree.cwd or vim.v.exiting ~= vim.NIL then
     return
   end
@@ -202,14 +202,8 @@ local refresh_tree_internal = function ()
   end
 end
 
-local refresh_tree_callback = function (success, result)
-  if not success then
-    print("Error calling nvim-tree.lib.refresh_tree():", result)
-  end
-end
-
-function M.refresh_tree()
-  utils.debounce('refresh_tree', refresh_tree_internal, 200, refresh_tree_callback)
+function M.refresh_tree(callback)
+  utils.debounce('refresh_tree', refresh_tree_internal, 200, callback)
 end
 
 function M.set_index_and_redraw(fname)
@@ -601,8 +595,12 @@ function M.toggle_open_buffers_only(forceTrue)
   else
     pops.show_open_buffers_only = not pops.show_open_buffers_only
   end
-  M.refresh_tree()
-  M.expand_all()
+
+  if pops.show_open_buffers_only then
+    M.refresh_tree(M.expand_all)
+  else
+    M.refresh_tree()
+  end
 end
 
 function M.toggle_help()

--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -204,6 +204,10 @@ M.debounce = function(id, fn, frequency_in_ms, callback)
     fn_data.in_debounce_period = true
     local success, result = pcall(fn)
 
+    if not success then
+      print("Error calling nvim-tree.lib.refresh_tree():", result)
+    end
+
     -- Now schedule the next earliest execution.
     -- If there are no calls to run the same function between now
     -- and when this deferred executes, nothing will happen.
@@ -221,7 +225,7 @@ M.debounce = function(id, fn, frequency_in_ms, callback)
     end, frequency_in_ms)
 
     -- The callback function is outside the scope of the debounce period
-    if callback ~= nil then
+    if type(callback) == "function" then
         callback(success, result)
     end
 end

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -60,6 +60,7 @@ M.View = {
     { key = "H",                            cb = M.nvim_tree_callback("toggle_dotfiles") },
     { key = "R",                            cb = M.nvim_tree_callback("refresh") },
     { key = "a",                            cb = M.nvim_tree_callback("create") },
+    { key = "b",                            cb = M.nvim_tree_callback("toggle_open_buffers_only") },
     { key = "d",                            cb = M.nvim_tree_callback("remove") },
     { key = "r",                            cb = M.nvim_tree_callback("rename") },
     { key = "<C-r>",                        cb = M.nvim_tree_callback("full_rename") },


### PR DESCRIPTION
closes #744

This also includes updates to the refresh limiting code to make it more reliable. As it was, extra refresh calls were just being dropped which sometimes resulted with the view being out of sync. This was particularly noticeable with any toggle calls like the one I added. I turned it into a more of a debounce strategy, where the refresh is guaranteed to run after every call, but not more than once per vim.g.nvim_tree_refresh_wait period. I also set that default to 100 ms, let me know if that is not acceptable.
 