### PR TITLE
fix(statusline): better window picker highlight

### DIFF
--- a/lua/nvim-tree/actions/open-file.lua
+++ b/lua/nvim-tree/actions/open-file.lua
@@ -58,16 +58,23 @@ local function pick_window()
   local laststatus = vim.o.laststatus
   vim.o.laststatus = 2
 
+  local not_selectable = vim.tbl_filter(function(id)
+    return not vim.tbl_contains(selectable, id)
+  end, win_ids)
+
   if laststatus == 3 then
-    local ok_status, statusline = pcall(api.nvim_win_get_option, tree_winid, "statusline")
-    local ok_hl, winhl = pcall(api.nvim_win_get_option, tree_winid, "winhl")
+    for _, win_id in ipairs(not_selectable) do
+      local ok_status, statusline = pcall(api.nvim_win_get_option, win_id, "statusline")
+      local ok_hl, winhl = pcall(api.nvim_win_get_option, win_id, "winhl")
 
-    win_opts[tree_winid] = {
-      statusline = ok_status and statusline or "",
-      winhl = ok_hl and winhl or "",
-    }
+      win_opts[win_id] = {
+        statusline = ok_status and statusline or "",
+        winhl = ok_hl and winhl or "",
+      }
 
-    api.nvim_win_set_option(tree_winid, "statusline", " ")
+      -- Clear statusline for windows not selectable
+      api.nvim_win_set_option(win_id, "statusline", " ")
+    end
   end
 
   -- Setup UI
@@ -104,7 +111,19 @@ local function pick_window()
     end
   end
 
+  if laststatus == 3 then
+    for _, id in ipairs(not_selectable) do
+      for opt, value in pairs(win_opts[id]) do
+        api.nvim_win_set_option(id, opt, value)
+      end
+    end
+  end
+
   vim.o.laststatus = laststatus
+
+  if not vim.tbl_contains(vim.split(M.window_picker.chars, ""), resp) then
+    return
+  end
 
   return win_map[resp]
 end
@@ -161,7 +180,11 @@ function M.fn(mode, filename)
   if not M.window_picker.enable or mode == "edit_no_picker" then
     target_winid = lib.target_winid
   else
-    target_winid = pick_window()
+    local pick_window_id = pick_window()
+    if pick_window_id == nil then
+      return
+    end
+    target_winid = pick_window_id
   end
 
   if target_winid == -1 then

--- a/lua/nvim-tree/actions/open-file.lua
+++ b/lua/nvim-tree/actions/open-file.lua
@@ -68,7 +68,6 @@ local function pick_window()
     }
 
     api.nvim_win_set_option(tree_winid, "statusline", " ")
-    api.nvim_win_set_option(tree_winid, "winhl", "StatusLine:NvimTreeWindowPicker")
   end
 
   -- Setup UI
@@ -102,12 +101,6 @@ local function pick_window()
   for _, id in ipairs(selectable) do
     for opt, value in pairs(win_opts[id]) do
       api.nvim_win_set_option(id, opt, value)
-    end
-  end
-
-  if laststatus == 3 then
-    for opt, value in pairs(win_opts[tree_winid]) do
-      api.nvim_win_set_option(tree_winid, opt, value)
     end
   end
 


### PR DESCRIPTION
This PR removes highlighting on `NvimTree` introduced in #1098 

Before:
![image](https://user-images.githubusercontent.com/16160544/162557531-125a2e60-0546-4185-b3f7-c63b1a3b6fba.png)


After:
![image](https://user-images.githubusercontent.com/16160544/162109820-7338b62e-cd56-4e43-98cb-a01c6910fb5f.png)


### Other change:

- Not open file if input char not included in `window_picker.chars`
