### PR TITLE
fix: use fs_realpath to normalize path

### DIFF
--- a/lua/nvim-tree/explorer/init.lua
+++ b/lua/nvim-tree/explorer/init.lua
@@ -13,7 +13,7 @@ local Explorer = {}
 Explorer.__index = Explorer
 
 function Explorer.new(cwd)
-  cwd = utils.path_normalize(cwd or uv.cwd())
+  cwd = uv.fs_realpath(cwd or uv.cwd())
   return setmetatable({
     cwd = cwd,
     nodes = {}

--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -208,24 +208,4 @@ function M.file_exists(path)
   return error == nil
 end
 
---- @param num number elements to take
---- @param list table elements
---- @return table
-function M.take(num, list)
-  local t = {}
-  for i, c in ipairs(list) do
-    if i > num then break end
-    table.insert(t, c)
-  end
-  return t
-end
-
---- @param path string
---- @return string
-function M.path_normalize(path)
-  local components = vim.split(vim.fn.expand(path), path_separator)
-  local num_dots = #vim.tbl_filter(function(v) return v == ".." end, components)
-  return M.path_join(M.take(#components - num_dots * 2, components))
-end
-
 return M


### PR DESCRIPTION
I notice that `path_normalize` here is to change path like `/home/young/foo/..` to `/home/young`.

But it may not handle paths like `/home/young/../xavier` correctly.

 https://github.com/kyazdani42/nvim-tree.lua/blob/3f4ed9b6c2598ab8304186486a05ae7a328b8d49/lua/nvim-tree/utils.lua#L225-L229