### PR TITLE
#998 allow users to unmap keys, remove user keys from default multi key maps

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -641,7 +641,7 @@ Defaults to:
 The `list` option in `view.mappings.list` is a table of
 
 - key can be either a string or a table of string (lhs)
-- action is the name of the action
+- action is the name of the action, set to nil to unmap default actions
 - action_cb is the function that will be called, it receives the node as a parameter. Optional for default actions
 - mode is normal by default
 >
@@ -656,6 +656,7 @@ The `list` option in `view.mappings.list` is a table of
       { key = {"<CR>", "o" }, action = "edit", mode = "n"},
       { key = "p", action = "print_path", action_cb = print_node_path },
       { key = "s", cb = tree_cb("vsplit") }, --tree_cb and the cb property are deprecated
+      { key = "<2-RightMouse>", action = nil },
     }
 
 

--- a/lua/nvim-tree/actions/init.lua
+++ b/lua/nvim-tree/actions/init.lua
@@ -127,24 +127,46 @@ local function merge_mappings(user_mappings)
   end
 
   local user_keys = {}
+  local removed_keys = {}
   for _, map in pairs(user_mappings) do
     if type(map.key) == "table" then
       for _, key in pairs(map.key) do
         table.insert(user_keys, key)
+        if not map.action then
+          table.insert(removed_keys, key)
+        end
       end
     else
-       table.insert(user_keys, map.key)
+      table.insert(user_keys, map.key)
+      if not map.action then
+        table.insert(removed_keys, map.key)
+      end
     end
     if map.action and type(map.action_cb) == "function" then
       M.custom_keypress_funcs[map.action] = map.action_cb
     end
   end
 
-  local mappings = vim.tbl_filter(function(map)
-    return not vim.tbl_contains(user_keys, map.key)
+  local default_map = vim.tbl_filter(function(map)
+    if type(map.key) == "table" then
+      local filtered_keys = {}
+      for _, key in pairs(map.key) do
+        if not vim.tbl_contains(user_keys, key) and not vim.tbl_contains(removed_keys, key) then
+          table.insert(filtered_keys, key)
+        end
+      end
+      map.key = filtered_keys
+      return not vim.tbl_isempty(map.key)
+    else
+      return not vim.tbl_contains(user_keys, map.key) and not vim.tbl_contains(removed_keys, map.key)
+    end
   end, M.mappings)
 
-  return vim.fn.extend(mappings, user_mappings)
+  local user_map = vim.tbl_filter(function(map)
+    return map.action
+  end, user_mappings)
+
+  return vim.fn.extend(default_map, user_map)
 end
 
 local DEFAULT_MAPPING_CONFIG = {


### PR DESCRIPTION
Resolves #998 

The method of unmapping is to set action to nil.

An alternative might be to add a `view.mappings.clear` however this seems simpler.

Also resolves a bug in which custom mappings for "multi key mappings" such a `{ key = {"<CR>", "o", "<2-LeftMouse>"}, action = "edit" },` would result in the key being shown twice in the help: once with the default mapping and once with the user.