### PR TITLE
#1228 close moves focus to previous win on current tab

### DIFF
--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -47,7 +47,6 @@ local tabinitial = {
 }
 
 local BUFNR_PER_TAB = {}
-local LAST_FOCUSED_WIN = nil
 local BUFFER_OPTIONS = {
   swapfile = false,
   buftype = "nofile",
@@ -173,8 +172,9 @@ function M.close()
   for _, win in pairs(a.nvim_list_wins()) do
     if tree_win ~= win and a.nvim_win_get_config(win).relative == "" then
       a.nvim_win_close(tree_win, true)
-      if tree_win == current_win and LAST_FOCUSED_WIN then
-        a.nvim_set_current_win(LAST_FOCUSED_WIN)
+      local prev_win = vim.fn.winnr "#" -- this tab only
+      if tree_win == current_win and prev_win > 0 then
+        a.nvim_set_current_win(vim.fn.win_getid(prev_win))
       end
       events._dispatch_on_tree_close()
       return
@@ -187,7 +187,6 @@ function M.open(options)
     return
   end
 
-  LAST_FOCUSED_WIN = a.nvim_get_current_win()
   create_buffer()
   open_window()
   set_window_options_and_buffer()


### PR DESCRIPTION
When closing the tree:
* focus the last used window in the current tab OR
* do not change focus

closes #1227 #1228