### PR TITLE
fix: bufnr is nil when incomplete setup

### DIFF
--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -106,6 +106,12 @@ function M.open()
   M.set_target_win()
 
   local cwd = vim.fn.getcwd()
+  if view.View.bufnr == nil then
+    vim.schedule(function ()
+      M.open()
+    end)
+    return
+  end
   local should_redraw = view.open()
 
   local respect_buf_cwd = vim.g.nvim_tree_respect_buf_cwd or 0


### PR DESCRIPTION
bufnr is nil when opening quickly:

```
Vim(lua):E5108: Error executing lua ...nvim-tree.lua/lua/nvim-tree/view.lua:225: Expected Lua number
  stack traceback:
          [C]: in function 'nvim_buf_is_valid'
          ...e/pack/packer/start/nvim-tree.lua/lua/nvim-tree/view.lua:225: in function 'is_buf_valid'
```

Reproduce:
1. Set keymap, eg: `map <leader>1 :NvimTreeOpen<cr>`
1. **Fast press**: `<leader>1` when nvim starting