### PR TITLE
feat: add hl_group for file icons

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -792,6 +792,7 @@ NvimTreeSymlink
 NvimTreeFolderName
 NvimTreeRootFolder
 NvimTreeFolderIcon
+NvimTreeFileIcon
 NvimTreeEmptyFolderName
 NvimTreeOpenedFolderName
 NvimTreeExecFile

--- a/lua/nvim-tree/renderer/init.lua
+++ b/lua/nvim-tree/renderer/init.lua
@@ -83,8 +83,13 @@ if icon_state.show_file_icon then
       end
     end
   else
-    get_file_icon = function()
-      return #icon_state.icons.default > 0 and icon_state.icons.default .. icon_padding or ""
+    get_file_icon = function(_, _, line, depth)
+      local hl_group = "NvimTreeFileIcon"
+      local icon = icon_state.icons.default
+      if #icon > 0 then
+        table.insert(hl, { hl_group, line, depth, depth + #icon + 1 })
+      end
+      return #icon > 0 and icon .. icon_padding or ""
     end
   end
 end


### PR DESCRIPTION
The PR adds an `hl_group` named `NvimTreeFileIcon` which is used similarly to `NvimTreeFolderIcon`. It changes the color of file icons without the use of [nvim-web-devicons](https://github.com/kyazdani42/nvim-web-devicons).

Closes #1124