### PR TITLE
restore-feat: highlight-git-ignored-files

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -255,9 +255,9 @@ Here is a list of the options available in the setup call:
     type: `boolean`
     default: `true`
 
-  - |git.ignore|: ignore files based on `.gitignore`.
-    will add `ignored=matching` to the integration when `true`. Otherwise will
-    add `ignored=no` to the integration which can lead to better performance.
+  - |git.ignore|: ignore files based on `.gitignore`
+    type: `boolean`
+    default: `true`
 
   - |git.timeout|: kills the git process after some time if it takes too long
     type: `number`

--- a/lua/nvim-tree/git/init.lua
+++ b/lua/nvim-tree/git/init.lua
@@ -19,7 +19,7 @@ function M.reload(callback)
     Runner.run {
       project_root = project_root,
       list_untracked = git_utils.should_show_untracked(project_root),
-      list_ignored = M.config.ignore,
+      list_ignored = true,
       timeout = M.config.timeout,
       on_end = function(git_status)
         M.projects[project_root] = {
@@ -67,7 +67,7 @@ function M.load_project_status(cwd, callback)
   Runner.run {
     project_root = project_root,
     list_untracked = git_utils.should_show_untracked(project_root),
-    list_ignored = M.config.ignore,
+    list_ignored = true,
     timeout = M.config.timeout,
     on_end = function(git_status)
       M.projects[project_root] = {

--- a/lua/nvim-tree/populate.lua
+++ b/lua/nvim-tree/populate.lua
@@ -148,7 +148,8 @@ local function should_ignore(path)
 end
 
 local function should_ignore_git(path, status)
-  return M.config.filter_ignored and (status and status[path] == '!!')
+  return M.config.filter_ignored
+    and (M.config.filter_git_ignored and status and status[path] == '!!')
 end
 
 function M.refresh_entries(entries, cwd, parent_node, status)
@@ -351,6 +352,7 @@ function M.setup(opts)
   M.config = {
     filter_ignored = true,
     filter_dotfiles = opts.filters.dotfiles,
+    filter_git_ignored = opts.git.ignore,
   }
 
   local custom_filter = opts.filters.custom


### PR DESCRIPTION
See #813 for more details.

The commit 6662b60a2bb55f0c1eca4db54cba5c57c2b2daff introduced a breaking change in the plugin, as the git ignored folders/files could not be highlight anymore. This was caused by the decision to not include the parameter `--ignored=matching` in the git runner command when the user wants to *show* the ignored files, resulting in a `nil` git status for this files and making impossible to the renderer functions to set the proper highlights.

This PR aims to restore the previous behavior by  including `--ignored=matching` in all git commands. I think this is the only way to get the old behavior without changing the current config.

In order to be possible to get this behaviour *and* keep the possibility to call git without the  `--ignored=matching` (for possible performance gains) I think a new config option must be added, like `git.highlight_ignored`. But I would prefer to not have to make such change.

Fix #813