### PR TITLE
#1172 add renderer.icons.webdev_colors default true

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ require'nvim-tree'.setup { -- BEGIN_DEFAULT_OPTS
         none = "  ",
       },
     },
+    icons = {
+      webdev_colors = true,
+    },
   },
   hijack_directories = {
     enable = true,

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -120,6 +120,9 @@ function.
             none = "  ",
           },
         },
+        icons = {
+          webdev_colors = true,
+        },
       },
       hijack_directories = {
         enable = true,
@@ -430,6 +433,12 @@ Here is a list of the options available in the setup call:
     - |renderer.indent_markers.icons|: icons shown before the file/directory
         type: `table`
 	default: `{ corner = "└ ", edge = "│ ", none = "  ", }`
+
+  - |renderer.icons|: configuration options for icons
+
+    - |renderer.icons.webdev_colors|: use the webdev icon colors, otherwise `NvimTreeFileIcon`.
+        type: `boolean`
+        default: `true`
 
 *nvim-tree.filters*
 |filters|: filtering options

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -345,6 +345,9 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
         none = "  ",
       },
     },
+    icons = {
+      webdev_colors = true,
+    },
   },
   hijack_directories = {
     enable = true,


### PR DESCRIPTION
Closes #1172 

Allows user to ignore webdev icon colours, optionally using `NvimTreeFileIcon`.

An option could have been avoided by detecting :hi NvimTreeFileIcon and using that, however there is no API to do this. Executing `:hi NvimTreeFileIcon` via pcall is error prone and slow. It also results in false positives as that group is cleared after rendering a non-webdev icon.

Most of this is a refactor. The change is commented.