### PR TITLE
feat: add signcolumn setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ require'nvim-tree'.setup {
     hide_root_folder = false,
     side = 'left',
     auto_resize = false,
+    signcolumn = 'yes',
     mappings = {
       custom_only = false,
       list = {}

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -106,6 +106,7 @@ function.
         height = 30,
         side = 'left',
         auto_resize = false,
+	signcolumn = 'yes',
         mappings = {
           custom_only = false,
           list = {}
@@ -257,6 +258,11 @@ Here is a list of the options available in the setup call:
   - |view.auto_resize|: auto resize the tree after opening a file
       type: `boolean`
       default: false
+
+  - |view.signcolumn|: When and how to draw the signcolumn, which is before the
+    linenumber. when this option is 'no', |nvim-tree.diagnostics| might not work. see 'signcolumn'.
+      type: `string`
+      default: 'yes'
 
   - |view.mappings|: configuration options for keymaps
 

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -111,6 +111,7 @@ local DEFAULT_CONFIG = {
   height = 30,
   side = 'left',
   auto_resize = false,
+  signcolumn = 'yes',
   mappings = {
     custom_only = false,
     list = {}
@@ -147,6 +148,7 @@ function M.setup(opts)
   M.View.height = options.height
   M.View.hide_root_folder = options.hide_root_folder
   M.View.auto_resize = opts.auto_resize
+  M.View.winopts.signcolumn = options.signcolumn
   if options.mappings.custom_only then
     M.View.mappings = options.mappings.list
   else


### PR DESCRIPTION
I think there is someone doesn't like the blank signcolum, so I add an option to change that.
As it is 'auto', there won't be a signcolumn before every line. :)

config:
![image](https://user-images.githubusercontent.com/55988662/142148358-64eab677-b52d-4d2a-8198-0f8baa0f42ef.png)
when no errors and no warnings:
![image](https://user-images.githubusercontent.com/55988662/142149049-f27b20bd-9389-418c-ac1c-466e34547095.png)
when there are something wrong:
![image](https://user-images.githubusercontent.com/55988662/142148969-062bdc14-740f-4ceb-b74a-19719000ae4d.png)
