### PR TITLE
fix: idx passed to api.nvim_win_set_cursor may be -1

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -338,7 +338,10 @@ function M.place_cursor_on_node()
   local line = api.nvim_get_current_line()
   local cursor = api.nvim_win_get_cursor(0)
   local idx = vim.fn.stridx(line, node.name)
-  api.nvim_win_set_cursor(0, {cursor[1], idx})
+
+  if idx >= 0 then
+    api.nvim_win_set_cursor(0, {cursor[1], idx})
+  end
 end
 
 local function manage_netrw(disable_netrw, hijack_netrw)


### PR DESCRIPTION
This causes out of range error on CursorMoved event is fired if hijack_cursor option is set to true.
Although I don't know why it fixes the issue, but it has been working fine for me.

Potentially fix #783, #803