### PR TITLE
fix: update diagnostic icon when a node is closed 

### DIFF
--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -375,6 +375,7 @@ function M.parent_node(node, should_close)
   end
 
   if altered_tree then
+    diagnostics.update()
     M.redraw()
   end
 end


### PR DESCRIPTION
[before](https://gyazo.com/f9119737f4bb2707d75798e75cc6f310), [after](https://gyazo.com/7e5753a86f637c02fe71db074b5cae79)