### PR TITLE
fix: trash filenames with spaces

### DIFF
--- a/lua/nvim-tree/actions/trash.lua
+++ b/lua/nvim-tree/actions/trash.lua
@@ -47,7 +47,7 @@ function M.fn(node)
 
   -- trashes a path (file or folder)
   local function trash_path(on_exit)
-    vim.fn.jobstart(M.config.trash.cmd .. " " .. node.absolute_path, {
+    vim.fn.jobstart(M.config.trash.cmd .. ' "' .. node.absolute_path .. '"', {
       detach = true,
       on_exit = on_exit,
     })


### PR DESCRIPTION
Trash was not working on files with spaces in the name and could even delete unwanted files.

This wraps it in double quotes, so that `trash` command receives correct filepath