### PR TITLE
feat: make it possible to collapse the tree but keep the directories open which are in used in buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ nnoremap <leader>n :NvimTreeFindFile<CR>
 " NvimTreeFocus
 " NvimTreeFindFileToggle
 " NvimTreeResize
+" NvimTreeCollapse
+" NvimTreeCollapseKeepBuffers
 
 set termguicolors " this variable must be enabled for colors to be applied properly
 

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -66,6 +66,15 @@ adds or removes the given value to the current window width.
 Example `:NvimTreeResize -20` removes the value 20 from the current width. And
 `:NvimTreeResize +20` adds the value 20 to the current width.
 
+|:NvimTreeCollapse|			          *:NvimTreeCollapse*
+
+Collapses the nvim-tree recursively.
+
+|:NvimTreeCollapseKeepBuffers|		          *:NvimTreeCollapseKeepBuffers*
+
+Collapses the nvim-tree recursively, but keep the directories open, which are 
+used in an open buffer.
+
 
 ==============================================================================
 SETUP                                *nvim-tree.setup*

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -280,6 +280,8 @@ local function setup_vim_commands()
     command! NvimTreeFindFile lua require'nvim-tree'.find_file(true)
     command! NvimTreeFindFileToggle lua require'nvim-tree'.toggle(true)
     command! -nargs=1 NvimTreeResize lua require'nvim-tree'.resize("<args>")
+    command! NvimTreeCollapse lua require'nvim-tree.actions.collapse-all'.fn()
+    command! NvimTreeCollapseKeepBuffers lua require'nvim-tree.actions.collapse-all'.fn(true)
   ]]
 end
 

--- a/lua/nvim-tree/actions/collapse-all.lua
+++ b/lua/nvim-tree/actions/collapse-all.lua
@@ -1,12 +1,29 @@
 local renderer = require "nvim-tree.renderer"
+local utils = require "nvim-tree.utils"
 
 local M = {}
 
-function M.fn()
+function M.fn(keep_buffers)
+  local buffer_paths = {}
+  for _, buffer in ipairs(vim.api.nvim_list_bufs()) do
+    table.insert(buffer_paths, vim.api.nvim_buf_get_name(buffer))
+  end
+
   local function iter(nodes)
     for _, node in pairs(nodes) do
       if node.open then
-        node.open = false
+        local new_open = false
+
+        if keep_buffers == true then
+          for _, buffer_path in ipairs(buffer_paths) do
+            local matches = utils.str_find(buffer_path, node.absolute_path)
+            if matches then
+              new_open = true
+            end
+          end
+        end
+
+        node.open = new_open
       end
       if node.nodes then
         iter(node.nodes)


### PR DESCRIPTION
Sometimes I want to "clean up" my nvim-tree but keep the directories open, which are opened in buffers at the moment.