### PR TITLE
feat(renderer): set git icons in signcolumn

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -432,7 +432,10 @@ UI rendering setup
 	*nvim-tree.renderer.icons.git_placement*
 	Place where the git icons will be rendered.
 	After or before the `filename` (after the file/folders icons).
-	  Type: `after` or `before`, Default: `before`
+        When placed in the signcolumn, the value of signcolumn should be `yes`
+        for the nvim-tree window.
+        Note that the diagnostic signs will take precedence over the git signs.
+	  Type: `after`, `before` or `signcolumn`, Default: `before`
 
 *nvim-tree.filters*
 Filtering options.

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -432,9 +432,9 @@ UI rendering setup
 	*nvim-tree.renderer.icons.git_placement*
 	Place where the git icons will be rendered.
 	After or before the `filename` (after the file/folders icons).
-        When placed in the signcolumn, the value of signcolumn should be `yes`
-        for the nvim-tree window.
-        Note that the diagnostic signs will take precedence over the git signs.
+	When placed in the signcolumn, the value of signcolumn should be `yes`
+	for the nvim-tree window.
+	Note that the diagnostic signs will take precedence over the git signs.
 	  Type: `after`, `before` or `signcolumn`, Default: `before`
 
 *nvim-tree.filters*

--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -32,7 +32,7 @@ local function add_sign(linenr, severity)
     return
   end
   local sign_name = sign_names[severity][1]
-  vim.fn.sign_place(1, GROUP, sign_name, buf, { lnum = linenr, priority = 2 })
+  vim.fn.sign_place(0, GROUP, sign_name, buf, { lnum = linenr, priority = 2 })
 end
 
 local function from_nvim_lsp()

--- a/lua/nvim-tree/diagnostics.lua
+++ b/lua/nvim-tree/diagnostics.lua
@@ -32,7 +32,7 @@ local function add_sign(linenr, severity)
     return
   end
   local sign_name = sign_names[severity][1]
-  vim.fn.sign_place(1, GROUP, sign_name, buf, { lnum = linenr })
+  vim.fn.sign_place(1, GROUP, sign_name, buf, { lnum = linenr, priority = 2 })
 end
 
 local function from_nvim_lsp()

--- a/lua/nvim-tree/renderer/builder.lua
+++ b/lua/nvim-tree/renderer/builder.lua
@@ -14,6 +14,7 @@ function Builder.new(root_cwd)
     highlights = {},
     lines = {},
     markers = {},
+    signs = {},
     root_cwd = root_cwd,
   }, Builder)
 end
@@ -61,9 +62,11 @@ function Builder:configure_git_icons_padding(padding)
 end
 
 function Builder:configure_git_icons_placement(where)
-  where = where or "before"
-  self.is_git_before = where == "before"
-  self.is_git_after = not self.is_git_before
+  if where == "signcolumn" then
+    vim.fn.sign_unplace(git.SIGN_GROUP)
+    self.is_git_sign = true
+  end
+  self.is_git_after = where == "after" and not self.is_git_sign
   return self
 end
 
