### PR TITLE
#1059 protect against duplicates

### DIFF
--- a/lua/nvim-tree/explorer/explore.lua
+++ b/lua/nvim-tree/explorer/explore.lua
@@ -24,7 +24,11 @@ local function populate_children(handle, cwd, node, status)
     local nodes_by_path = utils.key_by(node.nodes, "absolute_path")
     local abs = utils.path_join { cwd, name }
     t = get_type_from(t, abs)
-    if not filters.should_ignore(abs) and not filters.should_ignore_git(abs, status.files) and not nodes_by_path[abs] then
+    if
+      not filters.should_ignore(abs)
+      and not filters.should_ignore_git(abs, status.files)
+      and not nodes_by_path[abs]
+    then
       if t == "directory" and uv.fs_access(abs, "R") then
         table.insert(node.nodes, builders.folder(abs, name, status, node_ignored))
       elseif t == "file" then

--- a/lua/nvim-tree/explorer/explore.lua
+++ b/lua/nvim-tree/explorer/explore.lua
@@ -21,9 +21,10 @@ local function populate_children(handle, cwd, node, status)
       break
     end
 
+    local nodes_by_path = utils.key_by(node.nodes, "absolute_path")
     local abs = utils.path_join { cwd, name }
     t = get_type_from(t, abs)
-    if not filters.should_ignore(abs) and not filters.should_ignore_git(abs, status.files) then
+    if not filters.should_ignore(abs) and not filters.should_ignore_git(abs, status.files) and not nodes_by_path[abs] then
       if t == "directory" and uv.fs_access(abs, "R") then
         table.insert(node.nodes, builders.folder(abs, name, status, node_ignored))
       elseif t == "file" then

--- a/lua/nvim-tree/explorer/reload.lua
+++ b/lua/nvim-tree/explorer/reload.lua
@@ -9,14 +9,6 @@ local sorters = require "nvim-tree.explorer.sorters"
 
 local M = {}
 
-local function key_by(nodes, key)
-  local v = {}
-  for _, node in ipairs(nodes) do
-    v[node[key]] = node
-  end
-  return v
-end
-
 local function update_status(nodes_by_path, node_ignored, status)
   return function(node)
     if nodes_by_path[node.absolute_path] then

--- a/lua/nvim-tree/explorer/reload.lua
+++ b/lua/nvim-tree/explorer/reload.lua
@@ -46,7 +46,7 @@ function M.reload(node, status)
   local child_names = {}
 
   local node_ignored = node.git_status == "!!"
-  local nodes_by_path = key_by(node.nodes, "absolute_path")
+  local nodes_by_path = utils.key_by(node.nodes, "absolute_path")
   while true do
     local name, t = uv.fs_scandir_next(handle)
     if not name then

--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -210,4 +210,12 @@ function M.format_bytes(bytes)
   return (units[pow] == nil) and (bytes .. "B") or (value .. units[pow])
 end
 
+function M.key_by(tbl, key)
+  local keyed = {}
+  for _, val in ipairs(tbl) do
+    keyed[val[key]] = val
+  end
+  return keyed
+end
+
 return M


### PR DESCRIPTION
Avoid duplicates during `populate_children`.

It is not clear how this could happen, however this is safe.