### PR TITLE
feat: allow not changing the cwd when changing directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ require'nvim-tree'.setup {
   },
   actions = {
     change_dir = {
+      enable = true,
       global = false,
     },
     open_file = {

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -132,6 +132,7 @@ function.
       },
       actions = {
         change_dir = {
+          enable = true,
           global = false,
         },
         open_file = {
@@ -396,6 +397,11 @@ Here is a list of the options available in the setup call:
 
 *nvim-tree.actions*
 |actions|: configuration for various actions
+
+  - |actions.change_dir.enable|: change the working directory when changing
+    directories in the tree.
+      type: `boolean`
+      default: `true`
 
   - |actions.change_dir.global|: use `:cd` instead of `:lcd` when changing
     directories. Consider that this might cause issues with

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -358,6 +358,7 @@ local DEFAULT_OPTS = {
   },
   actions = {
     change_dir = {
+      enable = true,
       global = vim.g.nvim_tree_change_dir_global == 1,
     },
     open_file = {

--- a/lua/nvim-tree/actions/change-dir.lua
+++ b/lua/nvim-tree/actions/change-dir.lua
@@ -5,6 +5,7 @@ local M = {
   current_tab = a.nvim_get_current_tabpage(),
   options = {
     global = false,
+    change_cwd = true,
   }
 }
 
@@ -23,7 +24,7 @@ function M.fn(name, with_open)
 end
 
 function M.force_dirchange(foldername, with_open)
-  if vim.tbl_isempty(vim.v.event) then
+  if M.options.change_cwd and vim.tbl_isempty(vim.v.event) then
     if M.options.global then
       vim.cmd('cd '..vim.fn.fnameescape(foldername))
     else
@@ -39,6 +40,7 @@ function M.force_dirchange(foldername, with_open)
 end
 
 function M.setup(options)
+  M.options.change_cwd = options.actions.change_dir.enable
   M.options.global = options.actions.change_dir.global
 end
 


### PR DESCRIPTION
Allow keeping the cwd constant when changing directories inside the tree. `TreeExplorer.cwd` is the source of truth for the current root directory of the tree.

With `enable = false`, this matches the behavior of netrw.

Not changing the cwd can break some other plugins, e.g. [the lualine extension for NERDTree](https://github.com/nvim-lualine/lualine.nvim/blob/master/lua/lualine/extensions/nerdtree.lua) (which [the nvim-tree extension uses](https://github.com/nvim-lualine/lualine.nvim/blob/master/lua/lualine/extensions/nvim-tree.lua)) relies on `cwd` to show the directory in the status line. Those should be modified to rely on `TreeExplorer.cwd` if someone disables `change_dir`. I did exactly that change in https://github.com/Gelio/ubuntu-dotfiles/pull/1 by creating my own lualine extension that reads the directory from `TreeExplorer.cwd`.

Related to https://github.com/kyazdani42/nvim-tree.lua/issues/860