### PR TITLE
docs: Warn about dirbuf.nvim in `update_to_buf_dir` docs

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -172,7 +172,8 @@ Here is a list of the options available in the setup call:
 *nvim-tree.update_to_buf_dir*
 - |update_to_buf_dir|: hijacks new directory buffers when they are opened (`:e dir`).
 
-  - |update_to_buf_dir.enable|: enable the feature. Disable this option if you use vim-dirvish.
+  - |update_to_buf_dir.enable|: enable the feature. Disable this option if you
+    use vim-dirvish or dirbuf.nvim.
     type: `boolean`
     default: `true`
 


### PR DESCRIPTION
Hello! I'm the author of the file manager plugin [dirbuf.nvim](https://github.com/elihunter173/dirbuf.nvim).

It seems dirbuf is incompatible with nvim-tree's `update_to_buf_dir` option in the same way that `vim-dirvish` is, so I added a warning to the documentation about this alongside the warning about vim-dirvish. I'm also adding similar warnings to dirbuf's documentation

Related: https://github.com/elihunter173/dirbuf.nvim/issues/2