### PR TITLE
#1157 update lsp diagnostics when the tree state is changed

### DIFF
--- a/lua/nvim-tree/actions/change-dir.lua
+++ b/lua/nvim-tree/actions/change-dir.lua
@@ -3,6 +3,7 @@ local a = vim.api
 local log = require "nvim-tree.log"
 local utils = require "nvim-tree.utils"
 local core = require "nvim-tree.core"
+local diagnostics = require "nvim-tree.diagnostics"
 
 local M = {
   current_tab = a.nvim_get_current_tabpage(),
@@ -44,6 +45,7 @@ function M.force_dirchange(foldername, with_open)
   else
     require("nvim-tree.renderer").draw()
   end
+  diagnostics.update()
 
   log.profile_end(ps, "change dir %s", foldername)
 end

--- a/lua/nvim-tree/actions/collapse-all.lua
+++ b/lua/nvim-tree/actions/collapse-all.lua
@@ -1,6 +1,7 @@
 local renderer = require "nvim-tree.renderer"
 local utils = require "nvim-tree.utils"
 local core = require "nvim-tree.core"
+local diagnostics = require "nvim-tree.diagnostics"
 
 local M = {}
 
@@ -38,6 +39,7 @@ function M.fn(keep_buffers)
 
   iter(core.get_explorer().nodes)
   renderer.draw()
+  diagnostics.update()
 end
 
 return M

--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -122,6 +122,7 @@ function M.open(cwd)
   else
     open_view_and_draw()
   end
+  diagnostics.update()
   view.restore_tab_state()
 end
 


### PR DESCRIPTION
Closes #1157 which raised some problems with LSP signs not being displayed or being displayed on the wrong node.

This is pretty hacky. After the renderer rewrite and moving the lsp sign to the node, renderer.draw will deal with the signs more efficiently.

These specific changes should not cause significant performance issues. Putting the update in, say, renderer.draw would work, however it would cause performance issues.

The following actions do not require changes:
```
create-file
dir-up
remove-file
rename-file
toggles
```