### PR TITLE
Focus the parent node instead of its first child node

### DIFF
--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -556,6 +556,7 @@ function M.parent_node(node, should_close)
       parent.open = false
       altered_tree = true
     end
+    line = math.max(unpack({line - 1, 1}))
     view.set_cursor({line, 0})
   end
 


### PR DESCRIPTION
This change make the `parent_node` (`P` mapping) repeatable, this way by pressing `P` multiple times one can navigate to the parent directory on each key press.