### PR TITLE
Set target window whenever we open "open" a visible tree

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -41,6 +41,7 @@ end
 function M.open(cwd)
   cwd = cwd ~= "" and cwd or nil
   if view.is_visible() then
+    lib.set_target_win()
     view.focus()
   else
     lib.open(cwd)


### PR DESCRIPTION
Currently the target window to be used (with a disabled pick window) is the one that was "focused" when the tree was first opened.
So, if you let the tree open, the splits and open file are going to target the original window.
This is counter intuitive and annoying if what you want to achieve is to open a file in a split.
This minor change updates the target window whenever we try to open the tree, that's executed whenever we focus the tree, so the behavior is now that the splits and open_file are executed against the previously focused buffer.