### PR TITLE
Revert "fix: replace vertsplit highlights (#1142)"

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -875,7 +875,7 @@ There are also links to normal bindings to style the tree itself.
 Normal
 EndOfBuffer
 CursorLine
-WinSeparator
+VertSplit
 CursorColumn
 
 There are also links for file highlight with git properties

--- a/lua/nvim-tree/colors.lua
+++ b/lua/nvim-tree/colors.lua
@@ -64,7 +64,7 @@ local function get_links()
     NormalNC = "NvimTreeNormal",
     EndOfBuffer = "EndOfBuffer",
     CursorLine = "CursorLine",
-    WinSeparator = "WinSeparator",
+    VertSplit = "VertSplit",
     CursorColumn = "CursorColumn",
     FileDirty = "NvimTreeGitDirty",
     FileNew = "NvimTreeGitNew",

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -27,7 +27,7 @@ M.View = {
       "EndOfBuffer:NvimTreeEndOfBuffer",
       "Normal:NvimTreeNormal",
       "CursorLine:NvimTreeCursorLine",
-      "WinSeparator:NvimTreeWinSeparator",
+      "VertSplit:NvimTreeVertSplit",
       "StatusLine:NvimTreeStatusLine",
       "StatusLineNC:NvimTreeStatuslineNC",
       "SignColumn:NvimTreeSignColumn",


### PR DESCRIPTION
Reverts kyazdani42/nvim-tree.lua#1219

See #1221

`WinSeparator` is not available as a built-in highlight group for many users.