@@ -109,7 +112,7 @@ function Builder:_build_folder(node, padding, git_hl, git_icons_tbl)
 
   local foldername = name .. self.trailing_slash
   local git_icons = self:_unwrap_git_data(git_icons_tbl, offset + #icon + (self.is_git_after and #foldername + 1 or 0))
-  local fname_starts_at = offset + #icon + (self.is_git_before and #git_icons or 0)
+  local fname_starts_at = offset + #icon + (self.is_git_after and 0 or #git_icons)
   local line = self:_format_line(padding .. icon, foldername, git_icons)
   self:_insert_line(line)
 
@@ -226,6 +229,12 @@ function Builder:_build_line(tree, node, idx)
   local git_highlight = git.get_highlight(node)
   local git_icons_tbl = git.get_icons(node)
 
+  if self.is_git_sign and git_icons_tbl and #git_icons_tbl > 0 then
+    local git_info = git_icons_tbl[1]
+    table.insert(self.signs, { sign = git_info.hl, lnum = self.index + 1 })
+    git_icons_tbl = {}
+  end
+
   local is_folder = node.nodes ~= nil
   local is_symlink = node.link_to ~= nil
 
@@ -270,7 +279,7 @@ function Builder:build_header(show_header)
 end
 
 function Builder:unwrap()
-  return self.lines, self.highlights
+  return self.lines, self.highlights, self.signs
 end
 
 return Builder

--- a/lua/nvim-tree/renderer/components/git.lua
+++ b/lua/nvim-tree/renderer/components/git.lua
@@ -1,7 +1,9 @@
 local _icons = require "nvim-tree.renderer.icon-config"
 local utils = require "nvim-tree.utils"
 
-local M = {}
+local M = {
+  SIGN_GROUP = "NvimTreeGitSigns"
+}
 
 local function build_icons_table()
   local i = M.icon_state.icons.git_icons
@@ -123,6 +125,17 @@ local git_hl = {
   ["!!"] = "NvimTreeGitIgnored",
   [" A"] = "none",
 }
+
+function M.setup_signs()
+  local i = M.icon_state.icons.git_icons
+  vim.fn.sign_define("NvimTreeGitDirty",     { text = i.unstaged,  texthl = "NvimTreeGitDirty" })
+  vim.fn.sign_define("NvimTreeGitStaged",    { text = i.staged,    texthl = "NvimTreeGitStaged" })
+  vim.fn.sign_define("NvimTreeGitMerge",     { text = i.unmerged,  texthl = "NvimTreeGitMerge" })
+  vim.fn.sign_define("NvimTreeGitRenamed",   { text = i.renamed,   texthl = "NvimTreeGitRenamed" })
+  vim.fn.sign_define("NvimTreeGitNew",       { text = i.untracked, texthl = "NvimTreeGitNew" })
+  vim.fn.sign_define("NvimTreeGitDeleted",   { text = i.deleted,   texthl = "NvimTreeGitDeleted" })
+  vim.fn.sign_define("NvimTreeGitIgnored",   { text = i.ignored,   texthl = "NvimTreeGitIgnored" })
+end
 
 local function get_highlight_(node)
   local git_status = node.git_status

--- a/lua/nvim-tree/renderer/components/git.lua
+++ b/lua/nvim-tree/renderer/components/git.lua
@@ -2,7 +2,7 @@ local _icons = require "nvim-tree.renderer.icon-config"
 local utils = require "nvim-tree.utils"
 
 local M = {
-  SIGN_GROUP = "NvimTreeGitSigns"
+  SIGN_GROUP = "NvimTreeGitSigns",
 }
 
 local function build_icons_table()
@@ -128,13 +128,13 @@ local git_hl = {
 
 function M.setup_signs()
   local i = M.icon_state.icons.git_icons
-  vim.fn.sign_define("NvimTreeGitDirty",     { text = i.unstaged,  texthl = "NvimTreeGitDirty" })
-  vim.fn.sign_define("NvimTreeGitStaged",    { text = i.staged,    texthl = "NvimTreeGitStaged" })
-  vim.fn.sign_define("NvimTreeGitMerge",     { text = i.unmerged,  texthl = "NvimTreeGitMerge" })
-  vim.fn.sign_define("NvimTreeGitRenamed",   { text = i.renamed,   texthl = "NvimTreeGitRenamed" })
-  vim.fn.sign_define("NvimTreeGitNew",       { text = i.untracked, texthl = "NvimTreeGitNew" })
-  vim.fn.sign_define("NvimTreeGitDeleted",   { text = i.deleted,   texthl = "NvimTreeGitDeleted" })
-  vim.fn.sign_define("NvimTreeGitIgnored",   { text = i.ignored,   texthl = "NvimTreeGitIgnored" })
+  vim.fn.sign_define("NvimTreeGitDirty", { text = i.unstaged, texthl = "NvimTreeGitDirty" })
+  vim.fn.sign_define("NvimTreeGitStaged", { text = i.staged, texthl = "NvimTreeGitStaged" })
+  vim.fn.sign_define("NvimTreeGitMerge", { text = i.unmerged, texthl = "NvimTreeGitMerge" })
+  vim.fn.sign_define("NvimTreeGitRenamed", { text = i.renamed, texthl = "NvimTreeGitRenamed" })
+  vim.fn.sign_define("NvimTreeGitNew", { text = i.untracked, texthl = "NvimTreeGitNew" })
+  vim.fn.sign_define("NvimTreeGitDeleted", { text = i.deleted, texthl = "NvimTreeGitDeleted" })
+  vim.fn.sign_define("NvimTreeGitIgnored", { text = i.ignored, texthl = "NvimTreeGitIgnored" })
 end
 
 local function get_highlight_(node)

--- a/lua/nvim-tree/renderer/init.lua
+++ b/lua/nvim-tree/renderer/init.lua
@@ -23,7 +23,7 @@ local function _draw(bufnr, lines, hl, signs)
   M.render_hl(bufnr, hl)
   api.nvim_buf_set_option(bufnr, "modifiable", false)
   for _, sign in pairs(signs) do
-    vim.fn.sign_place(1, git.SIGN_GROUP, sign.sign, bufnr, { lnum = sign.lnum, priority = 1 })
+    vim.fn.sign_place(0, git.SIGN_GROUP, sign.sign, bufnr, { lnum = sign.lnum, priority = 1 })
   end
 end
 

--- a/lua/nvim-tree/renderer/init.lua
+++ b/lua/nvim-tree/renderer/init.lua
@@ -17,11 +17,14 @@ local M = {
 
 local namespace_id = api.nvim_create_namespace "NvimTreeHighlights"
 
-local function _draw(bufnr, lines, hl)
+local function _draw(bufnr, lines, hl, signs)
   api.nvim_buf_set_option(bufnr, "modifiable", true)
   api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
   M.render_hl(bufnr, hl)
   api.nvim_buf_set_option(bufnr, "modifiable", false)
+  for _, sign in pairs(signs) do
+    vim.fn.sign_place(1, git.SIGN_GROUP, sign.sign, bufnr, { lnum = sign.lnum, priority = 1 })
+  end
 end
 
 function M.render_hl(bufnr, hl)
@@ -71,10 +74,11 @@ function M.draw()
   git.reload()
 
   local lines, hl
+  local signs = {}
   if view.is_help_ui() then
     lines, hl = help.compute_lines()
   else
-    lines, hl = Builder.new(core.get_cwd())
+    lines, hl, signs = Builder.new(core.get_cwd())
       :configure_initial_depth(should_show_arrows())
       :configure_root_modifier(vim.g.nvim_tree_root_folder_modifier)
       :configure_trailing_slash(vim.g.nvim_tree_add_trailing == 1)
@@ -88,7 +92,8 @@ function M.draw()
       :unwrap()
   end
 
-  _draw(bufnr, lines, hl)
+  _draw(bufnr, lines, hl, signs)
+
   M.last_highlights = hl
 
   if cursor and #lines >= cursor[1] then
@@ -111,6 +116,7 @@ function M.setup(opts)
   }
 
   _padding.setup(opts)
+  git.setup_signs()
 end
 
 return M


### PR DESCRIPTION
This is a work in progress. It works as is but there are some caveat that i'd like to discuss first.

Right, now, we will display the first icon returned by the list of icons from the node. Should we have a smarter way of doing that ?
Also, if displaying only one icons in signs, should we also always display one icon (after and before filename for instance ?)

TODO:
- [x] documentation

Fixes #553