### PR TITLE
fix(nvim-0.6): wrong color group for warning sign

### DIFF
--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -119,7 +119,7 @@ end
 local has_06 = vim.fn.has('nvim-0.6') == 1
 local links = {
   NvimTreeLspDiagnosticsError = has_06 and "DiagnosticError" or "LspDiagnosticsDefaultError",
-  NvimTreeLspDiagnosticsWarning = has_06 and "DiagnosticWarning" or "LspDiagnosticsDefaultWarning",
+  NvimTreeLspDiagnosticsWarning = has_06 and "DiagnosticWarn" or "LspDiagnosticsDefaultWarning",
   NvimTreeLspDiagnosticsInformation = has_06 and "DiagnosticInfo" or "LspDiagnosticsDefaultInformation",
   NvimTreeLspDiagnosticsHint = has_06 and "DiagnosticHint" or "LspDiagnosticsDefaultHint",
 }


### PR DESCRIPTION
Change color group to `DiagnosticWarn` for [nvim-0.6](https://github.com/neovim/neovim/blob/725cbe7d414f609e769081276f2a034e32a4337b/runtime/doc/diagnostic.txt#L192).