### PR TITLE
custom node keymaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,50 +219,60 @@ highlight NvimTreeFolderIcon guibg=blue
 The `list` option in `view.mappings.list` is a table of
 ```lua
 -- key can be either a string or a table of string (lhs)
--- cb is the callback that will be called
+-- action is the name of the action
+-- action_cb is the function that will be called, it receives the node as a parameter. Optional for default actions
 -- mode is normal by default
+
+local tree_cb = require'nvim-tree.config'.nvim_tree_callback
+
+local function print_node_path(node) {
+  print(node.absolute_path)
+}
+
 local list = {
-  { key = {"<CR>", "o" }, cb = ":lua some_func()<cr>", mode = "n"}
+  { key = {"<CR>", "o" }, action = "edit", mode = "n"},
+  { key = "p", action = "print_path", action_cb = print_node_path },
+  { key = "s", cb = tree_cb("vsplit") }, --tree_cb and the cb property are deprecated
 }
 ```
 
 These are the default bindings:
 ```lua
-local tree_cb = require'nvim-tree.config'.nvim_tree_callback
+
 -- default mappings
 local list = {
-  { key = {"<CR>", "o", "<2-LeftMouse>"}, cb = tree_cb("edit") },
-  { key = {"<2-RightMouse>", "<C-]>"},    cb = tree_cb("cd") },
-  { key = "<C-v>",                        cb = tree_cb("vsplit") },
-  { key = "<C-x>",                        cb = tree_cb("split") },
-  { key = "<C-t>",                        cb = tree_cb("tabnew") },
-  { key = "<",                            cb = tree_cb("prev_sibling") },
-  { key = ">",                            cb = tree_cb("next_sibling") },
-  { key = "P",                            cb = tree_cb("parent_node") },
-  { key = "<BS>",                         cb = tree_cb("close_node") },
-  { key = "<Tab>",                        cb = tree_cb("preview") },
-  { key = "K",                            cb = tree_cb("first_sibling") },
-  { key = "J",                            cb = tree_cb("last_sibling") },
-  { key = "I",                            cb = tree_cb("toggle_ignored") },
-  { key = "H",                            cb = tree_cb("toggle_dotfiles") },
-  { key = "R",                            cb = tree_cb("refresh") },
-  { key = "a",                            cb = tree_cb("create") },
-  { key = "d",                            cb = tree_cb("remove") },
-  { key = "D",                            cb = tree_cb("trash") },
-  { key = "r",                            cb = tree_cb("rename") },
-  { key = "<C-r>",                        cb = tree_cb("full_rename") },
-  { key = "x",                            cb = tree_cb("cut") },
-  { key = "c",                            cb = tree_cb("copy") },
-  { key = "p",                            cb = tree_cb("paste") },
-  { key = "y",                            cb = tree_cb("copy_name") },
-  { key = "Y",                            cb = tree_cb("copy_path") },
-  { key = "gy",                           cb = tree_cb("copy_absolute_path") },
-  { key = "[c",                           cb = tree_cb("prev_git_item") },
-  { key = "]c",                           cb = tree_cb("next_git_item") },
-  { key = "-",                            cb = tree_cb("dir_up") },
-  { key = "s",                            cb = tree_cb("system_open") },
-  { key = "q",                            cb = tree_cb("close") },
-  { key = "g?",                           cb = tree_cb("toggle_help") },
+  { key = {"<CR>", "o", "<2-LeftMouse>"}, action = "edit" },
+  { key = {"<2-RightMouse>", "<C-]>"},    action = "cd" },
+  { key = "<C-v>",                        action = "vsplit" },
+  { key = "<C-x>",                        action = "split" },
+  { key = "<C-t>",                        action = "tabnew" },
+  { key = "<",                            action = "prev_sibling" },
+  { key = ">",                            action = "next_sibling" },
+  { key = "P",                            action = "parent_node" },
+  { key = "<BS>",                         action = "close_node" },
+  { key = "<Tab>",                        action = "preview" },
+  { key = "K",                            action = "first_sibling" },
+  { key = "J",                            action = "last_sibling" },
+  { key = "I",                            action = "toggle_ignored" },
+  { key = "H",                            action = "toggle_dotfiles" },
+  { key = "R",                            action = "refresh" },
+  { key = "a",                            action = "create" },
+  { key = "d",                            action = "remove" },
+  { key = "D",                            action = "trash" },
+  { key = "r",                            action = "rename" },
+  { key = "<C-r>",                        action = "full_rename" },
+  { key = "x",                            action = "cut" },
+  { key = "c",                            action = "copy" },
+  { key = "p",                            action = "paste" },
+  { key = "y",                            action = "copy_name" },
+  { key = "Y",                            action = "copy_path" },
+  { key = "gy",                           action = "copy_absolute_path" },
+  { key = "[c",                           action = "prev_git_item" },
+  { key = "]c",                           action = "next_git_item" },
+  { key = "-",                            action = "dir_up" },
+  { key = "s",                            action = "system_open" },
+  { key = "q",                            action = "close" },
+  { key = "g?",                           action = "toggle_help" },
 }
 ```
 

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -568,42 +568,61 @@ INFORMATIONS				        *nvim-tree-info*
 Defaults to:
 >
   lua <<EOF
