### PR TITLE
fix: window picker bug on global statusline

### DIFF
--- a/lua/nvim-tree/actions/open-file.lua
+++ b/lua/nvim-tree/actions/open-file.lua
@@ -58,6 +58,19 @@ local function pick_window()
   local laststatus = vim.o.laststatus
   vim.o.laststatus = 2
 
+  if laststatus == 3 then
+    local ok_status, statusline = pcall(api.nvim_win_get_option, tree_winid, "statusline")
+    local ok_hl, winhl = pcall(api.nvim_win_get_option, tree_winid, "winhl")
+
+    win_opts[tree_winid] = {
+      statusline = ok_status and statusline or "",
+      winhl = ok_hl and winhl or "",
+    }
+
+    api.nvim_win_set_option(tree_winid, "statusline", " ")
+    api.nvim_win_set_option(tree_winid, "winhl", "StatusLine:NvimTreeWindowPicker")
+  end
+
   -- Setup UI
   for _, id in ipairs(selectable) do
     local char = M.window_picker.chars:sub(i, i)
@@ -89,6 +102,12 @@ local function pick_window()
   for _, id in ipairs(selectable) do
     for opt, value in pairs(win_opts[id]) do
       api.nvim_win_set_option(id, opt, value)
+    end
+  end
+
+  if laststatus == 3 then
+    for opt, value in pairs(win_opts[tree_winid]) do
+      api.nvim_win_set_option(tree_winid, opt, value)
     end
   end
 


### PR DESCRIPTION
This PR attempts to fix #1096. 

I set the NvimTree status line to blank when global status is set and window picker is activated. When window picker is deactivated, I restores NvimTree status line to its previous state. 

See below screenshots for reference.

Before patch
![before](https://user-images.githubusercontent.com/61618751/159491199-85ab1e72-dad1-43c7-a3ee-54ef7e45732e.jpg)

After patch
![after](https://user-images.githubusercontent.com/61618751/159491309-ccc2f7bc-30c8-4c59-828d-e1ed59dbf71f.jpg)