### PR TITLE
fix: close_node behavior on file

### DIFF
--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -554,6 +554,7 @@ function M.parent_node(node, should_close)
       line = 1
     elseif should_close then
       parent.open = false
+      altered_tree = true
     end
     view.set_cursor({line, 0})
   end


### PR DESCRIPTION
If `close_node` was called on a file, the parent folder is collapsed, but the ui was not being redrawn.