### PR TITLE
#1217 show git status for link targets, when no status on the link itself

### DIFF
--- a/lua/nvim-tree/explorer/common.lua
+++ b/lua/nvim-tree/explorer/common.lua
@@ -2,8 +2,41 @@ local uv = vim.loop
 
 local M = {}
 
+local function get_dir_git_status(parent_ignored, status, absolute_path)
+  if parent_ignored then
+    return "!!"
+  end
+  local dir_status = status.dirs and status.dirs[absolute_path]
+  local file_status = status.files and status.files[absolute_path]
+  return dir_status or file_status
+end
+
+local function get_git_status(parent_ignored, status, absolute_path)
+  return parent_ignored and "!!" or status.files and status.files[absolute_path]
+end
+
 function M.has_one_child_folder(node)
   return #node.nodes == 1 and node.nodes[1].nodes and uv.fs_access(node.nodes[1].absolute_path, "R")
 end
 
+function M.update_git_status(node, parent_ignored, status)
+
+  -- status of the node's absolute path
+  if node.nodes then
+    node.git_status = get_dir_git_status(parent_ignored, status, node.absolute_path)
+  else
+    node.git_status = get_git_status(parent_ignored, status, node.absolute_path)
+  end
+
+  -- status of the link target, if the link itself is not dirty
+  if node.link_to and not node.git_status then
+    if node.nodes then
+      node.git_status = get_dir_git_status(parent_ignored, status, node.link_to)
+    else
+      node.git_status = get_git_status(parent_ignored, status, node.link_to)
+    end
+  end
+end
+
 return M
+

--- a/lua/nvim-tree/explorer/common.lua
+++ b/lua/nvim-tree/explorer/common.lua
@@ -20,7 +20,6 @@ function M.has_one_child_folder(node)
 end
 
 function M.update_git_status(node, parent_ignored, status)
-
   -- status of the node's absolute path
   if node.nodes then
     node.git_status = get_dir_git_status(parent_ignored, status, node.absolute_path)
@@ -39,4 +38,3 @@ function M.update_git_status(node, parent_ignored, status)
 end
 
 return M
-

--- a/lua/nvim-tree/explorer/explore.lua
+++ b/lua/nvim-tree/explorer/explore.lua
@@ -29,15 +29,20 @@ local function populate_children(handle, cwd, node, status)
       and not filters.should_ignore_git(abs, status.files)
       and not nodes_by_path[abs]
     then
+      local child = nil
       if t == "directory" and uv.fs_access(abs, "R") then
-        table.insert(node.nodes, builders.folder(node, abs, name, status, node_ignored))
+        child = builders.folder(node, abs, name, status, node_ignored)
       elseif t == "file" then
-        table.insert(node.nodes, builders.file(node, abs, name, status, node_ignored))
+        child = builders.file(node, abs, name, status, node_ignored)
       elseif t == "link" then
         local link = builders.link(node, abs, name, status, node_ignored)
         if link.link_to ~= nil then
-          table.insert(node.nodes, link)
+          child = link
         end
+      end
+      if child then
+        table.insert(node.nodes, child)
+        common.update_git_status(child, node_ignored, status)
       end
     end
   end

--- a/lua/nvim-tree/explorer/node-builders.lua
+++ b/lua/nvim-tree/explorer/node-builders.lua
@@ -5,19 +5,6 @@ local M = {
   is_windows = vim.fn.has "win32" == 1,
 }
 
-function M.get_dir_git_status(parent_ignored, status, absolute_path)
-  if parent_ignored then
-    return "!!"
-  end
-  local dir_status = status.dirs and status.dirs[absolute_path]
-  local file_status = status.files and status.files[absolute_path]
-  return dir_status or file_status
-end
-
-function M.get_git_status(parent_ignored, status, absolute_path)
-  return parent_ignored and "!!" or status.files and status.files[absolute_path]
-end
-
 function M.folder(parent, absolute_path, name, status, parent_ignored)
   local handle = uv.fs_scandir(absolute_path)
   local has_children = handle and uv.fs_scandir_next(handle) ~= nil
