### PR TITLE
fix: use "" as flag to remove default mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ require'nvim-tree'.setup {
 The `list` option in `view.mappings.list` is a table of
 ```lua
 -- key can be either a string or a table of string (lhs)
--- action is the name of the action
+-- action is the name of the action, set to `""` to remove default action
 -- action_cb is the function that will be called, it receives the node as a parameter. Optional for default actions
 -- mode is normal by default
 
@@ -242,6 +242,7 @@ local list = {
   { key = {"<CR>", "o" }, action = "edit", mode = "n"},
   { key = "p", action = "print_path", action_cb = print_node_path },
   { key = "s", cb = tree_cb("vsplit") }, --tree_cb and the cb property are deprecated
+  { key = "<2-RightMouse>", action = "" }, -- will remove default cd action
 }
 ```
 

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -641,7 +641,7 @@ Defaults to:
 The `list` option in `view.mappings.list` is a table of
 
 - key can be either a string or a table of string (lhs)
-- action is the name of the action, set to nil to unmap default actions
+- action is the name of the action, set to `""` to remove default action
 - action_cb is the function that will be called, it receives the node as a parameter. Optional for default actions
 - mode is normal by default
 >
@@ -656,7 +656,7 @@ The `list` option in `view.mappings.list` is a table of
       { key = {"<CR>", "o" }, action = "edit", mode = "n"},
       { key = "p", action = "print_path", action_cb = print_node_path },
       { key = "s", cb = tree_cb("vsplit") }, --tree_cb and the cb property are deprecated
-      { key = "<2-RightMouse>", action = nil },
+      { key = "<2-RightMouse>", action = "" }, -- will remove default cd action
     }
 
 


### PR DESCRIPTION
Before, It will remove all user mappings which only have `key` and `cb`.  such as
```lua
mappings = {
      custom_only = false,
      list = {
        { key = 'h', cb = tree_cb 'close_node' },
        { key = { '<CR>', 'o', '<2-LeftMouse>', 'l' }, cb = tree_cb 'edit' },
        { key = 's', cb = tree_cb 'vsplit' },
        { key = 'i', cb = tree_cb 'split' },
      },
}
```

