### PR TITLE
fix(doc): nvim_tree_create_in_closed_folder default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ let g:nvim_tree_disable_window_picker = 1 "0 by default, will disable the window
 let g:nvim_tree_icon_padding = ' ' "one space by default, used for rendering the space between the icon and the filename. Use with caution, it could break rendering if you set an empty string depending on your font.
 let g:nvim_tree_symlink_arrow = ' >> ' " defaults to ' ➛ '. used as a separator between symlinks' source and target.
 let g:nvim_tree_respect_buf_cwd = 1 "0 by default, will change cwd of nvim-tree to that of new buffer's when opening nvim-tree.
-let g:nvim_tree_create_in_closed_folder = 0 "1 by default, When creating files, sets the path of a file when cursor is on a closed folder to the parent folder when 0, and inside the folder when 1.
+let g:nvim_tree_create_in_closed_folder = 1 "0 by default, When creating files, sets the path of a file when cursor is on a closed folder to the parent folder when 0, and inside the folder when 1.
 let g:nvim_tree_window_picker_exclude = {
     \   'filetype': [
     \     'notify',

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -553,7 +553,7 @@ Will change cwd of nvim-tree to that of new buffer's when opening nvim-tree.
 
 |g:nvim_tree_create_in_closed_folder|     *g:nvim_tree_create_in_closed_folder*
 
-Can be 0 or 1. 1 by default.
+Can be 0 or 1. 0 by default.
 Creating a file when the cursor is on a closed folder will set the
 path to be inside the closed folder when 1, and on the parent folder when 0.
 


### PR DESCRIPTION
https://github.com/kyazdani42/nvim-tree.lua/blob/15afe3a8b4a058e7b841a67da1e61b420465e40f/lua/nvim-tree/fs.lua#L60

Note that the actual default value is `nil` but this is currently equivalent to `0` from the user's perspective.