### PR TITLE
refacto: buffer management, setup fixes, autocmd fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ require'nvim-tree'.setup {
   open_on_tab          = false,
   hijack_cursor        = false,
   update_cwd           = false,
-  update_to_buf_dir    = {
+  hijack_directories   = {
     enable = true,
     auto_open = true,
   },

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -23,7 +23,7 @@ COMMANDS                                           *nvim-tree-commands*
 
 |:NvimTreeOpen| 	                                  *:NvimTreeOpen*
 
-opens the tree
+opens the tree. Takes an optional path argument.
 
 |:NvimTreeClose| 	                          *:NvimTreeClose*
 
@@ -75,7 +75,7 @@ function.
       hijack_netrw         = true,
       open_on_setup        = false,
       ignore_ft_on_setup   = {},
-      update_to_buf_dir    = {
+      hijack_directories   = {
         enable = true,
         auto_open = true,
       },
@@ -183,16 +183,16 @@ Here is a list of the options available in the setup call:
   type: `boolean`
   default: `false`
 
-*nvim-tree.update_to_buf_dir*
-- |update_to_buf_dir|: hijacks new directory buffers when they are opened (`:e dir`).
+*nvim-tree.hijack_directories*
+- |hijack_directories|: hijacks new directory buffers when they are opened (`:e dir`).
 
-  - |update_to_buf_dir.enable|: enable the feature. Disable this option if you
+  - |hijack_directories.enable|: enable the feature. Disable this option if you
     use vim-dirvish or dirbuf.nvim. If |hijack_netrw| and |disable_netrw| are
     `false`, this feature will be disabled.
     type: `boolean`
     default: `true`
 
-  - |update_to_buf_dir.auto_open|: opens the tree if the tree was previously closed.
+  - |hijack_directories.auto_open|: opens the tree if the tree was previously closed.
     type: `boolean`
     default: `true`
 

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -6,7 +6,7 @@ local colors = require'nvim-tree.colors'
 local renderer = require'nvim-tree.renderer'
 local view = require'nvim-tree.view'
 local utils = require'nvim-tree.utils'
-local ChangeDir = require'nvim-tree.actions.change-dir'
+local change_dir = require'nvim-tree.actions.change-dir'
 
 local _config = {}
 
@@ -21,64 +21,26 @@ end
 M.on_keypress = require'nvim-tree.actions'.on_keypress
 
 function M.toggle(find_file)
-  if view.win_open() then
+  if view.is_visible() then
     view.close()
   else
-    if _config.update_focused_file.enable or find_file then
-      M.find_file(true)
-    end
     M.open()
+    if TreeExplorer and (_config.update_focused_file.enable or find_file) then
+      M.find_file(false)
+    end
   end
 end
 
-function M.open()
-  if not view.win_open() then
-    lib.open()
+function M.open(cwd)
+  cwd = cwd ~= "" and cwd or nil
+  if not view.is_visible() then
+    lib.open(cwd)
   end
-end
-
-local move_cmd = {
-  right = 'h',
-  left = 'l',
-  top = 'j',
-  bottom = 'k',
-}
-
-function M._prevent_buffer_override()
-  vim.schedule(function()
-    local curwin = api.nvim_get_current_win()
-    local curbuf = api.nvim_win_get_buf(curwin)
-
-    if curwin ~= view.get_winnr() or curbuf == view.View.bufnr then
-      return
-    end
-
-    if view.is_buf_valid(view.View.bufnr) then
-      -- pcall necessary to avoid erroring with `mark not set` although no mark are set
-      -- this avoid other issues
-      pcall(api.nvim_win_set_buf, view.get_winnr(), view.View.bufnr)
-    end
-
-    local bufname = api.nvim_buf_get_name(curbuf)
-    local isdir = vim.fn.isdirectory(bufname) == 1
-    if isdir or not bufname or bufname == "" then
-      return
-    end
-
-    if #vim.api.nvim_list_wins() < 2 then
-      local cmd = view.is_vertical() and "vsplit" or "split"
-      vim.cmd(cmd)
-    else
-      vim.cmd("wincmd "..move_cmd[view.View.side])
-    end
-    vim.cmd("buffer "..curbuf)
-    view.resize()
-  end)
 end
 
 function M.tab_change()
   vim.schedule(function()
-    if not view.win_open() and view.win_open({ any_tabpage = true }) then
+    if not view.is_visible() and view.is_visible({ any_tabpage = true }) then
       local bufname = vim.api.nvim_buf_get_name(0)
       if bufname:match("Neogit") ~= nil or bufname:match("--graph") ~= nil then
         return
@@ -88,45 +50,14 @@ function M.tab_change()
   end)
 end
 
-local function remove_empty_buffer()
-  if not view.win_open() or #api.nvim_list_wins() ~= 1 then
-    return
-  end
-
-  local bufs = vim.api.nvim_list_bufs()
-  for _, buf in ipairs(bufs) do
-    if api.nvim_buf_is_valid(buf) and api.nvim_buf_is_loaded(buf) then
-      local name = api.nvim_buf_get_name(buf)
-      if name == "" then
-        api.nvim_buf_delete(buf, {})
-      end
-    end
-  end
-end
-
-function M.hijack_current_window()
-  local View = require'nvim-tree.view'.View
-  if not View.bufnr then
-    View.bufnr = api.nvim_get_current_buf()
-  else
-    local bufs = api.nvim_list_bufs()
-    for _, buf in ipairs(bufs) do
-      local bufname = api.nvim_buf_get_name(buf)
-      local stat = luv.fs_stat(bufname)
-      if stat and stat.type == "directory" then
-        api.nvim_buf_delete(buf, { force = true })
-      end
-    end
-  end
-  local current_tab = api.nvim_get_current_tabpage()
-  if not View.tabpages then
-    View.tabpages = {
-      [current_tab] = { winnr = api.nvim_get_current_win() }
-    }
-  else
-    View.tabpages[current_tab] = { winnr = api.nvim_get_current_win() }
-  end
-  vim.defer_fn(remove_empty_buffer, 20)
+local function find_existing_windows()
+  return vim.tbl_filter(
+    function(win)
+      local buf = api.nvim_win_get_buf(win)
+      return api.nvim_buf_get_name(buf):match("NvimTree") ~= nil
+    end,
+    api.nvim_list_wins()
+  )
 end
 
 function M.on_enter(netrw_disabled)
@@ -151,13 +82,15 @@ function M.on_enter(netrw_disabled)
   local buf_is_empty = bufname == "" and not buf_has_content
   local should_be_preserved = vim.tbl_contains(ft_ignore, buftype)
   local should_open = _config.open_on_setup and not should_be_preserved and (buf_is_dir or buf_is_empty)
-  local should_hijack = _config.update_to_buf_dir.enable and _config.update_to_buf_dir.auto_open and is_dir and not should_be_preserved
+  local should_hijack = _config.hijack_directories.enable and _config.hijack_directories.auto_open and is_dir and not should_be_preserved
 
-  if should_hijack or should_open then
-    M.hijack_current_window()
+  -- Session that left a NvimTree Buffer opened, reopen with it
+  local existing_tree_wins = find_existing_windows()
+  if existing_tree_wins[1] then
+    api.nvim_set_current_win(existing_tree_wins[1])
   end
 
-  lib.init(should_open or should_hijack, cwd)
+  lib.init(should_open or should_hijack or existing_tree_wins[1] ~= nil, cwd)
 end
 
 local function is_file_readable(fname)
@@ -166,10 +99,6 @@ local function is_file_readable(fname)
 end
 
 local function update_base_dir_with_filepath(filepath, bufnr)
-  if not _config.update_focused_file.update_cwd then
-    return
-  end
-
   local ft = api.nvim_buf_get_option(bufnr, 'filetype') or ""
   for _, value in pairs(_config.update_focused_file.ignore_list) do
     if utils.str_find(filepath, value) or utils.str_find(ft, value) then
@@ -177,8 +106,8 @@ local function update_base_dir_with_filepath(filepath, bufnr)
     end
   end
 
-  if not vim.startswith(filepath, TreeExplorer.cwd or vim.loop.cwd()) then
-    ChangeDir.fn(vim.fn.fnamemodify(filepath, ':p:h'))
+  if not vim.startswith(filepath, TreeExplorer.cwd) then
+    change_dir.fn(vim.fn.fnamemodify(filepath, ':p:h'))
   end
 end
 
@@ -194,22 +123,19 @@ function M.find_file(with_open)
 
   if with_open then
     M.open()
-    view.focus()
   end
 
-  update_base_dir_with_filepath(filepath, bufnr)
+  if _config.update_focused_file.update_cwd then
+    update_base_dir_with_filepath(filepath, bufnr)
+  end
   require"nvim-tree.actions.find-file".fn(filepath)
 end
 
-function M.resize(size)
-  view.View.width = size
-  view.View.height = size
-  view.resize()
-end
+M.resize = view.resize
 
 function M.on_leave()
   vim.defer_fn(function()
-    if not view.win_open() then
+    if not view.is_visible() then
       return
     end
 
@@ -226,35 +152,24 @@ function M.on_leave()
   end, 50)
 end
 
--- TODO: rewrite this to take into account setup by open
 function M.open_on_directory()
-  local should_proceed = _config.update_to_buf_dir.auto_open or view.win_open()
-  if not _config.update_to_buf_dir.enable or not should_proceed then
+  local should_proceed = TreeExplorer and (_config.hijack_directories.auto_open or view.is_visible())
+  if not should_proceed then
     return
   end
+
   local buf = api.nvim_get_current_buf()
   local bufname = api.nvim_buf_get_name(buf)
   if vim.fn.isdirectory(bufname) ~= 1 then
     return
   end
 
-  view.close()
-  if bufname ~= TreeExplorer.cwd  then
-    ChangeDir.fn(bufname)
-  end
-
-  M.hijack_current_window()
-
-  view.open()
-  view.focus()
-  view.replace_window()
-
-  require"nvim-tree.actions.find-file".fn(bufname)
+  change_dir.force_dirchange(bufname, true)
 end
 
 function M.reset_highlight()
   colors.setup()
-  renderer.render_hl(view.View.bufnr)
+  renderer.render_hl(view.get_bufnr())
 end
 
 local prev_line
@@ -291,7 +206,7 @@ end
 
 local function setup_vim_commands()
   vim.cmd [[
-    command! NvimTreeOpen lua require'nvim-tree'.open()
+    command! -nargs=? -complete=dir NvimTreeOpen lua require'nvim-tree'.open("<args>")
     command! NvimTreeClose lua require'nvim-tree.view'.close()
     command! NvimTreeToggle lua require'nvim-tree'.toggle(false)
     command! NvimTreeFocus lua require'nvim-tree'.focus()
@@ -304,7 +219,7 @@ local function setup_vim_commands()
 end
 
 function M.change_dir(name)
-  ChangeDir.fn(name)
+  change_dir.fn(name)
 
   if _config.update_focused_file.enable then
     M.find_file(false)
@@ -337,11 +252,13 @@ local function setup_autocommands(opts)
     vim.cmd "au BufEnter * lua require'nvim-tree'.find_file(false)"
   end
 
-  vim.cmd "au BufUnload NvimTree lua require'nvim-tree.view'.View.tabpages = {}"
   if not opts.actions.open_file.quit_on_open then
-    vim.cmd "au BufWinEnter,BufWinLeave * lua require'nvim-tree'._prevent_buffer_override()"
+    vim.cmd "au BufWipeout NvimTree lua require'nvim-tree.view'._prevent_buffer_override()"
   end
-  vim.cmd "au BufEnter,BufNewFile * lua require'nvim-tree'.open_on_directory()"
+
+  if opts.hijack_directories.enable then
+    vim.cmd "au BufEnter,BufNewFile * lua require'nvim-tree'.open_on_directory()"
+  end
 
   vim.cmd "augroup end"
 end
@@ -351,7 +268,7 @@ local DEFAULT_OPTS = {
   hijack_netrw         = true,
   open_on_setup        = false,
   open_on_tab          = false,
-  update_to_buf_dir    = {
+  hijack_directories   = {
     enable = true,
     auto_open = true,
   },
@@ -400,30 +317,38 @@ local DEFAULT_OPTS = {
   }
 }
 
-function M.setup(conf)
-  local opts = vim.tbl_deep_extend('force', DEFAULT_OPTS, conf or {})
+local function merge_options(conf)
+  if conf and conf.update_to_buf_dir then
+    conf.hijack_directories = conf.update_to_buf_dir
+    conf.update_to_buf_dir = nil
+  end
+  return vim.tbl_deep_extend('force', DEFAULT_OPTS, conf or {})
+end
 
-  manage_netrw(opts.disable_netrw, opts.hijack_netrw)
+function M.setup(conf)
+  local opts = merge_options(conf)
   local netrw_disabled = opts.disable_netrw or opts.hijack_netrw
 
   _config.update_focused_file = opts.update_focused_file
   _config.open_on_setup = opts.open_on_setup
   _config.ignore_ft_on_setup = opts.ignore_ft_on_setup
-  _config.update_to_buf_dir = opts.update_to_buf_dir
-  _config.update_to_buf_dir.enable = _config.update_to_buf_dir.enable and netrw_disabled
+  _config.hijack_directories = opts.hijack_directories
+  _config.hijack_directories.enable = _config.hijack_directories.enable and netrw_disabled
+
+  manage_netrw(opts.disable_netrw, opts.hijack_netrw)
 
   require'nvim-tree.actions'.setup(opts)
+  require'nvim-tree.colors'.setup()
   require'nvim-tree.diagnostics'.setup(opts)
   require'nvim-tree.explorer'.setup(opts)
   require'nvim-tree.git'.setup(opts)
   require'nvim-tree.view'.setup(opts)
+
   setup_vim_commands()
+  setup_autocommands(opts)
 
   vim.schedule(function()
-    require'nvim-tree.colors'.setup()
-    require'nvim-tree.view'.create_buffer()
     M.on_enter(netrw_disabled)
-    setup_autocommands(opts)
   end)
 end
 

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -263,8 +263,6 @@ local function setup_autocommands(opts)
     vim.cmd "au BufEnter,BufNewFile * lua require'nvim-tree'.open_on_directory()"
   end
 
-  vim.cmd "au WinClosed,WinNew * lua vim.schedule(function() require'nvim-tree'.resize() end)"
-
   vim.cmd "augroup end"
 end
 

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -263,6 +263,8 @@ local function setup_autocommands(opts)
     vim.cmd "au BufEnter,BufNewFile * lua require'nvim-tree'.open_on_directory()"
   end
 
+  vim.cmd "au WinClosed,WinNew * lua vim.schedule(function() require'nvim-tree'.resize() end)"
+
   vim.cmd "augroup end"
 end
 

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -90,7 +90,10 @@ function M.on_enter(netrw_disabled)
     api.nvim_set_current_win(existing_tree_wins[1])
   end
 
-  lib.init(should_open or should_hijack or existing_tree_wins[1] ~= nil, cwd)
+  if should_open or should_hijack or existing_tree_wins[1] ~= nil then
+    lib.init(true, cwd)
+  end
+  M.initialized = true
 end
 
 local function is_file_readable(fname)
@@ -153,7 +156,7 @@ function M.on_leave()
 end
 
 function M.open_on_directory()
-  local should_proceed = TreeExplorer and (_config.hijack_directories.auto_open or view.is_visible())
+  local should_proceed = M.initialized and (_config.hijack_directories.auto_open or view.is_visible())
   if not should_proceed then
     return
   end

--- a/lua/nvim-tree/actions/change-dir.lua
+++ b/lua/nvim-tree/actions/change-dir.lua
@@ -1,5 +1,4 @@
 local a = vim.api
-local lib = function() return require'nvim-tree.lib' end
 local utils = require'nvim-tree.utils'
 
 local M = {
@@ -9,7 +8,7 @@ local M = {
   }
 }
 
-function M.fn(name)
+function M.fn(name, with_open)
   if not TreeExplorer then return end
 
   local foldername = name == '..' and vim.fn.fnamemodify(utils.path_remove_trailing(TreeExplorer.cwd), ':h') or name
@@ -20,13 +19,18 @@ function M.fn(name)
     return
   end
   M.current_tab = new_tab
+  M.force_dirchange(foldername, with_open)
+end
 
-  if M.options.global then
-    vim.cmd('cd '..vim.fn.fnameescape(foldername))
-  else
-    vim.cmd('lcd '..vim.fn.fnameescape(foldername))
+function M.force_dirchange(foldername, with_open)
+  if vim.tbl_isempty(vim.v.event) then
+    if M.options.global then
+      vim.cmd('cd '..vim.fn.fnameescape(foldername))
+    else
+      vim.cmd('lcd '..vim.fn.fnameescape(foldername))
+    end
   end
-  lib().init(false, foldername)
+  require'nvim-tree.lib'.init(with_open, foldername)
 end
 
 function M.setup(options)

--- a/lua/nvim-tree/actions/find-file.lua
+++ b/lua/nvim-tree/actions/find-file.lua
@@ -56,7 +56,7 @@ function M.fn(fname)
   if tree_altered then
     renderer.draw()
   end
-  if index and view.win_open() then
+  if index and view.is_visible() then
     view.set_cursor({index, 0})
   end
 end

--- a/lua/nvim-tree/actions/init.lua
+++ b/lua/nvim-tree/actions/init.lua
@@ -156,6 +156,7 @@ function M.setup(opts)
   require'nvim-tree.actions.system-open'.setup(opts.system_open)
   require'nvim-tree.actions.trash'.setup(opts.trash)
   require'nvim-tree.actions.open-file'.setup(opts)
+  require'nvim-tree.actions.change-dir'.setup(opts)
 
   local user_map_config = (opts.view or {}).mappings or {}
   local options = vim.tbl_deep_extend('force', DEFAULT_MAPPING_CONFIG, user_map_config)

--- a/lua/nvim-tree/actions/reloaders.lua
+++ b/lua/nvim-tree/actions/reloaders.lua
@@ -41,7 +41,7 @@ function M.reload_explorer(callback)
 
   git.reload(function(projects)
     refresh_nodes(TreeExplorer, projects)
-    if view.win_open() then
+    if view.is_visible() then
       renderer.draw()
       if callback and type(callback) == 'function' then
         callback()

--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -25,7 +25,7 @@ local sign_names = {
 local signs = {}
 
 local function add_sign(linenr, severity)
-  local buf = view.View.bufnr
+  local buf = view.get_bufnr()
   if not a.nvim_buf_is_valid(buf) or not a.nvim_buf_is_loaded(buf) then return end
   local sign_name = sign_names[severity][1]
   table.insert(signs, vim.fn.sign_place(1, 'NvimTreeDiagnosticSigns', sign_name, buf, { lnum = linenr+1 }))
@@ -114,7 +114,7 @@ function M.update()
   if #signs then
     vim.fn.sign_unplacelist(vim.tbl_map(function(sign)
       return {
-        buffer = view.View.bufnr,
+        buffer = view.get_bufnr(),
         group = "NvimTreeDiagnosticSigns",
         id = sign
       }

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -120,7 +120,11 @@ end
 function M.open(cwd)
   M.set_target_win()
   if not TreeExplorer or cwd then
-    M.init(true, cwd or vim.loop.cwd())
+    M.init(false, cwd or vim.loop.cwd())
+  end
+  if api.nvim_buf_get_name(api.nvim_get_current_buf()) == "" then
+    view.open_in_current_win()
+    renderer.draw()
   else
     open_view_and_draw()
   end

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -17,10 +17,10 @@ TreeExplorer = nil
 function M.init(with_open, foldername)
   TreeExplorer = explorer.Explorer.new(foldername)
   TreeExplorer:init(function()
-    renderer.draw()
     if with_open then
-      M.open()
+      view.open_in_current_win()
     end
+    renderer.draw()
 
     if not first_init_done then
       events._dispatch_ready()
@@ -103,24 +103,26 @@ function M.set_target_win()
   M.target_winid = id
 end
 
-function M.open()
-  M.set_target_win()
-
-  local cwd = vim.fn.getcwd()
-  if view.View.bufnr == nil then
-    vim.schedule(function ()
-      M.open()
-    end)
-    return
-  end
-  local should_redraw = view.open()
-
+local function handle_buf_cwd(cwd)
   local respect_buf_cwd = vim.g.nvim_tree_respect_buf_cwd or 0
   if respect_buf_cwd == 1 and cwd ~= TreeExplorer.cwd then
     require'nvim-tree.actions.change-dir'.fn(cwd)
   end
-  if should_redraw then
-    renderer.draw()
+end
+
+local function open_view_and_draw()
+  local cwd = vim.fn.getcwd()
+  view.open()
+  handle_buf_cwd(cwd)
+  renderer.draw()
+end
+
+function M.open(cwd)
+  M.set_target_win()
+  if not TreeExplorer or cwd then
+    M.init(true, cwd or vim.loop.cwd())
+  else
+    open_view_and_draw()
   end
 end
 

--- a/lua/nvim-tree/renderer/init.lua
+++ b/lua/nvim-tree/renderer/init.lua
@@ -371,11 +371,12 @@ end
 local M = {}
 
 function M.draw()
-  if not TreeExplorer or not view.View.bufnr or not api.nvim_buf_is_loaded(view.View.bufnr) then
+  local bufnr = view.get_bufnr()
+  if not TreeExplorer or not bufnr or not api.nvim_buf_is_loaded(bufnr) then
     return
   end
   local cursor
-  if view.win_open() then
+  if view.is_visible() then
     cursor = api.nvim_win_get_cursor(view.get_winnr())
   end
   index = 0
@@ -393,10 +394,10 @@ function M.draw()
   if view.is_help_ui() then
     lines, hl = _help.compute_lines()
   end
-  api.nvim_buf_set_option(view.View.bufnr, 'modifiable', true)
-  api.nvim_buf_set_lines(view.View.bufnr, 0, -1, false, lines)
-  M.render_hl(view.View.bufnr)
-  api.nvim_buf_set_option(view.View.bufnr, 'modifiable', false)
+  api.nvim_buf_set_option(bufnr, 'modifiable', true)
+  api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+  M.render_hl(bufnr)
+  api.nvim_buf_set_option(bufnr, 'modifiable', false)
 
   if cursor and #lines >= cursor[1] then
     api.nvim_win_set_cursor(view.get_winnr(), cursor)

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -10,6 +10,8 @@ M.View = {
     number = false,
     list = false,
     foldenable = false,
+    winfixwidth = true,
+    winfixheight = true,
     spell = false,
     signcolumn = 'yes',
     foldmethod = 'manual',
@@ -292,6 +294,10 @@ function M._prevent_buffer_override()
       return
     end
 
+    -- patch to avoid the overriding window to be fixed in size
+    -- might need a better patch
+    vim.cmd "setlocal nowinfixwidth"
+    vim.cmd "setlocal nowinfixheight"
     M.open({ focus_tree = false })
     require"nvim-tree.renderer".draw()
     require"nvim-tree".find_file(false)

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -103,7 +103,6 @@ local function open_window()
   local winnr = a.nvim_get_current_win()
   local tabpage = a.nvim_get_current_tabpage()
   M.View.tabpages[tabpage] = vim.tbl_extend("force", M.View.tabpages[tabpage] or {help = false}, {winnr = winnr})
-  vim.cmd ":wincmd ="
 end
 
 local function set_window_options_and_buffer()
@@ -180,6 +179,7 @@ function M.resize(size)
   else
     a.nvim_win_set_height(M.get_winnr(), get_size())
   end
+  vim.cmd ":wincmd ="
 end
 
 function M.reposition_window()

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -9,8 +9,6 @@ M.View = {
     relativenumber = false,
     number = false,
     list = false,
-    winfixwidth = true,
-    winfixheight = true,
     foldenable = false,
     spell = false,
     signcolumn = 'yes',
@@ -296,6 +294,7 @@ function M._prevent_buffer_override()
 
     M.open({ focus_tree = false })
     require"nvim-tree.renderer".draw()
+    require"nvim-tree".find_file(false)
   end)
 end
 

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -169,7 +169,7 @@ function M.resize(size)
     M.View.height = size
   end
 
-  if not a.nvim_win_is_valid(M.get_winnr()) then
+  if not M.is_visible() then
     return
   end
 

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -3,8 +3,6 @@ local a = vim.api
 local M = {}
 
 M.View = {
-  last_focused_winnr = nil,
-  bufnr = nil,
   tabpages = {},
   hide_root_folder = false,
   winopts = {
@@ -33,93 +31,37 @@ M.View = {
       'NormalNC:NvimTreeNormalNC',
     }, ',')
   },
-  bufopts = {
-    { name = 'swapfile', val = false },
-    { name = 'buftype', val = 'nofile' },
-    { name = 'modifiable', val = false },
-    { name = 'filetype', val = 'NvimTree' },
-    { name = 'bufhidden', val = 'hide' }
-  },
+}
+
+local BUFNR = nil
+local LAST_FOCUSED_WIN = nil
+local BUFFER_OPTIONS = {
+  swapfile = false,
+  buftype = 'nofile',
+  modifiable = false,
+  filetype = 'NvimTree',
+  bufhidden = 'wipe',
+  buflisted = false,
 }
 
 local function wipe_rogue_buffer()
-  for _, bn in ipairs(a.nvim_list_bufs()) do
-    if vim.fn.bufname(bn) == "NvimTree" then
-      return pcall(a.nvim_buf_delete, bn, { force = true })
+  for _, bufnr in ipairs(a.nvim_list_bufs()) do
+    if bufnr ~= BUFNR and a.nvim_buf_get_name(bufnr):match("NvimTree") ~= nil then
+      return pcall(a.nvim_buf_delete, bufnr, { force = true })
     end
   end
 end
 
--- FIXME: setting options to buffer clears the startup screen
-function M.create_buffer()
+local function create_buffer(bufnr)
+  BUFNR = bufnr or a.nvim_create_buf(false, false)
   wipe_rogue_buffer()
-  M.View.bufnr = a.nvim_create_buf(false, false)
-  a.nvim_buf_set_name(M.View.bufnr, 'NvimTree')
+  a.nvim_buf_set_name(BUFNR, 'NvimTree')
 
-  for _, opt in ipairs(M.View.bufopts) do
-    vim.bo[M.View.bufnr][opt.name] = opt.val
+  for option, value in pairs(BUFFER_OPTIONS) do
+    vim.bo[BUFNR][option] = value
   end
 
-  require'nvim-tree.actions'.apply_mappings(M.View.bufnr)
-end
-
-local DEFAULT_CONFIG = {
-  width = 30,
-  height = 30,
-  side = 'left',
-  auto_resize = false,
-  number = false,
-  relativenumber = false,
-  signcolumn = 'yes'
-}
-
-function M.setup(opts)
-  local options = vim.tbl_deep_extend('force', DEFAULT_CONFIG, opts.view or {})
-  M.View.side = options.side
-  M.View.width = options.width
-  M.View.height = options.height
-  M.View.hide_root_folder = options.hide_root_folder
-  M.View.auto_resize = options.auto_resize
-  M.View.winopts.number = options.number
-  M.View.winopts.relativenumber = options.relativenumber
-  M.View.winopts.signcolumn = options.signcolumn
-end
-
-function M.win_open(opts)
-  if opts and opts.any_tabpage then
-    for _, v in pairs(M.View.tabpages) do
-      if a.nvim_win_is_valid(v.winnr) then
-        return true
-      end
-    end
-    return false
-  else
-    return M.get_winnr() ~= nil and a.nvim_win_is_valid(M.get_winnr())
-  end
-end
-
-function M.set_cursor(opts)
-  if M.win_open() then
-    pcall(a.nvim_win_set_cursor, M.get_winnr(), opts)
-  end
-end
-
-function M.focus(winnr, open_if_closed)
-  local wnr = winnr or M.get_winnr()
-
-  if a.nvim_win_get_tabpage(wnr) ~= a.nvim_win_get_tabpage(0) then
-    M.close()
-    M.open()
-    wnr = M.get_winnr()
-  elseif open_if_closed and not M.win_open() then
-    M.open()
-  end
-
-  a.nvim_set_current_win(wnr)
-end
-
-function M.is_vertical()
-  return M.View.side == 'left' or M.View.side == 'right'
+  require'nvim-tree.actions'.apply_mappings(BUFNR)
 end
 
 local function get_size()
@@ -133,18 +75,6 @@ local function get_size()
   local size_as_number = tonumber(size:sub(0, -2))
   local percent_as_decimal = size_as_number / 100
   return math.floor(vim.o.columns * percent_as_decimal)
-end
-
-function M.resize()
-  if not M.View.auto_resize or not a.nvim_win_is_valid(M.get_winnr()) then
-    return
-  end
-
-  if M.is_vertical() then
-    a.nvim_win_set_width(M.get_winnr(), get_size())
-  else
-    a.nvim_win_set_height(M.get_winnr(), get_size())
-  end
 end
 
 local move_tbl = {
@@ -167,48 +97,20 @@ local function set_local(opt, value)
   vim.cmd(cmd)
 end
 
-function M.replace_window()
-  local move_to = move_tbl[M.View.side]
-  a.nvim_command("wincmd "..move_to)
-  local resize_direction = M.is_vertical() and 'vertical ' or ''
-  a.nvim_command(resize_direction.."resize "..get_size())
-end
-
 local function open_window()
   a.nvim_command("vsp")
   M.replace_window()
   local winnr = a.nvim_get_current_win()
   local tabpage = a.nvim_get_current_tabpage()
   M.View.tabpages[tabpage] = vim.tbl_extend("force", M.View.tabpages[tabpage] or {help = false}, {winnr = winnr})
+  vim.cmd ":wincmd ="
 end
 
-function M.is_buf_valid(bufnr)
-  return bufnr and a.nvim_buf_is_valid(bufnr) and a.nvim_buf_is_loaded(bufnr)
-end
-
-function M.open(options)
-  M.View.last_focused_winnr = a.nvim_get_current_win()
-  local should_redraw = false
-  if not M.is_buf_valid(M.View.bufnr) then
-    should_redraw = true
-    M.create_buffer()
-  end
-
-  if not M.win_open() then
-    open_window()
-  end
-
-  pcall(vim.cmd, "buffer "..M.View.bufnr)
+local function set_window_options_and_buffer()
+  pcall(vim.cmd, "buffer "..BUFNR)
   for k, v in pairs(M.View.winopts) do
     set_local(k, v)
   end
-  vim.cmd ":wincmd ="
-
-	local opts = options or { focus_tree = true }
-	if not opts.focus_tree then
-		vim.cmd("wincmd p")
-	end
-  return should_redraw
 end
 
 local function get_existing_buffers()
@@ -220,27 +122,121 @@ local function get_existing_buffers()
   )
 end
 
-function M.close()
-  if not M.win_open() then return end
+local function switch_buf_if_last_buf()
   if #a.nvim_list_wins() == 1 then
-    local existing_bufs = get_existing_buffers()
-    if #existing_bufs > 0 then
+    if #get_existing_buffers() > 0 then
       vim.cmd "sbnext"
     else
       vim.cmd "new"
     end
   end
+end
+
+function M.close()
+  if not M.is_visible() then return end
+  switch_buf_if_last_buf()
   local tree_win = M.get_winnr()
   local current_win = a.nvim_get_current_win()
   for _, win in pairs(a.nvim_list_wins()) do
     if tree_win ~= win and a.nvim_win_get_config(win).relative == "" then
-      a.nvim_win_hide(tree_win)
-      if tree_win == current_win and M.View.last_focused_winnr then
-        a.nvim_set_current_win(M.View.last_focused_winnr)
+      a.nvim_win_close(tree_win, true)
+      if tree_win == current_win and LAST_FOCUSED_WIN then
+        a.nvim_set_current_win(LAST_FOCUSED_WIN)
       end
       return
     end
   end
+end
+
+function M.open(options)
+  if M.is_visible() then
+    return
+  end
+
+  LAST_FOCUSED_WIN = a.nvim_get_current_win()
+  create_buffer()
+  open_window()
+  set_window_options_and_buffer()
+  M.resize()
+
+	local opts = options or { focus_tree = true }
+	if not opts.focus_tree then
+		vim.cmd("wincmd p")
+	end
+end
+
+function M.resize(size)
+  if size then
+    M.View.width = size
+    M.View.height = size
+  end
+
+  if not a.nvim_win_is_valid(M.get_winnr()) then
+    return
+  end
+
+  if M.is_vertical() then
+    a.nvim_win_set_width(M.get_winnr(), get_size())
+  else
+    a.nvim_win_set_height(M.get_winnr(), get_size())
+  end
+end
+
+function M.replace_window()
+  local move_to = move_tbl[M.View.side]
+  a.nvim_command("wincmd "..move_to)
+  local resize_direction = M.is_vertical() and 'vertical ' or ''
+  a.nvim_command(resize_direction.."resize "..get_size())
+end
+
+local function set_current_win()
+  local current_tab = a.nvim_get_current_tabpage()
+  M.View.tabpages[current_tab] = { winnr = a.nvim_get_current_win() }
+end
+
+function M.open_in_current_win()
+  create_buffer(a.nvim_get_current_buf())
+  set_current_win()
+  set_window_options_and_buffer()
+  M.replace_window()
+  M.resize()
+end
+
+function M.is_visible(opts)
+  if opts and opts.any_tabpage then
+    for _, v in pairs(M.View.tabpages) do
+      if a.nvim_win_is_valid(v.winnr) then
+        return true
+      end
+    end
+    return false
+  end
+
+  return M.get_winnr() ~= nil and a.nvim_win_is_valid(M.get_winnr())
+end
+
+function M.set_cursor(opts)
+  if M.is_visible() then
+    pcall(a.nvim_win_set_cursor, M.get_winnr(), opts)
+  end
+end
+
+function M.focus(winnr, open_if_closed)
+  local wnr = winnr or M.get_winnr()
+
+  if a.nvim_win_get_tabpage(wnr) ~= a.nvim_win_get_tabpage(0) then
+    M.close()
+    M.open()
+    wnr = M.get_winnr()
+  elseif open_if_closed and not M.is_visible() then
+    M.open()
+  end
+
+  a.nvim_set_current_win(wnr)
+end
+
+function M.is_vertical()
+  return M.View.side == 'left' or M.View.side == 'right'
 end
 
 --- Returns the window number for nvim-tree within the tabpage specified
@@ -252,6 +248,12 @@ function M.get_winnr(tabpage)
   if tabinfo ~= nil then
     return tabinfo.winnr
   end
+end
+
+--- Returns the current nvim tree bufnr
+---@return number
+function M.get_bufnr()
+  return BUFNR
 end
 
 --- Checks if nvim-tree is displaying the help ui within the tabpage specified
@@ -268,6 +270,57 @@ end
 function M.toggle_help(tabpage)
   tabpage = tabpage or a.nvim_get_current_tabpage()
   M.View.tabpages[tabpage].help = not M.View.tabpages[tabpage].help
+end
+
+function M.is_buf_valid(bufnr)
+  return bufnr and a.nvim_buf_is_valid(bufnr) and a.nvim_buf_is_loaded(bufnr)
+end
+
+function M._prevent_buffer_override()
+  local view_winnr = M.get_winnr()
+  local view_bufnr = M.get_bufnr()
+
+  -- need to schedule to let the new buffer populate the window
+  -- because this event needs to be run on bufWipeout.
+  -- Otherwise the curwin/curbuf would match the view buffer and the view window.
+  vim.schedule(function()
+    local curwin = a.nvim_get_current_win()
+    local curbuf = a.nvim_win_get_buf(curwin)
+    local bufname = a.nvim_buf_get_name(curbuf)
+    if not bufname:match("NvimTree") then
+      M.View.tabpages = {}
+    end
+    if curwin ~= view_winnr or bufname == "" or curbuf == view_bufnr then
+      return
+    end
+
+    M.open({ focus_tree = false })
+    require"nvim-tree.renderer".draw()
+  end)
+end
+
+
+
+local DEFAULT_CONFIG = {
+  width = 30,
+  height = 30,
+  side = 'left',
+  auto_resize = false,
+  number = false,
+  relativenumber = false,
+  signcolumn = 'yes'
+}
+
+function M.setup(opts)
+  local options = vim.tbl_deep_extend('force', DEFAULT_CONFIG, opts.view or {})
+  M.View.side = options.side
+  M.View.width = options.width
+  M.View.height = options.height
+  M.View.hide_root_folder = options.hide_root_folder
+  M.View.auto_resize = options.auto_resize
+  M.View.winopts.number = options.number
+  M.View.winopts.relativenumber = options.relativenumber
+  M.View.winopts.signcolumn = options.signcolumn
 end
 
 return M

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -99,7 +99,7 @@ end
 
 local function open_window()
   a.nvim_command("vsp")
-  M.replace_window()
+  M.reposition_window()
   local winnr = a.nvim_get_current_win()
   local tabpage = a.nvim_get_current_tabpage()
   M.View.tabpages[tabpage] = vim.tbl_extend("force", M.View.tabpages[tabpage] or {help = false}, {winnr = winnr})
@@ -182,7 +182,7 @@ function M.resize(size)
   end
 end
 
-function M.replace_window()
+function M.reposition_window()
   local move_to = move_tbl[M.View.side]
   a.nvim_command("wincmd "..move_to)
   local resize_direction = M.is_vertical() and 'vertical ' or ''
@@ -198,7 +198,7 @@ function M.open_in_current_win()
   create_buffer(a.nvim_get_current_buf())
   set_current_win()
   set_window_options_and_buffer()
-  M.replace_window()
+  M.reposition_window()
   M.resize()
 end
 


### PR DESCRIPTION
Buffer management rewritten to be completely wiped out when closing the view. 
Buffer is properly intanciated when needed.
Started to make a proper api for the view, to avoid mutating the internals from the outside (and thus leaking abstractions to the callers).

The autocmds have been a bit cleaned up, less indirections.
Renamed `update_to_buf_dir` to `hijack_directories` wich makes more sense.
Sessions with a tree buffer will open with the tree (without the state saved).
Also added ability to open with a path like `:NvimTreeOpen /some/dir`.
Renamed `view.win_open` to `view.is_visible` (BREAKING).
Doesn't load the directory on setup when not needed, which should improve startuptime.

Fixes #601
Fixes #488 
Fixes #965 
Fixes #238 (possible to setup `open_on_setup` to `false` and `hijack_directories` with auto open and enable to `true` will do this behavior)
Fixes #502 
Fixes #193 
Fixes #592 

And maybe even more issues could be closed.
Please people tagged in these issue, try this PR and confirm it works well.
