### PR TITLE
feat: allow number and relativenumber settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ require'nvim-tree'.setup {
     mappings = {
       custom_only = false,
       list = {}
-    }
+    },
+    number = false,
+    relativenumber = false
   }
 }
 ```

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -106,14 +106,16 @@ function.
         height = 30,
         side = 'left',
         auto_resize = false,
+        number = false,
+        relativenumber = false,
         mappings = {
           custom_only = false,
           list = {}
         }
       },
       filters = {
-	dotfiles = false,
-	custom = {}
+        dotfiles = false,
+        custom = {}
       }
     }
 <
@@ -255,6 +257,16 @@ Here is a list of the options available in the setup call:
       default: 'left'
 
   - |view.auto_resize|: auto resize the tree after opening a file
+      type: `boolean`
+      default: false
+
+  - |view.number|: print the line number in front of each line.
+      type: `boolean`
+      default: false
+
+  - |view.relativenumber|: show the line number relative to the line with the
+    cursor in front of each line. If the option `view.number` is also `true`,
+    the number on the cursor line will be the line number instead of `0`.
       type: `boolean`
       default: false
 

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -114,7 +114,9 @@ local DEFAULT_CONFIG = {
   mappings = {
     custom_only = false,
     list = {}
-  }
+  },
+  number = false,
+  relativenumber = false
 }
 
 local function merge_mappings(user_mappings)
@@ -147,6 +149,8 @@ function M.setup(opts)
   M.View.height = options.height
   M.View.hide_root_folder = options.hide_root_folder
   M.View.auto_resize = opts.auto_resize
+  M.View.winopts.number = options.number
+  M.View.winopts.relativenumber = options.relativenumber
   if options.mappings.custom_only then
     M.View.mappings = options.mappings.list
   else


### PR DESCRIPTION
This PR contains one commit that allows us to configure the line number, just like we would do with our regular buffers. 

Default behaviour:
![default](https://user-images.githubusercontent.com/32601980/139590018-cb9b4c8d-316f-4d2e-bfb7-3c26dc1068ce.png)

Just number:
![just_number](https://user-images.githubusercontent.com/32601980/139590027-2b216c82-c4aa-4799-8f08-1fb74e233e55.png)

Just relative number:
![just_relative](https://user-images.githubusercontent.com/32601980/139590037-6bdee8d5-9987-46ca-b224-9c8299a8a819.png)

Number and relative number:
![number_and_relative](https://user-images.githubusercontent.com/32601980/139590043-f474c295-60b1-4055-8a4b-5c07292fda1d.png)


