### PR TITLE
feat: reload explorer on buf enter

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ require'nvim-tree'.setup { -- BEGIN_DEFAULT_OPTS
   open_on_tab = false,
   sort_by = "name",
   update_cwd = false,
+  reload_on_bufenter = false,
   view = {
     width = 30,
     height = 30,

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ require'nvim-tree'.setup { -- BEGIN_DEFAULT_OPTS
     icons = {
       webdev_colors = true,
       git_placement = "before",
-    }
+    },
   },
   hijack_directories = {
     enable = true,

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -96,6 +96,7 @@ Values may be functions. Warning: this may result in unexpected behaviour.
       open_on_tab = false,
       sort_by = "name",
       update_cwd = false,
+      reload_on_bufenter = false,
       view = {
         width = 30,
         height = 30,
@@ -124,7 +125,7 @@ Values may be functions. Warning: this may result in unexpected behaviour.
         icons = {
           webdev_colors = true,
           git_placement = "before",
-        }
+        },
       },
       hijack_directories = {
         enable = true,
@@ -260,7 +261,7 @@ Changes the tree root directory on `DirChanged` and refreshes the tree.
   Type: `boolean`, Default: `false`
 
 *nvim-tree.reload_on_bufenter
-Automatically reloads the tree on `BufEnter`.
+Automatically reloads the tree on `BufEnter` nvim-tree.
   Type: `boolean`, Default: `false`
 
 *nvim-tree.hijack_directories*

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -260,7 +260,7 @@ Keeps the cursor on the first letter of the filename when moving in the tree.
 Changes the tree root directory on `DirChanged` and refreshes the tree.
   Type: `boolean`, Default: `false`
 
-*nvim-tree.reload_on_bufenter
+*nvim-tree.reload_on_bufenter*
 Automatically reloads the tree on `BufEnter` nvim-tree.
   Type: `boolean`, Default: `false`
 

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -259,6 +259,10 @@ Keeps the cursor on the first letter of the filename when moving in the tree.
 Changes the tree root directory on `DirChanged` and refreshes the tree.
   Type: `boolean`, Default: `false`
 
+*nvim-tree.reload_on_bufenter
+Automatically reloads the tree on `BufEnter`.
+  Type: `boolean`, Default: `false`
+
 *nvim-tree.hijack_directories*
 hijacks new directory buffers when they are opened (`:e dir`).
 

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -336,6 +336,8 @@ local function setup_autocommands(opts)
   if opts.hijack_directories.enable then
     create_nvim_tree_autocmd({ "BufEnter", "BufNewFile" }, { callback = M.open_on_directory })
   end
+
+  create_nvim_tree_autocmd("BufEnter", { pattern = "NvimTree_*", callback = reloaders.reload_explorer })
 end
 
 local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -337,7 +337,9 @@ local function setup_autocommands(opts)
     create_nvim_tree_autocmd({ "BufEnter", "BufNewFile" }, { callback = M.open_on_directory })
   end
 
-  create_nvim_tree_autocmd("BufEnter", { pattern = "NvimTree_*", callback = reloaders.reload_explorer })
+  if opts.reload_on_bufenter then
+    create_nvim_tree_autocmd("BufEnter", { pattern = "NvimTree_*", callback = reloaders.reload_explorer })
+  end
 end
 
 local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
@@ -352,6 +354,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
   open_on_tab = false,
   sort_by = "name",
   update_cwd = false,
+  reload_on_bufenter = false,
   view = {
     width = 30,
     height = 30,


### PR DESCRIPTION
I found myself pressing `r` too often to update the tree.

I think this is a rather useful feature if you create/modify/delete files in the terminal. I don't really see downsides to this, but I can put it behind a config option if needed.