### PR TITLE
feat: add sort_by option to sort files by modification time

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -83,6 +83,7 @@ function.
       auto_close           = false,
       auto_reload_on_write = true,
       open_on_tab          = false,
+      sort_by              = "name",
       hijack_cursor        = false,
       update_cwd           = false,
       hijack_unnamed_buffer_when_opening = false,
@@ -200,6 +201,12 @@ Here is a list of the options available in the setup call:
   tabpage if the tree was previously open.
   type: `boolean`
   default: `false`
+
+*nvim-tree.sort_by*
+- |sort_by|: changes how files within the same directory are sorted. can be
+  one of 'name' | 'modification_time'
+  type: `string`
+  default: `"name"`
 
 *nvim-tree.hijack_unnamed_buffer_when_opening*
 - |hijack_unnamed_buffer_when_opening|: opens in place of the unnamed

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -338,6 +338,7 @@ local DEFAULT_OPTS = {
   ignore_buffer_on_setup = false,
   open_on_setup = false,
   open_on_tab = false,
+  sort_by = "name",
   update_cwd = false,
   hijack_directories = {
     enable = true,

--- a/lua/nvim-tree/explorer/utils.lua
+++ b/lua/nvim-tree/explorer/utils.lua
@@ -5,9 +5,10 @@ local utils = require'nvim-tree.utils'
 local M = {
   ignore_list = {},
   exclude_list = {},
+  node_comparator = nil,
 }
 
-function M.node_comparator(a, b)
+function M.node_comparator_name(a, b)
   if not (a and b) then
     return true
   end
@@ -18,6 +19,19 @@ function M.node_comparator(a, b)
   end
 
   return a.name:lower() <= b.name:lower()
+end
+
+function M.node_comparator_modification_time(a, b)
+  if not (a and b) then
+    return true
+  end
+  if a.nodes and not b.nodes then
+    return true
+  elseif not a.nodes and b.nodes then
+    return false
+  end
+
+  return b.last_modified <= a.last_modified
 end
 
 ---Check if the given path should be ignored.
@@ -73,6 +87,7 @@ function M.setup(opts)
     filter_ignored = true,
     filter_dotfiles = opts.filters.dotfiles,
     filter_git_ignored = opts.git.ignore,
+    sort_by = opts.sort_by,
   }
 
   M.exclude_list = opts.filters.exclude
@@ -82,6 +97,12 @@ function M.setup(opts)
     for _, filter_name in pairs(custom_filter) do
       M.ignore_list[filter_name] = true
     end
+  end
+
+  if M.config.sort_by == "modification_time" then
+    M.node_comparator = M.node_comparator_modification_time
+  else
+    M.node_comparator = M.node_comparator_name
   end
 end
 


### PR DESCRIPTION
Fixes #1039 for files only. I'll wait for feedback on whether you like this feature or not before investigating why it's not working on directories. I was thinking that directories will always be sorted above files at the same level. So for each node, show `sorted(directories)` followed by `sorted(files/symlinks)`. What do you think? 