### PR TITLE
fix(icons): typo in function name

### DIFF
--- a/lua/nvim-tree/renderer/components/icons.lua
+++ b/lua/nvim-tree/renderer/components/icons.lua
@@ -99,7 +99,7 @@ local function config_folder_icon()
     M.get_folder_icon = get_folder_icon
     M.set_folder_hl = set_folder_hl
   else
-    M.get_file_icon = empty
+    M.get_folder_icon = empty
     M.set_folder_hl = set_folder_hl_default
   end
 end


### PR DESCRIPTION
Fix typo for icons file.


This patch fixes the error below when calling :NvimTreeToggle:

```
E5108: Error executing lua ...r/start/nvim-tree.lua/lua/nvim-tree/renderer/builder.lua:85: attempt to call field 'get_folder_icon' (a
 nil value)
stack traceback:
        ...r/start/nvim-tree.lua/lua/nvim-tree/renderer/builder.lua:85: in function '_build_folder'
        ...r/start/nvim-tree.lua/lua/nvim-tree/renderer/builder.lua:199: in function 'build'
        ...cker/start/nvim-tree.lua/lua/nvim-tree/renderer/init.lua:81: in function 'draw'
        ...te/pack/packer/start/nvim-tree.lua/lua/nvim-tree/lib.lua:99: in function 'open_view_and_draw'
        ...te/pack/packer/start/nvim-tree.lua/lua/nvim-tree/lib.lua:123: in function 'open'
        ...m/site/pack/packer/start/nvim-tree.lua/lua/nvim-tree.lua:47: in function 'open'
        ...m/site/pack/packer/start/nvim-tree.lua/lua/nvim-tree.lua:31: in function 'toggle'
        [string ":lua"]:1: in main chunk
```