### PR TITLE
Tweak Bug Report Form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -58,7 +58,7 @@ body:
   - type: textarea
     attributes:
       label: "Minimal config"
-      description: "Minimal(!) configuration necessary to reproduce the issue, using the latest version. Save [nvt-min.lua]() to `/tmp` and run using `nvim -nu /tmp/nvt-min.lua`. If _absolutely_ necessary, add plugins and modify the nvim-tree setup at the indicated lines."
+      description: "Minimal(!) configuration necessary to reproduce the issue, using the latest version. Save [nvt-min.lua](.github/ISSUE_TEMPLATE/nvt-min.lua) to `/tmp` and run using `nvim -nu /tmp/nvt-min.lua`. If _absolutely_ necessary, add plugins and modify the nvim-tree setup at the indicated lines."
       render: Lua
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -58,7 +58,7 @@ body:
   - type: textarea
     attributes:
       label: "Minimal config"
-      description: "Minimal(!) configuration necessary to reproduce the issue, using the latest version.
+      description: "Minimal(!) configuration necessary to reproduce the issue, using the latest version.<CR>
         (Right click) save [nvt-min.lua](https://raw.githubusercontent.com/alex-courtis/nvim-tree.lua/master/.github/ISSUE_TEMPLATE/nvt-min.lua) to `/tmp` and run using `nvim -nu /tmp/nvt-min.lua`.
         If _absolutely_ necessary, add plugins and modify the nvim-tree setup at the indicated lines."
       render: lua

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -58,7 +58,7 @@ body:
   - type: textarea
     attributes:
       label: "Minimal config"
-      description: "Minimal(!) configuration necessary to reproduce the issue, using the latest version. Save [nvt-min.lua](lua/nvim-tree.lua) to `/tmp` and run using `nvim -nu /tmp/nvt-min.lua`. If _absolutely_ necessary, add plugins and modify the nvim-tree setup at the indicated lines."
+      description: "Minimal(!) configuration necessary to reproduce the issue, using the latest version. Save [nvt-min.lua](blob/master/lua/nvim-tree.lua) to `/tmp` and run using `nvim -nu /tmp/nvt-min.lua`. If _absolutely_ necessary, add plugins and modify the nvim-tree setup at the indicated lines."
       render: Lua
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -39,6 +39,19 @@ body:
       required: true
   - type: textarea
     attributes:
+      label: "Minimal config"
+      description: "Minimal(!) configuration necessary to reproduce the issue, using the latest version.
+
+        (Right click) save [nvt-min.lua](https://raw.githubusercontent.com/alex-courtis/nvim-tree.lua/master/.github/ISSUE_TEMPLATE/nvt-min.lua) to `/tmp` and run using `nvim -nu /tmp/nvt-min.lua`
+
+        If _absolutely_ necessary, add plugins and modify the nvim-tree setup at the indicated lines.
+
+        Paste the contents of `/tmp/nvt-min.lua` here."
+      render: lua
+    validations:
+      required: true
+  - type: textarea
+    attributes:
       label: "Steps to reproduce"
       description: "Steps to reproduce using the minimal config provided below."
       placeholder: |
@@ -55,15 +68,4 @@ body:
     attributes:
       label: "Actual behavior"
       description: "Observed behavior (may optionally include images, videos or a screencast)."
-  - type: textarea
-    attributes:
-      label: "Minimal config"
-      description: "Minimal(!) configuration necessary to reproduce the issue, using the latest version.
-
-        (Right click) save [nvt-min.lua](https://raw.githubusercontent.com/alex-courtis/nvim-tree.lua/master/.github/ISSUE_TEMPLATE/nvt-min.lua) to `/tmp` and run using `nvim -nu /tmp/nvt-min.lua`.
-
-        If _absolutely_ necessary, add plugins and modify the nvim-tree setup at the indicated lines."
-      render: lua
-    validations:
-      required: true
  

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -58,7 +58,7 @@ body:
   - type: textarea
     attributes:
       label: "Minimal config"
-      description: "Minimal(!) configuration necessary to reproduce the issue, using the latest version. Save [nvt-min.lua](.github/ISSUE_TEMPLATE/nvt-min.lua) to `/tmp` and run using `nvim -nu /tmp/nvt-min.lua`. If _absolutely_ necessary, add plugins and modify the nvim-tree setup at the indicated lines."
+      description: "Minimal(!) configuration necessary to reproduce the issue, using the latest version. Save [nvt-min.lua](nvt-min.lua) to `/tmp` and run using `nvim -nu /tmp/nvt-min.lua`. If _absolutely_ necessary, add plugins and modify the nvim-tree setup at the indicated lines."
       render: Lua
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,13 +40,13 @@ body:
   - type: textarea
     attributes:
       label: "Minimal config"
-      description: "Minimal(!) configuration necessary to reproduce the issue, using the latest version.
+      description: "Minimal(!) configuration necessary to reproduce the issue.
 
         (Right click) save [nvt-min.lua](https://raw.githubusercontent.com/alex-courtis/nvim-tree.lua/master/.github/ISSUE_TEMPLATE/nvt-min.lua) to `/tmp` and run using `nvim -nu /tmp/nvt-min.lua`
 
         If _absolutely_ necessary, add plugins and modify the nvim-tree setup at the indicated lines.
 
-        Paste the contents of `/tmp/nvt-min.lua` here."
+        Paste the contents of your `/tmp/nvt-min.lua` here."
       render: lua
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -58,7 +58,7 @@ body:
   - type: textarea
     attributes:
       label: "Minimal config"
-      description: "Minimal(!) configuration necessary to reproduce the issue, using the latest version. Save [nvt-min.lua](/blob/master/lua/nvim-tree.lua) to `/tmp` and run using `nvim -nu /tmp/nvt-min.lua`. If _absolutely_ necessary, add plugins and modify the nvim-tree setup at the indicated lines."
+      description: "Minimal(!) configuration necessary to reproduce the issue, using the latest version. Save [nvt-min.lua](https://raw.githubusercontent.com/alex-courtis/nvim-tree.lua/master/.github/ISSUE_TEMPLATE/nvt-min.lua) to `/tmp` and run using `nvim -nu /tmp/nvt-min.lua`. If _absolutely_ necessary, add plugins and modify the nvim-tree setup at the indicated lines."
       render: Lua
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,7 +16,6 @@ body:
     attributes:
       label: "Neovim version"
       description: "Output of `nvim --version`. Please see nvim-tree.lua [minimum required version](https://github.com/kyazdani42/nvim-tree.lua#notice)."
-      render: markdown
       placeholder: |
         NVIM v0.6.1
         Build type&#58 Release
@@ -59,7 +58,7 @@ body:
     attributes:
       label: "Minimal config"
       description: "Minimal(!) configuration necessary to reproduce the issue, using the latest version. Save [nvt-min.lua](https://raw.githubusercontent.com/alex-courtis/nvim-tree.lua/master/.github/ISSUE_TEMPLATE/nvt-min.lua) to `/tmp` and run using `nvim -nu /tmp/nvt-min.lua`. If _absolutely_ necessary, add plugins and modify the nvim-tree setup at the indicated lines."
-      render: Lua
+      render: lua
     validations:
       required: true
  

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -58,8 +58,10 @@ body:
   - type: textarea
     attributes:
       label: "Minimal config"
-      description: "Minimal(!) configuration necessary to reproduce the issue, using the latest version.<CR>
+      description: "Minimal(!) configuration necessary to reproduce the issue, using the latest version.
+
         (Right click) save [nvt-min.lua](https://raw.githubusercontent.com/alex-courtis/nvim-tree.lua/master/.github/ISSUE_TEMPLATE/nvt-min.lua) to `/tmp` and run using `nvim -nu /tmp/nvt-min.lua`.
+
         If _absolutely_ necessary, add plugins and modify the nvim-tree setup at the indicated lines."
       render: lua
     validations:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -58,7 +58,7 @@ body:
   - type: textarea
     attributes:
       label: "Minimal config"
-      description: "Minimal(!) configuration necessary to reproduce the issue, using the latest version. Save [nvt-min.lua](nvt-min.lua) to `/tmp` and run using `nvim -nu /tmp/nvt-min.lua`. If _absolutely_ necessary, add plugins and modify the nvim-tree setup at the indicated lines."
+      description: "Minimal(!) configuration necessary to reproduce the issue, using the latest version. Save [nvt-min.lua](.github/ISSUE_TEMPLATE/nvt-min.lua) to `/tmp` and run using `nvim -nu /tmp/nvt-min.lua`. If _absolutely_ necessary, add plugins and modify the nvim-tree setup at the indicated lines."
       render: Lua
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -58,7 +58,7 @@ body:
   - type: textarea
     attributes:
       label: "Minimal config"
-      description: "Minimal(!) configuration necessary to reproduce the issue, using the latest version. Save [nvt-min.lua](.github/ISSUE_TEMPLATE/nvt-min.lua) to `/tmp` and run using `nvim -nu /tmp/nvt-min.lua`. If _absolutely_ necessary, add plugins and modify the nvim-tree setup at the indicated lines."
+      description: "Minimal(!) configuration necessary to reproduce the issue, using the latest version. Save [nvt-min.lua](lua/nvim-tree.lua) to `/tmp` and run using `nvim -nu /tmp/nvt-min.lua`. If _absolutely_ necessary, add plugins and modify the nvim-tree setup at the indicated lines."
       render: Lua
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -42,7 +42,7 @@ body:
       label: "Minimal config"
       description: "Minimal(!) configuration necessary to reproduce the issue.
 
-        (Right click) save [nvt-min.lua](https://raw.githubusercontent.com/alex-courtis/nvim-tree.lua/master/.github/ISSUE_TEMPLATE/nvt-min.lua) to `/tmp` and run using `nvim -nu /tmp/nvt-min.lua`
+        (Right click) save [nvt-min.lua](https://raw.githubusercontent.com/kyazdani42/nvim-tree.lua/master/.github/ISSUE_TEMPLATE/nvt-min.lua) to `/tmp` and run using `nvim -nu /tmp/nvt-min.lua`
 
         If _absolutely_ necessary, add plugins and modify the nvim-tree setup at the indicated lines.
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -42,8 +42,8 @@ body:
       label: "Steps to reproduce"
       description: "Steps to reproduce using the minimal config provided below."
       placeholder: |
-        1. `nvim -nu /tmp/nvt-min.lua`
-        2. `:NvimTreeOpen`
+        1. nvim -nu /tmp/nvt-min.lua
+        2. :NvimTreeOpen
         3. ...
     validations:
       required: true
@@ -58,42 +58,8 @@ body:
   - type: textarea
     attributes:
       label: "Minimal config"
-      description: "Minimal(!) configuration necessary to reproduce the issue, using the latest version. Save this as `/tmp/nvt-min.lua` and run using `nvim -nu /tmp/nvt-min.lua`. If _absolutely_ necessary, add plugins and modify the nvim-tree setup at the indicated lines."
+      description: "Minimal(!) configuration necessary to reproduce the issue, using the latest version. Save [nvt-min.lua]() to `/tmp` and run using `nvim -nu /tmp/nvt-min.lua`. If _absolutely_ necessary, add plugins and modify the nvim-tree setup at the indicated lines."
       render: Lua
-      value: |
-        vim.cmd [[set runtimepath=$VIMRUNTIME]]
-        vim.cmd [[set packpath=/tmp/nvt-min/site]]
-        local package_root = "/tmp/nvt-min/site/pack"
-        local install_path = package_root .. "/packer/start/packer.nvim"
-        local function load_plugins()
-          require("packer").startup {
-            {
-              "wbthomason/packer.nvim",
-              "kyazdani42/nvim-tree.lua",
-              "kyazdani42/nvim-web-devicons",
-              -- ADD PLUGINS THAT ARE _NECESSARY_ FOR REPRODUCING THE ISSUE
-            },
-            config = {
-              package_root = package_root,
-              compile_path = install_path .. "/plugin/packer_compiled.lua",
-              display = { non_interactive = true },
-            },
-          }
-        end
-        if vim.fn.isdirectory(install_path) == 0 then
-          print "Installing nvim-tree and dependencies."
-          vim.fn.system { "git", "clone", "--depth=1", "https://github.com/wbthomason/packer.nvim", install_path }
-        end
-        load_plugins()
-        require("packer").sync()
-        vim.cmd [[autocmd User PackerComplete ++once echo "Ready!" | lua setup()]]
-        vim.opt.termguicolors = true
-        vim.opt.cursorline = true
-        
-        -- MODIFY NVIM-TREE SETTINGS THAT ARE _NECESSARY_ FOR REPRODUCING THE ISSUE
-        _G.setup = function()
-          require("nvim-tree").setup {}
-        end
     validations:
       required: true
  

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -20,6 +20,7 @@ body:
         NVIM v0.6.1
         Build type&#58 Release
         LuaJIT 2.1.0-beta3
+      render: text
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -58,7 +58,7 @@ body:
   - type: textarea
     attributes:
       label: "Minimal config"
-      description: "Minimal(!) configuration necessary to reproduce the issue, using the latest version. Save [nvt-min.lua](blob/master/lua/nvim-tree.lua) to `/tmp` and run using `nvim -nu /tmp/nvt-min.lua`. If _absolutely_ necessary, add plugins and modify the nvim-tree setup at the indicated lines."
+      description: "Minimal(!) configuration necessary to reproduce the issue, using the latest version. Save [nvt-min.lua](/blob/master/lua/nvim-tree.lua) to `/tmp` and run using `nvim -nu /tmp/nvt-min.lua`. If _absolutely_ necessary, add plugins and modify the nvim-tree setup at the indicated lines."
       render: Lua
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -58,7 +58,9 @@ body:
   - type: textarea
     attributes:
       label: "Minimal config"
-      description: "Minimal(!) configuration necessary to reproduce the issue, using the latest version. Save [nvt-min.lua](https://raw.githubusercontent.com/alex-courtis/nvim-tree.lua/master/.github/ISSUE_TEMPLATE/nvt-min.lua) to `/tmp` and run using `nvim -nu /tmp/nvt-min.lua`. If _absolutely_ necessary, add plugins and modify the nvim-tree setup at the indicated lines."
+      description: "Minimal(!) configuration necessary to reproduce the issue, using the latest version.
+        (Right click) save [nvt-min.lua](https://raw.githubusercontent.com/alex-courtis/nvim-tree.lua/master/.github/ISSUE_TEMPLATE/nvt-min.lua) to `/tmp` and run using `nvim -nu /tmp/nvt-min.lua`.
+        If _absolutely_ necessary, add plugins and modify the nvim-tree setup at the indicated lines."
       render: lua
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/nvt-min.lua
+++ b/.github/ISSUE_TEMPLATE/nvt-min.lua
@@ -1,0 +1,34 @@
+vim.cmd [[set runtimepath=$VIMRUNTIME]]
+vim.cmd [[set packpath=/tmp/nvt-min/site]]
+local package_root = "/tmp/nvt-min/site/pack"
+local install_path = package_root .. "/packer/start/packer.nvim"
+local function load_plugins()
+  require("packer").startup {
+    {
+      "wbthomason/packer.nvim",
+      "kyazdani42/nvim-tree.lua",
+      "kyazdani42/nvim-web-devicons",
+      -- ADD PLUGINS THAT ARE _NECESSARY_ FOR REPRODUCING THE ISSUE
+    },
+    config = {
+      package_root = package_root,
+      compile_path = install_path .. "/plugin/packer_compiled.lua",
+      display = { non_interactive = true },
+    },
+  }
+end
+if vim.fn.isdirectory(install_path) == 0 then
+  print "Installing nvim-tree and dependencies."
+  vim.fn.system { "git", "clone", "--depth=1", "https://github.com/wbthomason/packer.nvim", install_path }
+end
+load_plugins()
+require("packer").sync()
+vim.cmd [[autocmd User PackerComplete ++once echo "Ready!" | lua setup()]]
+vim.opt.termguicolors = true
+vim.opt.cursorline = true
+
+-- MODIFY NVIM-TREE SETTINGS THAT ARE _NECESSARY_ FOR REPRODUCING THE ISSUE
+_G.setup = function()
+  require("nvim-tree").setup {}
+end
+


### PR DESCRIPTION
Many bug reports are not using `nvt-min.lua`, just submitting the default.

This will "encourage" reporters to use it, with `nvt-min.lua` split out into a file.

@gegoune please can you test at https://github.com/alex-courtis/nvim-tree.lua/issues/new/choose . You will need to change the URL of nvt-min.lua `kyazdani42` -> `alex-courtis`.