### PR TITLE
profile uses uv.hrtime

### DIFF
--- a/lua/nvim-tree/log.lua
+++ b/lua/nvim-tree/log.lua
@@ -1,3 +1,5 @@
+local uv = vim.loop
+
 local M = {
   config = nil,
   path = nil,
@@ -21,18 +23,24 @@ end
 
 --- Write to log file via M.line
 --- START is prefixed
---- @return reltime to pass to profile_end
+--- @return nanos to pass to profile_end
 function M.profile_start(fmt, ...)
+  if not M.path or not M.config.types.profile and not M.config.types.all then
+    return
+  end
   M.line("profile", "START " .. (fmt or "???"), ...)
-  return vim.fn.reltime()
+  return uv.hrtime()
 end
 
 --- Write to log file via M.line
 --- END is prefixed and duration in seconds is suffixed
---- @param start reltime returned from profile_start
+--- @param start nanos returned from profile_start
 function M.profile_end(start, fmt, ...)
-  local dur = vim.fn.reltimestr(vim.fn.reltime(start, vim.fn.reltime()))
-  M.line("profile", "END   " .. (fmt or "???") .. "  " .. dur .. "s", ...)
+  if not M.path or not M.config.types.profile and not M.config.types.all then
+    return
+  end
+  local millis = start and math.modf((uv.hrtime() - start) / 1000000) or -1
+  M.line("profile", "END   " .. (fmt or "???") .. "  " .. millis .. "ms", ...)
 end
 
 -- Write to log file via M.raw


### PR DESCRIPTION
Use `uv.hrtime` instead of old vim method.

Adds more gates for a little optimisation when profiling not enabled.