### PR TITLE
add more sensible defaults for window_picker.excludes

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,11 +175,8 @@ require'nvim-tree'.setup {
         enable = true,
         chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
         exclude = {
-          filetype = {
-            "notify",
-            "packer",
-            "qf"
-          }
+          filetype = { "notify", "packer", "qf", "diff", "fugitive", "fugitiveblame", },
+          buftype  = { "nofile", "terminal", "help", },
         }
       }
     }

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -141,11 +141,8 @@ function.
 	    enable = true,
 	    chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
 	    exclude = {
-	      filetype = {
-		"notify",
-		"packer",
-		"qf"
-	      }
+	      filetype = { "notify", "packer", "qf", "diff", "fugitive", "fugitiveblame", },
+	      buftype  = { "nofile", "terminal", "help", },
 	    }
 	  }
         },

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -428,10 +428,13 @@ Here is a list of the options available in the setup call:
 	default: `"ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"`
 
     - |actions.open_file.window_picker.exclude|: Table of buffer option names
-      mapped to a list of option values taht indicates to the picker that the
+      mapped to a list of option values that indicates to the picker that the
       buffer's window should not be selectable.
 	type: `table`
-	default: `{ filetype = { "packer", "qf", "notify" } }`
+	default: `{`
+			`filetype = { "notify", "packer", "qf", "diff", "fugitive", "fugitiveblame", },`
+			`buftype  = { "nofile", "terminal", "help", }`
+		`}`
 
 ==============================================================================
 OPTIONS				                  *nvim-tree-options*

--- a/lua/nvim-tree/actions/open-file.lua
+++ b/lua/nvim-tree/actions/open-file.lua
@@ -10,11 +10,8 @@ local M = {
     enable = true,
     chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
     exclude = {
-      filetype = {
-        "notify",
-        "packer",
-        "qf"
-      }
+      filetype = { "notify", "packer", "qf", "diff", "fugitive", "fugitiveblame", },
+      buftype  = { "nofile", "terminal", "help", },
     }
   }
 }


### PR DESCRIPTION
There are many common windows - mostly plugin windows - that users will not want to open files in.

buftype `nofile` covers many vim and plugin cases such as man page, tagbar, bufexplorer etc. This saves the user from having to manually exclude all those filetypes.

filetype `diff` covers regular vim diff, as well as many plugins that use diffs such as vim-gitgutter and fugitive.

filetype `fugitive` is explicitly present as some of its buffers have an acwrite buftype. I added this as it is very popular, but happy to remove.