### PR TITLE
1221 handle deprecated vert split

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -872,11 +872,12 @@ NvimTreeWindowPicker
 
 There are also links to normal bindings to style the tree itself.
 
-Normal
-EndOfBuffer
-CursorLine
-VertSplit
-CursorColumn
+NvimTreeNormal
+NvimTreeEndOfBuffer
+NvimTreeCursorLine
+NvimTreeVertSplit (deprecated, use NvimTreeWinSeparator)
+NvimTreeWinSeparator
+NvimTreeCursorColumn
 
 There are also links for file highlight with git properties
 These all link to there Git equivalent

--- a/lua/nvim-tree/colors.lua
+++ b/lua/nvim-tree/colors.lua
@@ -65,6 +65,7 @@ local function get_links()
     EndOfBuffer = "EndOfBuffer",
     CursorLine = "CursorLine",
     VertSplit = "VertSplit",
+    WinSeparator = "NvimTreeVertSplit",
     CursorColumn = "CursorColumn",
     FileDirty = "NvimTreeGitDirty",
     FileNew = "NvimTreeGitNew",

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -27,7 +27,8 @@ M.View = {
       "EndOfBuffer:NvimTreeEndOfBuffer",
       "Normal:NvimTreeNormal",
       "CursorLine:NvimTreeCursorLine",
-      "VertSplit:NvimTreeVertSplit",
+      -- #1221 WinSeparator not present in nvim 0.6.1 and some builds of 0.7.0
+      pcall(vim.cmd, "silent hi WinSeparator") and "WinSeparator:NvimTreeWinSeparator" or "VertSplit:NvimTreeWinSeparator",
       "StatusLine:NvimTreeStatusLine",
       "StatusLineNC:NvimTreeStatuslineNC",
       "SignColumn:NvimTreeSignColumn",


### PR DESCRIPTION
closes #1221

- detect `WinSeparator`, falls back to `VertSplit`
- `NvimTreeWinSeparator` defaults to `NvimTreeVertSplit`

We could put a warning about this deprecation however I do not think it is worth it.