### PR TITLE
Fixed some trailing slash bugs

### DIFF
--- a/lua/nvim-tree/actions/change-dir.lua
+++ b/lua/nvim-tree/actions/change-dir.lua
@@ -1,5 +1,6 @@
 local a = vim.api
 local lib = function() return require'nvim-tree.lib' end
+local utils = require'nvim-tree.utils'
 
 local M = {
   current_tab = a.nvim_get_current_tabpage(),
@@ -9,7 +10,7 @@ local M = {
 }
 
 function M.fn(name)
-  local foldername = name == '..' and vim.fn.fnamemodify(TreeExplorer.cwd, ':h') or name
+  local foldername = name == '..' and vim.fn.fnamemodify(utils.path_remove_trailing(TreeExplorer.cwd), ':h') or name
   local no_cwd_change = vim.fn.expand(foldername) == TreeExplorer.cwd
   local new_tab = a.nvim_get_current_tabpage()
   local is_window = vim.v.event.scope == "window" and new_tab == M.current_tab

--- a/lua/nvim-tree/actions/dir-up.lua
+++ b/lua/nvim-tree/actions/dir-up.lua
@@ -1,10 +1,12 @@
+local utils = require'nvim-tree.utils'
+
 local M = {}
 
 function M.fn(node)
   if not node or node.name == ".." then
     return require'nvim-tree.actions.change-dir'.fn('..')
   else
-    local newdir = vim.fn.fnamemodify(TreeExplorer.cwd, ':h')
+    local newdir = vim.fn.fnamemodify(utils.path_remove_trailing(TreeExplorer.cwd), ':h')
     require'nvim-tree.actions.change-dir'.fn(newdir)
     return require"nvim-tree.actions.find-file".fn(node.absolute_path)
   end

--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -29,7 +29,7 @@ end
 
 local path_separator = package.config:sub(1,1)
 function M.path_join(paths)
-  return table.concat(paths, path_separator)
+  return table.concat(vim.tbl_map(M.path_remove_trailing, paths), path_separator)
 end
 
 function M.path_split(path)


### PR DESCRIPTION
Without this fix, if `cwd` has a trailing slash, then user has to trigger `dir-up` action multiple times for it to work

Was also finding an issue with the `find-file` action, and the cause there was in the path_join method for a similar reason