### PR TITLE
Add a mode that allows edit without the picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ These are the default bindings:
 -- default mappings
 local list = {
   { key = {"<CR>", "o", "<2-LeftMouse>"}, action = "edit" },
+  { key = {"O"},                          action = tree_cb("edit_no_picker") },
   { key = {"<2-RightMouse>", "<C-]>"},    action = "cd" },
   { key = "<C-v>",                        action = "vsplit" },
   { key = "<C-x>",                        action = "split" },

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -579,6 +579,7 @@ Defaults to:
   lua <<EOF
     local list = {
       { key = {"<CR>", "o", "<2-LeftMouse>"}, action = "edit" },
+      { key = {"O"},                          action = tree_cb("edit_no_picker") },
       { key = {"<2-RightMouse>", "<C-]>"},    action = "cd" },
       { key = "<C-v>",                        action = "vsplit" },
       { key = "<C-x>",                        action = "split" },
@@ -621,11 +622,11 @@ The `list` option in `view.mappings.list` is a table of
 >
   lua <<EOF
     local tree_cb = require'nvim-tree.config'.nvim_tree_callback
-    
+
     local function print_node_path(node) {
       print(node.absolute_path)
     }
-    
+
     local list = {
       { key = {"<CR>", "o" }, action = "edit", mode = "n"},
       { key = "p", action = "print_path", action_cb = print_node_path },

--- a/lua/nvim-tree/actions/init.lua
+++ b/lua/nvim-tree/actions/init.lua
@@ -8,6 +8,7 @@ local nvim_tree_callback = require'nvim-tree.config'.nvim_tree_callback
 local M = {
   mappings = {
     { key = {"<CR>", "o", "<2-LeftMouse>"}, action = "edit" },
+    { key = {"O"},                          action = nvim_tree_callback("edit_no_picker") },
     { key = {"<2-RightMouse>", "<C-]>"},    action = "cd" },
     { key = "<C-v>",                        action = "vsplit" },
     { key = "<C-x>",                        action = "split"},

--- a/lua/nvim-tree/actions/open-file.lua
+++ b/lua/nvim-tree/actions/open-file.lua
@@ -131,7 +131,7 @@ function M.fn(mode, filename)
   local win_ids = api.nvim_tabpage_list_wins(tabpage)
 
   local target_winid
-  if vim.g.nvim_tree_disable_window_picker == 1 then
+  if vim.g.nvim_tree_disable_window_picker == 1 or mode == "edit_no_picker" then
     target_winid = lib.Tree.target_winid
   else
     target_winid = pick_window()


### PR DESCRIPTION
I would like to open new files in the most left window by default, but
have the option to select a specific window when needed. Currently the
window picking logic is either enabled or disabled, but adding this mode
allows different keybindings for both situations.

This allows me to choose to either open it in the default windows with a
single keypress (which is often my default behavior), or to open it with
the picker asking me where I want it to be opened.

Curious what you think of this. Name of the mode or the default keybinding
can of course be changed to whatever you feel is a good name or binding,
but I would really like to be able to use this functionality. Thanks!