-    local tree_cb = require'nvim-tree.config'.nvim_tree_callback
     local list = {
-      { key = {"<CR>", "o", "<2-LeftMouse>"}, cb = tree_cb("edit") },
-      { key = {"<2-RightMouse>", "<C-]>"},    cb = tree_cb("cd") },
-      { key = "<C-v>",                        cb = tree_cb("vsplit") },
-      { key = "<C-x>",                        cb = tree_cb("split") },
-      { key = "<C-t>",                        cb = tree_cb("tabnew") },
-      { key = "<",                            cb = tree_cb("prev_sibling") },
-      { key = ">",                            cb = tree_cb("next_sibling") },
-      { key = "P",                            cb = tree_cb("parent_node") },
-      { key = "<BS>",                         cb = tree_cb("close_node") },
-      { key = "<Tab>",                        cb = tree_cb("preview") },
-      { key = "K",                            cb = tree_cb("first_sibling") },
-      { key = "J",                            cb = tree_cb("last_sibling") },
-      { key = "I",                            cb = tree_cb("toggle_ignored") },
-      { key = "H",                            cb = tree_cb("toggle_dotfiles") },
-      { key = "R",                            cb = tree_cb("refresh") },
-      { key = "a",                            cb = tree_cb("create") },
-      { key = "d",                            cb = tree_cb("remove") },
-      { key = "D",                            cb = tree_cb("trash") },
-      { key = "r",                            cb = tree_cb("rename") },
-      { key = "<C-r>",                        cb = tree_cb("full_rename") },
-      { key = "x",                            cb = tree_cb("cut") },
-      { key = "c",                            cb = tree_cb("copy") },
-      { key = "p",                            cb = tree_cb("paste") },
-      { key = "y",                            cb = tree_cb("copy_name") },
-      { key = "Y",                            cb = tree_cb("copy_path") },
-      { key = "gy",                           cb = tree_cb("copy_absolute_path") },
-      { key = "[c",                           cb = tree_cb("prev_git_item") },
-      { key = "]c",                           cb = tree_cb("next_git_item") },
-      { key = "-",                            cb = tree_cb("dir_up") },
-      { key = "s",                            cb = tree_cb("system_open") },
-      { key = "q",                            cb = tree_cb("close") },
-      { key = "g?",                           cb = tree_cb("toggle_help") },
+      { key = {"<CR>", "o", "<2-LeftMouse>"}, action = "edit" },
+      { key = {"<2-RightMouse>", "<C-]>"},    action = "cd" },
+      { key = "<C-v>",                        action = "vsplit" },
+      { key = "<C-x>",                        action = "split" },
+      { key = "<C-t>",                        action = "tabnew" },
+      { key = "<",                            action = "prev_sibling" },
+      { key = ">",                            action = "next_sibling" },
+      { key = "P",                            action = "parent_node" },
+      { key = "<BS>",                         action = "close_node" },
+      { key = "<Tab>",                        action = "preview" },
+      { key = "K",                            action = "first_sibling" },
+      { key = "J",                            action = "last_sibling" },
+      { key = "I",                            action = "toggle_ignored" },
+      { key = "H",                            action = "toggle_dotfiles" },
+      { key = "R",                            action = "refresh" },
+      { key = "a",                            action = "create" },
+      { key = "d",                            action = "remove" },
+      { key = "D",                            action = "trash" },
+      { key = "r",                            action = "rename" },
+      { key = "<C-r>",                        action = "full_rename" },
+      { key = "x",                            action = "cut" },
+      { key = "c",                            action = "copy" },
+      { key = "p",                            action = "paste" },
+      { key = "y",                            action = "copy_name" },
+      { key = "Y",                            action = "copy_path" },
+      { key = "gy",                           action = "copy_absolute_path" },
+      { key = "[c",                           action = "prev_git_item" },
+      { key = "]c",                           action = "next_git_item" },
+      { key = "-",                            action = "dir_up" },
+      { key = "s",                            action = "system_open" },
+      { key = "q",                            action = "close" },
+      { key = "g?",                           action = "toggle_help" },
     }
 <
