### PR TITLE
add get_config

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -236,6 +236,10 @@ function M.on_enter(netrw_disabled)
   M.initialized = true
 end
 
+function M.get_config()
+  return M.config
+end
+
 local function manage_netrw(disable_netrw, hijack_netrw)
   if hijack_netrw then
     vim.cmd "silent! autocmd! FileExplorer *"
@@ -486,6 +490,7 @@ function M.setup(conf)
 
   manage_netrw(opts.disable_netrw, opts.hijack_netrw)
 
+  M.config = opts
   require("nvim-tree.log").setup(opts)
 
   log.line("config", "default config + user")


### PR DESCRIPTION
This is a different approach to trying to get the behavior I was seeking out of #1201 provides a function to get the configuration as it was specified at `setup` time.

I overhauled the script I was using to use the lua autocmd api,
this script hardcodes 'width' as I didn't see any mechanism to determine the internal 'is_vertical()' from the publicly exported api.

```lua
local flex = vim.api.nvim_create_augroup("MyNVimTreeFocusResize", {clear = true})
vim.api.nvim_create_autocmd("BufLeave", {
    nested = true,
    callback =
      function()
        if vim.fn.bufname() == 'NvimTree_' .. tostring(vim.fn.tabpagenr()) then
          local nvim_tree = require('nvim-tree')
          local size = nvim_tree.get_config()["view"]["width"]
          nvim_tree.resize(size)
        end
      end,
    group=flex
})
vim.api.nvim_create_autocmd("BufEnter", {
    nested = true,
    callback =
      function()
        if vim.fn.bufname() == 'NvimTree_' .. tostring(vim.fn.tabpagenr()) then
          require('nvim-tree').resize(30)
        end
      end,
    group=flex
})
```