### PR TITLE
Added actions.opts.use_sys_clipboard, [issue: 789 ] 

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ require'nvim-tree'.setup { -- BEGIN_DEFAULT_OPTS
     timeout = 400,
   },
   actions = {
+    use_system_clipboard = true,
     change_dir = {
       enable = true,
       global = false,

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -481,12 +481,11 @@ Here is a list of the options available in the setup call:
 			`buftype  = { "nofile", "terminal", "help", }`
 		`}`
     
-    - actions.use_system_clipboard: A boolean value that toggle the use of system clipboard 
+    - |actions.use_system_clipboard|: A boolean value that toggle the use of system clipboard 
       when copy/paste function are invoked.
-      If is enabled all copy text are stored in registers '+', when disabled
-      in registers '1' and '"'.
-	type: boolean
-	default: true
+      When enabled, copied text will be stored in registers '+' (system), otherwise, it will be stored in '1' and '"'.
+	type: `boolean`
+	default: `true`
 	
 
 *nvim-tree.log*

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -146,6 +146,7 @@ function.
         timeout = 400,
       },
       actions = {
+        use_system_clipboard = true,
         change_dir = {
           enable = true,
           global = false,
@@ -479,6 +480,14 @@ Here is a list of the options available in the setup call:
 			`filetype = { "notify", "packer", "qf", "diff", "fugitive", "fugitiveblame", },`
 			`buftype  = { "nofile", "terminal", "help", }`
 		`}`
+    
+    - actions.use_system_clipboard: A boolean value that toggle the use of system clipboard 
+      when copy/paste function are invoked.
+      If is enabled all copy text are stored in registers '+', when disabled
+      in registers '1' and '"'.
+	type: boolean
+	default: true
+	
 
 *nvim-tree.log*
 |log|: configuration for diagnostic logging

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -1,4 +1,3 @@
-print "Hello, branch!"
 local luv = vim.loop
 local api = vim.api
 

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -1,3 +1,4 @@
+print "Hello, branch!"
 local luv = vim.loop
 local api = vim.api
 
@@ -371,6 +372,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
     timeout = 400,
   },
   actions = {
+    use_system_clipboard = true,
     change_dir = {
       enable = true,
       global = false,

--- a/lua/nvim-tree/actions/copy-paste.lua
+++ b/lua/nvim-tree/actions/copy-paste.lua
@@ -212,9 +212,15 @@ function M.print_clipboard()
 end
 
 local function copy_to_clipboard(content)
-  vim.fn.setreg("+", content)
-  vim.fn.setreg('"', content)
-  return a.nvim_out_write(string.format("Copied %s to system clipboard! \n", content))
+  if M.use_sys_clipboard then
+    vim.fn.setreg("+", content)
+    vim.fn.setreg('"', content)
+    return a.nvim_out_write(string.format("Copied %s to system clipboard! \n", content))
+  else
+    vim.fn.setreg('"', content)
+    vim.fn.setreg('1', content)
+    return a.nvim_out_write(string.format("Copied %s to neovim clipboard \n", content))
+  end
 end
 
 function M.copy_filename(node)
@@ -232,6 +238,11 @@ function M.copy_absolute_path(node)
   local absolute_path = node.absolute_path
   local content = node.nodes ~= nil and utils.path_add_trailing(absolute_path) or absolute_path
   return copy_to_clipboard(content)
+end
+
+function M.setup(opts)
+  M.use_sys_clipboard = opts.actions.use_sys_clipboard
+  if M.use_sys_clipboard == nil then M.use_sys_clipboard = true end
 end
 
 return M

--- a/lua/nvim-tree/actions/copy-paste.lua
+++ b/lua/nvim-tree/actions/copy-paste.lua
@@ -212,13 +212,13 @@ function M.print_clipboard()
 end
 
 local function copy_to_clipboard(content)
-  if M.use_sys_clipboard then
+  if M.use_sys_clipboard == true then
     vim.fn.setreg("+", content)
     vim.fn.setreg('"', content)
     return a.nvim_out_write(string.format("Copied %s to system clipboard! \n", content))
   else
     vim.fn.setreg('"', content)
-    vim.fn.setreg('1', content)
+    vim.fn.setreg("1", content)
     return a.nvim_out_write(string.format("Copied %s to neovim clipboard \n", content))
   end
 end
@@ -242,7 +242,8 @@ end
 
 function M.setup(opts)
   M.use_sys_clipboard = opts.actions.use_sys_clipboard
-  if M.use_sys_clipboard == nil then M.use_sys_clipboard = true end
+  if M.use_sys_clipboard == nil then
+    M.use_sys_clipboard = true
+  end
 end
-
 return M

--- a/lua/nvim-tree/actions/copy-paste.lua
+++ b/lua/nvim-tree/actions/copy-paste.lua
@@ -242,8 +242,6 @@ end
 
 function M.setup(opts)
   M.use_sys_clipboard = opts.actions.use_sys_clipboard
-  if M.use_sys_clipboard == nil then
-    M.use_sys_clipboard = true
-  end
 end
+
 return M

--- a/lua/nvim-tree/actions/init.lua
+++ b/lua/nvim-tree/actions/init.lua
@@ -226,6 +226,7 @@ function M.setup(opts)
   require("nvim-tree.actions.trash").setup(opts.trash)
   require("nvim-tree.actions.open-file").setup(opts)
   require("nvim-tree.actions.change-dir").setup(opts)
+  require("nvim-tree.actions.copy-paste").setup(opts)
 
   local user_map_config = (opts.view or {}).mappings or {}
   local options = vim.tbl_deep_extend("force", DEFAULT_MAPPING_CONFIG, user_map_config)


### PR DESCRIPTION
As requested on https://github.com/kyazdani42/nvim-tree.lua/issues/789 I've implemented an actions.opts to toggle the use of system clipboard. Default is true (use the system clipboard).