### PR TITLE
fix(view): check wins are floating

### DIFF
--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -355,8 +355,12 @@ function M.close()
       vim.cmd "new"
     end
   end
-  if #a.nvim_list_wins() > 1 then
-    a.nvim_win_hide(M.get_winnr())
+  local tree_win = M.get_winnr()
+  for _, win in pairs(a.nvim_list_wins()) do
+    if tree_win ~= win and a.nvim_win_get_config(win).relative == "" then
+      a.nvim_win_hide(tree_win)
+      return
+    end
   end
 end
 


### PR DESCRIPTION
Just adds a check to see if any of the other windows are not floating before closing nvim-tree.

Raised in nvim-notify in https://github.com/rcarriga/nvim-notify/issues/45 and also fixes the issue #859 