+The `list` option in `view.mappings.list` is a table of
+
+- key can be either a string or a table of string (lhs)
+- action is the name of the action
+- action_cb is the function that will be called, it receives the node as a parameter. Optional for default actions
+- mode is normal by default
+>
+  lua <<EOF
+    local tree_cb = require'nvim-tree.config'.nvim_tree_callback
+    
+    local function print_node_path(node) {
+      print(node.absolute_path)
+    }
+    
+    local list = {
+      { key = {"<CR>", "o" }, action = "edit", mode = "n"},
+      { key = "p", action = "print_path", action_cb = print_node_path },
+      { key = "s", cb = tree_cb("vsplit") }, --tree_cb and the cb property are deprecated
+    }
+
 
 |Features|					*nvim-tree-features*
 

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -155,31 +155,34 @@ local keypress_funcs = {
   trash = function(node) trash.trash_node(node, _config) end,
 }
 
-function M.on_keypress(mode)
-  if view.is_help_ui() and mode ~= 'toggle_help' then return end
+function M.on_keypress(action)
+  if view.is_help_ui() and action ~= 'toggle_help' then return end
   local node = lib.get_node_at_cursor()
   if not node then return end
 
-  if keypress_funcs[mode] then
-    return keypress_funcs[mode](node)
-  elseif view.View.custom_keypress_funcs[mode] then
-    return view.View.custom_keypress_funcs[mode](node)
+  local custom_function = view.View.custom_keypress_funcs[action]
+  local default_function = keypress_funcs[action]
+
+  if type(custom_function) == 'function' then
+    return custom_function(node)
+  elseif default_function then
+    return default_function(node)
   end
 
   if node.name == ".." then
     return lib.change_dir("..")
-  elseif mode == "cd" and node.entries ~= nil then
+  elseif action == "cd" and node.entries ~= nil then
     return lib.change_dir(lib.get_last_group_node(node).absolute_path)
-  elseif mode == "cd" then
+  elseif action == "cd" then
     return
   end
 
   if node.link_to and not node.entries then
-    lib.open_file(mode, node.link_to)
+    lib.open_file(action, node.link_to)
   elseif node.entries ~= nil then
     lib.expand_or_collapse(node)
   else
-    lib.open_file(mode, node.absolute_path)
+    lib.open_file(action, node.absolute_path)
   end
 end
 

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -162,6 +162,8 @@ function M.on_keypress(mode)
 
   if keypress_funcs[mode] then
     return keypress_funcs[mode](node)
