### PR TITLE
#1091 diagnostics logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ require'nvim-tree'.setup { -- BEGIN_DEFAULT_OPTS
       all = false,
       config = false,
       copy_paste = false,
+      diagnostics = false,
       git = false,
       profile = false,
     },

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -185,6 +185,7 @@ function.
           all = false,
           config = false,
           copy_paste = false,
+          diagnostics = false,
           git = false,
           profile = false,
         },

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -410,6 +410,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
       all = false,
       config = false,
       copy_paste = false,
+      diagnostics = false,
       git = false,
       profile = false,
     },

--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -125,7 +125,7 @@ function M.update()
   if not M.enable or not core.get_explorer() or not view.is_buf_valid(view.get_bufnr()) then
     return
   end
-  local ps = log.profile_start("diagnostics update")
+  local ps = log.profile_start "diagnostics update"
   log.line("diagnostics", "update")
 
   local buffer_severity

--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -131,10 +131,13 @@ function M.update()
     buffer_severity = from_nvim_lsp()
   end
 
+  require("nvim-tree.log").line("diagnostics", "update")
   M.clear()
   for bufname, severity in pairs(buffer_severity) do
+    require("nvim-tree.log").line("diagnostics", " bufname '%s' severity %d", bufname, severity)
     if 0 < severity and severity < 5 then
       local node, line = utils.find_node(core.get_explorer().nodes, function(node)
+        require("nvim-tree.log").line("diagnostics", "  checking node '%s'", node.absolute_path)
         if M.show_on_dirs and not node.open then
           return vim.startswith(bufname, node.absolute_path)
         else
@@ -142,6 +145,7 @@ function M.update()
         end
       end)
       if node then
+        require("nvim-tree.log").line("diagnostics", " matched node '%s'", node.absolute_path)
         add_sign(line, severity)
       end
     end

--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -2,6 +2,7 @@ local a = vim.api
 local utils = require "nvim-tree.utils"
 local view = require "nvim-tree.view"
 local core = require "nvim-tree.core"
+local log = require "nvim-tree.log"
 
 local M = {}
 
@@ -124,6 +125,9 @@ function M.update()
   if not M.enable or not core.get_explorer() or not view.is_buf_valid(view.get_bufnr()) then
     return
   end
+  local ps = log.profile_start("diagnostics update")
+  log.line("diagnostics", "update")
+
   local buffer_severity
   if is_using_coc() then
     buffer_severity = from_coc()
@@ -131,15 +135,14 @@ function M.update()
     buffer_severity = from_nvim_lsp()
   end
 
-  require("nvim-tree.log").line("diagnostics", "update")
   M.clear()
   for bufname, severity in pairs(buffer_severity) do
     local bufpath = utils.canonical_path(bufname)
-    require("nvim-tree.log").line("diagnostics", " bufpath '%s' severity %d", bufpath, severity)
+    log.line("diagnostics", " bufpath '%s' severity %d", bufpath, severity)
     if 0 < severity and severity < 5 then
       local node, line = utils.find_node(core.get_explorer().nodes, function(node)
         local nodepath = utils.canonical_path(node.absolute_path)
-        require("nvim-tree.log").line("diagnostics", "  checking nodepath '%s'", nodepath)
+        log.line("diagnostics", "  checking nodepath '%s'", nodepath)
         if M.show_on_dirs and not node.open then
           return vim.startswith(bufpath, nodepath)
         else
@@ -147,11 +150,12 @@ function M.update()
         end
       end)
       if node then
-        require("nvim-tree.log").line("diagnostics", " matched node '%s'", node.absolute_path)
+        log.line("diagnostics", " matched node '%s'", node.absolute_path)
         add_sign(line, severity)
       end
     end
   end
+  log.profile_end(ps, "diagnostics update")
 end
 
 local has_06 = vim.fn.has "nvim-0.6" == 1
@@ -176,8 +180,10 @@ function M.setup(opts)
 
   if M.enable then
     if has_06 then
+      log.line("diagnostics", "setup has_06")
       vim.cmd "au DiagnosticChanged * lua require'nvim-tree.diagnostics'.update()"
     else
+      log.line("diagnostics", "setup not has_06")
       vim.cmd "au User LspDiagnosticsChanged lua require'nvim-tree.diagnostics'.update()"
     end
   end

--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -134,14 +134,16 @@ function M.update()
   require("nvim-tree.log").line("diagnostics", "update")
   M.clear()
   for bufname, severity in pairs(buffer_severity) do
-    require("nvim-tree.log").line("diagnostics", " bufname '%s' severity %d", bufname, severity)
+    local bufpath = utils.canonical_path(bufname)
+    require("nvim-tree.log").line("diagnostics", " bufpath '%s' severity %d", bufpath, severity)
     if 0 < severity and severity < 5 then
       local node, line = utils.find_node(core.get_explorer().nodes, function(node)
-        require("nvim-tree.log").line("diagnostics", "  checking node '%s'", node.absolute_path)
+        local nodepath = utils.canonical_path(node.absolute_path)
+        require("nvim-tree.log").line("diagnostics", "  checking nodepath '%s'", nodepath)
         if M.show_on_dirs and not node.open then
-          return vim.startswith(bufname, node.absolute_path)
+          return vim.startswith(bufpath, nodepath)
         else
-          return node.absolute_path == bufname
+          return nodepath == bufpath
         end
       end)
       if node then


### PR DESCRIPTION
Add profiling and logging to diagnostics.

Checks canonical path of the node, to handle weird windows cases.

Closes #1091