### PR TITLE
Preserve cursor position across redraws

### DIFF
--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -126,6 +126,7 @@ function M.open(cwd)
   else
     open_view_and_draw()
   end
+  view.restore_tab_state()
 end
 
 -- @deprecated: use nvim-tree.actions.collapse-all.fn


### PR DESCRIPTION
I saw that defaults are set on the window and the buffer however there's additional state that should be preserved across redraws, this PR adds `view.state` which keeps track of these changes, for now the only variable set is cursor.

Testing:
- Open a file from the sidebar, close the sidebar, calling `NvimTreeOpen` moves the cursor to the position of the file, this is a new behavior.
- Open a file from the sidebar, close the sidebar, cycle to another buffer opened, calling `M.find_file(with_open, bufnr)` moves the cursor to the last know state on `M.open` however the next block will find the file in the tree overriding the cursor position, this is the existing behavior.
- Open a file from the sidebar, close the sidebar, open the sidebar to see that the cursor is still on the file, create a new tab, call NvimTreeOpen and open a file from the sidebar, close the sidebar, open the sidebar again and see that tab 2's cursor is restored, cycle to the previous tab, open the sidebar and see that tab 1's cursor is restored

Fixes #1129 