+  elseif view.View.custom_keypress_funcs[mode] then
+    return view.View.custom_keypress_funcs[mode](node)
   end
 
   if node.name == ".." then

--- a/lua/nvim-tree/config.lua
+++ b/lua/nvim-tree/config.lua
@@ -58,19 +58,9 @@ function M.get_icon_state()
   }
 end
 
+-- TODO: remove this once the cb property is not supported in mappings
 function M.nvim_tree_callback(callback_name)
   return string.format(":lua require'nvim-tree'.on_keypress('%s')<CR>", callback_name)
-end
-
-function M.nvim_tree_custom_node_callback(keys, callback_name, callback_fn)
-  return {
-    key = keys,
-    cb = M.nvim_tree_callback(callback_name),
-    custom_node_cb = {
-      name = callback_name,
-      fn = callback_fn,
-    }
-  }
 end
 
 function M.window_options()

--- a/lua/nvim-tree/config.lua
+++ b/lua/nvim-tree/config.lua
@@ -62,6 +62,17 @@ function M.nvim_tree_callback(callback_name)
   return string.format(":lua require'nvim-tree'.on_keypress('%s')<CR>", callback_name)
 end
 
+function M.nvim_tree_custom_node_callback(keys, callback_name, callback_fn)
+  return {
+    key = keys,
+    cb = M.nvim_tree_callback(callback_name),
+    custom_node_cb = {
+      name = callback_name,
+      fn = callback_fn,
+    }
+  }
+end
+
 function M.window_options()
   local opts = {}
   local side = require'nvim-tree.view'.View.side

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -1,17 +1,7 @@
 local a = vim.api
+local nvim_tree_callback = require'nvim-tree.config'.nvim_tree_callback
 
 local M = {}
