### PR TITLE
Added a new option `auto_reload_on_write`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,16 @@ Note that options under the `g:` command should be set **BEFORE** running the se
 -- following options are the default
 -- each of these are documented in `:help nvim-tree.OPTION_NAME`
 require'nvim-tree'.setup {
-  disable_netrw       = true,
-  hijack_netrw        = true,
-  open_on_setup       = false,
-  ignore_ft_on_setup  = {},
-  auto_close          = false,
-  open_on_tab         = false,
-  hijack_cursor       = false,
-  update_cwd          = false,
-  update_to_buf_dir   = {
+  disable_netrw        = true,
+  hijack_netrw         = true,
+  open_on_setup        = false,
+  ignore_ft_on_setup   = {},
+  auto_close           = false,
+  auto_reload_on_write = true,
+  open_on_tab          = false,
+  hijack_cursor        = false,
+  update_cwd           = false,
+  update_to_buf_dir    = {
     enable = true,
     auto_open = true,
   },

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -71,19 +71,20 @@ function.
 
 >
     require'nvim-tree'.setup {
-      disable_netrw       = true,
-      hijack_netrw        = true,
-      open_on_setup       = false,
-      ignore_ft_on_setup  = {},
-      update_to_buf_dir   = {
+      disable_netrw        = true,
+      hijack_netrw         = true,
+      open_on_setup        = false,
+      ignore_ft_on_setup   = {},
+      update_to_buf_dir    = {
         enable = true,
         auto_open = true,
       },
-      auto_close          = false,
-      open_on_tab         = false,
-      hijack_cursor       = false,
-      update_cwd          = false,
-      diagnostics         = {
+      auto_close           = false,
+      auto_reload_on_write = true,
+      open_on_tab          = false,
+      hijack_cursor        = false,
+      update_cwd           = false,
+      diagnostics          = {
         enable = false,
         show_on_dirs = false,
         icons = {
@@ -170,6 +171,11 @@ Here is a list of the options available in the setup call:
 - |auto_close|: force closing neovim when the tree is the last window in the view.
   type: `boolean`
   default: `false`
+
+*nvim-tree.auto_reload_on_write*
+- |auto_reload_on_write|: reloads the explorer every time a buffer is written to
+  type: `boolean`
+  default: `true`
 
 *nvim-tree.open_on_tab*
 - |open_on_tab|: opens the tree automatically when switching tabpage or opening a new

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -282,7 +282,9 @@ local function setup_autocommands(opts)
 
   -- reset highlights when colorscheme is changed
   vim.cmd "au ColorScheme * lua require'nvim-tree'.reset_highlight()"
-  vim.cmd "au BufWritePost * lua require'nvim-tree.actions.reloaders'.reload_explorer()"
+  if opts.auto_reload_on_write then
+    vim.cmd "au BufWritePost * lua require'nvim-tree.actions.reloaders'.reload_explorer()"
+  end
   vim.cmd "au User FugitiveChanged,NeogitStatusRefreshed lua require'nvim-tree.actions.reloaders'.reload_git()"
 
   if opts.auto_close then
@@ -311,19 +313,20 @@ local function setup_autocommands(opts)
 end
 
 local DEFAULT_OPTS = {
-  disable_netrw       = true,
-  hijack_netrw        = true,
-  open_on_setup       = false,
-  open_on_tab         = false,
-  update_to_buf_dir   = {
+  disable_netrw        = true,
+  hijack_netrw         = true,
+  open_on_setup        = false,
+  open_on_tab          = false,
+  update_to_buf_dir    = {
     enable = true,
     auto_open = true,
   },
-  auto_close          = false,
-  hijack_cursor       = false,
-  update_cwd          = false,
-  hide_root_folder    = false,
-  update_focused_file = {
+  auto_close           = false,
+  auto_reload_on_write = true,
+  hijack_cursor        = false,
+  update_cwd           = false,
+  hide_root_folder     = false,
+  update_focused_file  = {
     enable = false,
     update_cwd = false,
     ignore_list = {}


### PR DESCRIPTION
I was finding that this plugin was causing a weird delay every time I saved a file, and traced it down to the `au BufWritePost` autocommand, which was reloading the explorer every time.  So I added support for a new option to disable this feature, for users like myself that prefer the extra performance when saving files.

I actually think the default should be to have this off, but since this would be a breaking change, I set the default as true.