### PR TITLE
Show diagnostics on directories

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -85,6 +85,7 @@ function.
       update_cwd          = false,
       diagnostics         = {
         enable = false,
+        show_on_dirs = false,
         icons = {
           hint = "",
           info = "",
@@ -228,6 +229,11 @@ Here is a list of the options available in the setup call:
 - |diagnostics|: show lsp diagnostics in the signcolumn
 
   - |diagnostics.enable|: enable/disable the feature
+      type: `boolean`
+      default: `false`
+
+  - diagnostics.show_on_dirs: if the node with diagnostic is not visible,
+    then show diagnostic in the parent directory
       type: `boolean`
       default: `false`
 

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -431,6 +431,7 @@ local DEFAULT_OPTS = {
   },
   diagnostics = {
     enable = false,
+    show_on_dirs = false,
     icons = {
       hint = "",
       info = "",

--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -125,7 +125,11 @@ function M.update()
   for bufname, severity in pairs(buffer_severity) do
     if 0 < severity and severity < 5 then
       local node, line = utils.find_node(nodes, function(node)
-        return node.absolute_path == bufname
+        if M.show_on_dirs and not node.open then
+          return vim.startswith(bufname, node.absolute_path)
+        else
+          return node.absolute_path == bufname
+        end
       end)
       if node then add_sign(line, severity) end
     end
@@ -142,6 +146,7 @@ local links = {
 
 function M.setup(opts)
   M.enable = opts.diagnostics.enable
+  M.show_on_dirs = opts.diagnostics.show_on_dirs
   vim.fn.sign_define(sign_names[1][1], { text = opts.diagnostics.icons.error,   texthl = sign_names[1][2] })
   vim.fn.sign_define(sign_names[2][1], { text = opts.diagnostics.icons.warning, texthl = sign_names[2][2] })
   vim.fn.sign_define(sign_names[3][1], { text = opts.diagnostics.icons.info,    texthl = sign_names[3][2] })


### PR DESCRIPTION
This PR adds the ability to show diagnostics on a closed directory if it has child nodes with diagnostics.

The feature can be enabled/disabled via `diagnostics.show_on_dirs` option.

![img](https://i.imgur.com/w3SZeGX.png)
![img](https://i.imgur.com/39BkX1J.png)
![img](https://i.imgur.com/Ct6eouC.png)