-
-function M.nvim_tree_callback(callback_name)
-  return string.format(":lua require'nvim-tree'.on_keypress('%s')<CR>", callback_name)
-end
-
-function M.nvim_tree_custom_node_callback(callback_name, callback_fn)
-  return {
-    name = callback_name,
-    fn = callback_fn,
-  }
-end
 
 M.View = {
   bufnr = nil,
@@ -50,39 +40,39 @@ M.View = {
     { name = 'bufhidden', val = 'hide' }
   },
   mappings = {
-    { key = {"<CR>", "o", "<2-LeftMouse>"}, cb = M.nvim_tree_callback("edit") },
-    { key = {"<2-RightMouse>", "<C-]>"},    cb = M.nvim_tree_callback("cd") },
-    { key = "<C-v>",                        cb = M.nvim_tree_callback("vsplit") },
-    { key = "<C-x>",                        cb = M.nvim_tree_callback("split") },
-    { key = "<C-t>",                        cb = M.nvim_tree_callback("tabnew") },
-    { key = "<",                            cb = M.nvim_tree_callback("prev_sibling") },
-    { key = ">",                            cb = M.nvim_tree_callback("next_sibling") },
-    { key = "P",                            cb = M.nvim_tree_callback("parent_node") },
-    { key = "<BS>",                         cb = M.nvim_tree_callback("close_node") },
-    { key = "<S-CR>",                       cb = M.nvim_tree_callback("close_node") },
-    { key = "<Tab>",                        cb = M.nvim_tree_callback("preview") },
-    { key = "K",                            cb = M.nvim_tree_callback("first_sibling") },
-    { key = "J",                            cb = M.nvim_tree_callback("last_sibling") },
-    { key = "I",                            cb = M.nvim_tree_callback("toggle_ignored") },
-    { key = "H",                            cb = M.nvim_tree_callback("toggle_dotfiles") },
-    { key = "R",                            cb = M.nvim_tree_callback("refresh") },
-    { key = "a",                            cb = M.nvim_tree_callback("create") },
-    { key = "d",                            cb = M.nvim_tree_callback("remove") },
-    { key = "D",                            cb = M.nvim_tree_callback("trash") },
-    { key = "r",                            cb = M.nvim_tree_callback("rename") },
-    { key = "<C-r>",                        cb = M.nvim_tree_callback("full_rename") },
-    { key = "x",                            cb = M.nvim_tree_callback("cut") },
-    { key = "c",                            cb = M.nvim_tree_callback("copy") },
-    { key = "p",                            cb = M.nvim_tree_callback("paste") },
-    { key = "y",                            cb = M.nvim_tree_callback("copy_name") },
-    { key = "Y",                            cb = M.nvim_tree_callback("copy_path") },
-    { key = "gy",                           cb = M.nvim_tree_callback("copy_absolute_path") },
-    { key = "[c",                           cb = M.nvim_tree_callback("prev_git_item") },
-    { key = "]c",                           cb = M.nvim_tree_callback("next_git_item") },
-    { key = "-",                            cb = M.nvim_tree_callback("dir_up") },
-    { key = "s",                            cb = M.nvim_tree_callback("system_open") },
-    { key = "q",                            cb = M.nvim_tree_callback("close") },
-    { key = "g?",                           cb = M.nvim_tree_callback("toggle_help") }
+    { key = {"<CR>", "o", "<2-LeftMouse>"}, cb = nvim_tree_callback("edit") },
+    { key = {"<2-RightMouse>", "<C-]>"},    cb = nvim_tree_callback("cd") },
+    { key = "<C-v>",                        cb = nvim_tree_callback("vsplit") },
+    { key = "<C-x>",                        cb = nvim_tree_callback("split") },
+    { key = "<C-t>",                        cb = nvim_tree_callback("tabnew") },
+    { key = "<",                            cb = nvim_tree_callback("prev_sibling") },
+    { key = ">",                            cb = nvim_tree_callback("next_sibling") },
+    { key = "P",                            cb = nvim_tree_callback("parent_node") },
+    { key = "<BS>",                         cb = nvim_tree_callback("close_node") },
+    { key = "<S-CR>",                       cb = nvim_tree_callback("close_node") },
+    { key = "<Tab>",                        cb = nvim_tree_callback("preview") },
+    { key = "K",                            cb = nvim_tree_callback("first_sibling") },
+    { key = "J",                            cb = nvim_tree_callback("last_sibling") },
+    { key = "I",                            cb = nvim_tree_callback("toggle_ignored") },
+    { key = "H",                            cb = nvim_tree_callback("toggle_dotfiles") },
+    { key = "R",                            cb = nvim_tree_callback("refresh") },
+    { key = "a",                            cb = nvim_tree_callback("create") },
+    { key = "d",                            cb = nvim_tree_callback("remove") },
+    { key = "D",                            cb = nvim_tree_callback("trash") },
+    { key = "r",                            cb = nvim_tree_callback("rename") },
+    { key = "<C-r>",                        cb = nvim_tree_callback("full_rename") },
+    { key = "x",                            cb = nvim_tree_callback("cut") },
+    { key = "c",                            cb = nvim_tree_callback("copy") },
+    { key = "p",                            cb = nvim_tree_callback("paste") },
+    { key = "y",                            cb = nvim_tree_callback("copy_name") },
+    { key = "Y",                            cb = nvim_tree_callback("copy_path") },
+    { key = "gy",                           cb = nvim_tree_callback("copy_absolute_path") },
+    { key = "[c",                           cb = nvim_tree_callback("prev_git_item") },
+    { key = "]c",                           cb = nvim_tree_callback("next_git_item") },
+    { key = "-",                            cb = nvim_tree_callback("dir_up") },
+    { key = "s",                            cb = nvim_tree_callback("system_open") },
+    { key = "q",                            cb = nvim_tree_callback("close") },
+    { key = "g?",                           cb = nvim_tree_callback("toggle_help") }
   },
   custom_keypress_funcs = {},
 }

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -40,38 +40,38 @@ M.View = {
     { name = 'bufhidden', val = 'hide' }
   },
   mappings = {
-    { key = {"<CR>", "o", "<2-LeftMouse>"}, cb = nvim_tree_callback("edit") },
-    { key = {"<2-RightMouse>", "<C-]>"},    cb = nvim_tree_callback("cd") },
-    { key = "<C-v>",                        cb = nvim_tree_callback("vsplit") },
-    { key = "<C-x>",                        cb = nvim_tree_callback("split") },
-    { key = "<C-t>",                        cb = nvim_tree_callback("tabnew") },
-    { key = "<",                            cb = nvim_tree_callback("prev_sibling") },
-    { key = ">",                            cb = nvim_tree_callback("next_sibling") },
-    { key = "P",                            cb = nvim_tree_callback("parent_node") },
-    { key = "<BS>",                         cb = nvim_tree_callback("close_node") },
-    { key = "<Tab>",                        cb = nvim_tree_callback("preview") },
-    { key = "K",                            cb = nvim_tree_callback("first_sibling") },
-    { key = "J",                            cb = nvim_tree_callback("last_sibling") },
-    { key = "I",                            cb = nvim_tree_callback("toggle_ignored") },
-    { key = "H",                            cb = nvim_tree_callback("toggle_dotfiles") },
-    { key = "R",                            cb = nvim_tree_callback("refresh") },
-    { key = "a",                            cb = nvim_tree_callback("create") },
-    { key = "d",                            cb = nvim_tree_callback("remove") },
-    { key = "D",                            cb = nvim_tree_callback("trash") },
-    { key = "r",                            cb = nvim_tree_callback("rename") },
-    { key = "<C-r>",                        cb = nvim_tree_callback("full_rename") },
-    { key = "x",                            cb = nvim_tree_callback("cut") },
-    { key = "c",                            cb = nvim_tree_callback("copy") },
-    { key = "p",                            cb = nvim_tree_callback("paste") },
-    { key = "y",                            cb = nvim_tree_callback("copy_name") },
-    { key = "Y",                            cb = nvim_tree_callback("copy_path") },
-    { key = "gy",                           cb = nvim_tree_callback("copy_absolute_path") },
-    { key = "[c",                           cb = nvim_tree_callback("prev_git_item") },
-    { key = "]c",                           cb = nvim_tree_callback("next_git_item") },
-    { key = "-",                            cb = nvim_tree_callback("dir_up") },
-    { key = "s",                            cb = nvim_tree_callback("system_open") },
-    { key = "q",                            cb = nvim_tree_callback("close") },
-    { key = "g?",                           cb = nvim_tree_callback("toggle_help") }
+    { key = {"<CR>", "o", "<2-LeftMouse>"}, action = "edit" },
+    { key = {"<2-RightMouse>", "<C-]>"},    action = "cd" },
+    { key = "<C-v>",                        action = "vsplit" },
+    { key = "<C-x>",                        action = "split"},
+    { key = "<C-t>",                        action = "tabnew" },
+    { key = "<",                            action = "prev_sibling" },
+    { key = ">",                            action = "next_sibling" },
+    { key = "P",                            action = "parent_node" },
+    { key = "<BS>",                         action = "close_node"},
+    { key = "<Tab>",                        action = "preview" },
+    { key = "K",                            action = "first_sibling" },
+    { key = "J",                            action = "last_sibling" },
+    { key = "I",                            action = "toggle_ignored" },
+    { key = "H",                            action = "toggle_dotfiles" },
+    { key = "R",                            action = "refresh" },
+    { key = "a",                            action = "create" },
+    { key = "d",                            action = "remove" },
+    { key = "D",                            action = "trash"},
+    { key = "r",                            action = "rename" },
+    { key = "<C-r>",                        action = "full_rename" },
+    { key = "x",                            action = "cut" },
+    { key = "c",                            action = "copy"},
+    { key = "p",                            action = "paste" },
+    { key = "y",                            action = "copy_name" },
+    { key = "Y",                            action = "copy_path" },
+    { key = "gy",                           action = "copy_absolute_path" },
+    { key = "[c",                           action = "prev_git_item" },
+    { key = "]c",                           action = "next_git_item" },
+    { key = "-",                            action = "dir_up" },
+    { key = "s",                            action = "system_open" },
+    { key = "q",                            action = "close"},
+    { key = "g?",                           action = "toggle_help" }
   },
   custom_keypress_funcs = {},
 }
