### PR TITLE
Close help on q/close instead of ignore keypress

### DIFF
--- a/lua/nvim-tree/actions/init.lua
+++ b/lua/nvim-tree/actions/init.lua
@@ -81,6 +81,9 @@ local keypress_funcs = {
 }
 
 function M.on_keypress(action)
+  if view.is_help_ui() and action == 'close' then
+    action = 'toggle_help';
+  end
   if view.is_help_ui() and action ~= 'toggle_help' then return end
   local node = lib.get_node_at_cursor()
   if not node then return end


### PR DESCRIPTION
I believe this is better matches expectations when pressing 'q' on the help ui.