### PR TITLE
feat: delete preview buffers #1145

### DIFF
--- a/lua/nvim-tree/actions/open-file.lua
+++ b/lua/nvim-tree/actions/open-file.lua
@@ -194,6 +194,15 @@ function M.fn(mode, filename)
   local do_split = mode == "split" or mode == "vsplit"
   local vertical = mode ~= "split"
 
+  -- Check if file is already loaded in a buffer
+  local buf_loaded = false
+  for _, bufId in ipairs(api.nvim_list_bufs()) do
+    if api.nvim_buf_is_loaded(bufId) and filename == api.nvim_buf_get_name(bufId) then
+      buf_loaded = true
+      break
+    end
+  end
+
   -- Check if filename is already open in a window
   local found = false
   for _, id in ipairs(win_ids) do
@@ -245,6 +254,16 @@ function M.fn(mode, filename)
   end
 
   if mode == "preview" then
+    if not buf_loaded then
+      vim.bo.bufhidden = "delete"
+      vim.cmd [[
+      augroup RemoveBufHidden
+          autocmd!
+          autocmd TextChanged <buffer> setlocal bufhidden= | autocmd! RemoveBufHidden
+          autocmd TextChangedI <buffer> setlocal bufhidden= | autocmd! RemoveBufHidden
+      augroup end
+    ]]
+    end
     view.focus()
     return
   end

--- a/lua/nvim-tree/actions/open-file.lua
+++ b/lua/nvim-tree/actions/open-file.lua
@@ -196,8 +196,8 @@ function M.fn(mode, filename)
 
   -- Check if file is already loaded in a buffer
   local buf_loaded = false
-  for _, bufId in ipairs(api.nvim_list_bufs()) do
-    if api.nvim_buf_is_loaded(bufId) and filename == api.nvim_buf_get_name(bufId) then
+  for _, buf_id in ipairs(api.nvim_list_bufs()) do
+    if api.nvim_buf_is_loaded(buf_id) and filename == api.nvim_buf_get_name(buf_id) then
       buf_loaded = true
       break
     end


### PR DESCRIPTION
This adds `bufhidden = delete` for the preview buffer, which means that the buffer will be deleted after it is no longer displayed in a window.

This value gets reset with the autocommand:
if text changes in normal or insert mode, then `bufhidden` resets and now equals to the user's `hidden` option. 

So, if you change text in preview buffer, the buffer will persist.

Also, check for `buf_loaded` is needed, so that if you press `Tab` on an already opened file, it will not become temporary with `bufhidden`

See issue #1145 