@@ -94,12 +94,13 @@ local function create_buffer()
   end
 
   for _, b in pairs(M.View.mappings) do
+    local mapping_rhs = b.cb or nvim_tree_callback(b.action)
     if type(b.key) == "table" then
       for _, key in pairs(b.key) do
-        a.nvim_buf_set_keymap(M.View.bufnr, b.mode or 'n', key, b.cb, { noremap = true, silent = true, nowait = true })
+        a.nvim_buf_set_keymap(M.View.bufnr, b.mode or 'n', key, mapping_rhs, { noremap = true, silent = true, nowait = true })
       end
-    elseif b.cb then
-      a.nvim_buf_set_keymap(M.View.bufnr, b.mode or 'n', b.key, b.cb, { noremap = true, silent = true, nowait = true })
+    elseif mapping_rhs then
+      a.nvim_buf_set_keymap(M.View.bufnr, b.mode or 'n', b.key, mapping_rhs, { noremap = true, silent = true, nowait = true })
     end
   end
 end
@@ -132,8 +133,8 @@ local function merge_mappings(user_mappings)
     else
        table.insert(user_keys, map.key)
     end
-    if map.custom_node_cb then
-      M.View.custom_keypress_funcs[map.custom_node_cb.name] = map.custom_node_cb.fn
+    if map.action and type(map.action_cb) == "function" then
+      M.View.custom_keypress_funcs[map.action] = map.action_cb
     end
   end
 

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -6,6 +6,13 @@ function M.nvim_tree_callback(callback_name)
   return string.format(":lua require'nvim-tree'.on_keypress('%s')<CR>", callback_name)
 end
 
