### PR TITLE
Fixing deprecated LSP diagnostic getter (fixes https://github.com/kyazdani42/nvim-tree.lua/issues/833)

### DIFF
--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -1,7 +1,7 @@
 local a = vim.api
 local utils = require'nvim-tree.utils'
 local view = require'nvim-tree.view'
-local get_diagnostics = vim.lsp.diagnostic.get_all
+local get_diagnostics = vim.diagnostic.get
 
 local M = {}
 


### PR DESCRIPTION
TODO:
- [ ] check if `vim.diagnostic.get` really is the same as `vim.lsp.diagnostic.get_all`