### PR TITLE
fix(run-command): handle current directory node

### DIFF
--- a/lua/nvim-tree/actions/run-command.lua
+++ b/lua/nvim-tree/actions/run-command.lua
@@ -1,8 +1,21 @@
+local utils = require("nvim-tree.utils")
+
 local M = {}
 
+---Retrieves the absolute path to the node.
+---Safely handles the node representing the current directory
+---(the topmost node in the nvim-tree window)
+local function get_node_path(node)
+	if node.name == ".." then
+		return utils.path_remove_trailing(TreeExplorer.cwd)
+	else
+		return node.absolute_path
+	end
+end
+
 function M.run_file_command(node)
-  vim.api.nvim_input(": " .. node.absolute_path .. "<Home>")
+	local node_path = get_node_path(node)
+	vim.api.nvim_input(": " .. node_path .. "<Home>")
 end
 
 return M
-


### PR DESCRIPTION
Handle the node representing the current directory (the topmost node in the nvim-tree window). That node does not have the `absolute_path` set. Use `TreeExplorer.cwd` instead, similar to the logic in `change-dir`.

## Bug reproduction

1. `:NvimTreeOpen`
2. `gg`
3. `.`

Before:

![image](https://user-images.githubusercontent.com/889383/156733668-d1784815-7956-41e1-b492-37cd725e9709.png)

After:

![image](https://user-images.githubusercontent.com/889383/156733603-479c8ca5-47dd-41b7-9b1a-f61647f9b2d4.png)