+function M.nvim_tree_custom_node_callback(callback_name, callback_fn)
+  return {
+    name = callback_name,
+    fn = callback_fn,
+  }
+end
+
 M.View = {
   bufnr = nil,
   tabpages = {},
@@ -76,7 +83,8 @@ M.View = {
     { key = "s",                            cb = M.nvim_tree_callback("system_open") },
     { key = "q",                            cb = M.nvim_tree_callback("close") },
     { key = "g?",                           cb = M.nvim_tree_callback("toggle_help") }
-  }
+  },
+  custom_keypress_funcs = {},
 }
 
 local function wipe_rogue_buffer()
@@ -134,6 +142,9 @@ local function merge_mappings(user_mappings)
       end
     else
        table.insert(user_keys, map.key)
+    end
+    if map.custom_node_cb then
+      M.View.custom_keypress_funcs[map.custom_node_cb.name] = map.custom_node_cb.fn
     end
   end
 


### PR DESCRIPTION
This allows to define custom keybindings in configuration that receive the node as a parameter. Something like:
```lua
local tree_cb = require'nvim-tree.config'.nvim_tree_callback

local function print_node_path(node) {
  print(node.absolute_path)
}

require'nvim-tree'.setup {
  view = {
    mappings = {
      list = {
        { key = "s", cb = tree_cb("vsplit") }, -- deprecated
        { key = "t", action = "tabnew" },
        { key = "p", action = "print_path", action_cb = print_node_path },
      }
    }
  }
}

```

I use it to run a script in the node absolute path. Let me know if this could be useful for others and I will write down the docs.

Thank you so much for this awesome plugin!!!