@@ -25,7 +12,6 @@ function M.folder(parent, absolute_path, name, status, parent_ignored)
   return {
     absolute_path = absolute_path,
     fs_stat = uv.fs_stat(absolute_path),
-    git_status = M.get_dir_git_status(parent_ignored, status, absolute_path),
     group_next = nil, -- If node is grouped, this points to the next child dir/link node
     has_children = has_children,
     name = name,
@@ -50,7 +36,6 @@ function M.file(parent, absolute_path, name, status, parent_ignored)
     executable = is_executable(absolute_path, ext),
     extension = ext,
     fs_stat = uv.fs_stat(absolute_path),
-    git_status = M.get_git_status(parent_ignored, status, absolute_path),
     name = name,
     parent = parent,
   }
@@ -75,7 +60,6 @@ function M.link(parent, absolute_path, name, status, parent_ignored)
   return {
     absolute_path = absolute_path,
     fs_stat = uv.fs_stat(absolute_path),
-    git_status = M.get_git_status(parent_ignored, status, absolute_path),
     group_next = nil, -- If node is grouped, this points to the next child dir/link node
     has_children = has_children,
     link_to = link_to,

--- a/lua/nvim-tree/explorer/node-builders.lua
+++ b/lua/nvim-tree/explorer/node-builders.lua
@@ -5,7 +5,7 @@ local M = {
   is_windows = vim.fn.has "win32" == 1,
 }
 
-function M.folder(parent, absolute_path, name, status, parent_ignored)
+function M.folder(parent, absolute_path, name)
   local handle = uv.fs_scandir(absolute_path)
   local has_children = handle and uv.fs_scandir_next(handle) ~= nil
 
@@ -28,7 +28,7 @@ local function is_executable(absolute_path, ext)
   return uv.fs_access(absolute_path, "X")
 end
 
-function M.file(parent, absolute_path, name, status, parent_ignored)
+function M.file(parent, absolute_path, name)
   local ext = string.match(name, ".?[^.]+%.(.*)") or ""
 
   return {
@@ -46,7 +46,7 @@ end
 -- links (for instance libr2.so in /usr/lib) and thus even with a C program realpath fails
 -- when it has no real reason to. Maybe there is a reason, but errno is definitely wrong.
 -- So we need to check for link_to ~= nil when adding new links to the main tree
-function M.link(parent, absolute_path, name, status, parent_ignored)
+function M.link(parent, absolute_path, name)
   --- I dont know if this is needed, because in my understanding, there isnt hard links in windows, but just to be sure i changed it.
   local link_to = uv.fs_realpath(absolute_path)
   local open, nodes, has_children

--- a/lua/nvim-tree/explorer/reload.lua
+++ b/lua/nvim-tree/explorer/reload.lua
@@ -12,11 +12,7 @@ local M = {}
 local function update_status(nodes_by_path, node_ignored, status)
   return function(node)
     if nodes_by_path[node.absolute_path] then
-      if node.nodes then
-        node.git_status = builders.get_dir_git_status(node_ignored, status, node.absolute_path)
-      else
-        node.git_status = builders.get_git_status(node_ignored, status, node.absolute_path)
-      end
+      common.update_git_status(node, node_ignored, status)
     end
     return node
   end


### PR DESCRIPTION
closes #1217

naive attempt d81586e419adeee5007257827852fc030f3476a3 was ugly and duplicated logic, hence the refactor.

Priority for git status:
1. link itself: added or untracked
2. link target

Tested:
- Dirty hard/soft link:
  - untracked
  - added
- Clean soft link to:
  - file
  - folder
  - another link
- Clean hard link to:
  - file
  - another hard link
- Clean soft folder link:
   - open
   - closed
- External modification and reload