### PR TITLE
Fix redrawing tree when not inside git repo

### DIFF
--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -221,8 +221,8 @@ function M.set_index_and_redraw(fname)
           git.load_project_status(node.absolute_path, function(status)
             if status.dirs or status.files then
               reload_node_status(node, git.projects)
-              M.redraw()
             end
+            M.redraw()
           end)
         end
         if node.open == false then


### PR DESCRIPTION
Fixes #783 and #831

Redraw was not called when cwd is not a git repo.