### PR TITLE
fix: parent_node offset when hide_root_folder is true

### DIFF
--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -370,6 +370,7 @@ function M.parent_node(node, should_close)
       parent.open = false
       altered_tree = true
     end
+    line = require'nvim-tree.view'.View.hide_root_folder and line - 1 or line
     view.set_cursor({line, 0})
   end
 


### PR DESCRIPTION
Hello, I stumbled upon issue similar to #843: when you have `hide_root_folder = true` and try to close an open node, cursor selects the node after the parent.
Ascii cinema:  [before](https://asciinema.org/a/Ky5j2nYUDh5W5COMIUSVlmB6U), [after](https://asciinema.org/a/ZTYpHqJFdkDUvfdpHUqVzHbmt)