### PR TITLE
feat: Optional path argument for NvimTreeToggle and NvimTreeFindFileToggle

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -31,7 +31,7 @@ closes the tree
 
 |:NvimTreeToggle| 	                          *:NvimTreeToggle*
 
-open or close the tree
+open or close the tree. Takes an optional path argument.
 
 |:NvimTreeFocus| 	                          *:NvimTreeFocus*
 
@@ -52,7 +52,8 @@ It will also open the leafs of the tree leading to the file in the buffer
 |:NvimTreeFindFileToggle|			  *:NvimTreeFindFileToggle*
 
 close the tree or change the cursor in the tree for the current bufname,
-similar to combination of |:NvimTreeToggle| and |:NvimTreeFindFile|
+similar to combination of |:NvimTreeToggle| and |:NvimTreeFindFile. Takes an
+optional path argument.
 
 |:NvimTreeClipboard|			          *:NvimTreeClipboard*
 
@@ -233,7 +234,7 @@ Will ignore the buffer, when deciding to open the tree on setup.
   Type: `boolean`, Default: `false`
 
 *nvim-tree.ignore_ft_on_setup*
-List of filetypes that will make `open_on_setup` not open. 
+List of filetypes that will make `open_on_setup` not open.
 You can use this option if you don't want the tree to open
 in some scenarios (eg using vim startify).
   Type: {string}, Default: {}
@@ -411,7 +412,7 @@ Window / buffer setup.
       	Will use only the provided user mappings and not the default otherwise,
       	extends the default mappings with the provided user mappings.
       	  Type: `boolean`, Default: `false`
-  
+
 	*nvim-tree.view.mappings.list*
 	A list of keymaps that will extend or override the default keymaps.
 	  Type: list of { key: table of strings or string, mode: string (vim-mode), cb: callback function as a string }

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -52,7 +52,7 @@ It will also open the leafs of the tree leading to the file in the buffer
 |:NvimTreeFindFileToggle|			  *:NvimTreeFindFileToggle*
 
 close the tree or change the cursor in the tree for the current bufname,
-similar to combination of |:NvimTreeToggle| and |:NvimTreeFindFile. Takes an
+similar to combination of |:NvimTreeToggle| and |:NvimTreeFindFile|. Takes an
 optional path argument.
 
 |:NvimTreeClipboard|			          *:NvimTreeClipboard*

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -26,12 +26,12 @@ end
 ---@deprecated
 M.on_keypress = require("nvim-tree.actions").on_keypress
 
-function M.toggle(find_file, no_focus)
+function M.toggle(find_file, no_focus, cwd)
   if view.is_visible() then
     view.close()
   else
     local previous_buf = api.nvim_get_current_buf()
-    M.open()
+    M.open(cwd)
     if _config.update_focused_file.enable or find_file then
       M.find_file(false, previous_buf)
     end
@@ -259,18 +259,18 @@ local function setup_vim_commands()
     M.open(res.args)
   end, { nargs = "?", complete = "dir" })
   api.nvim_create_user_command("NvimTreeClose", view.close, {})
-  api.nvim_create_user_command("NvimTreeToggle", function()
-    M.toggle(false)
-  end, {})
+  api.nvim_create_user_command("NvimTreeToggle", function(res)
+    M.toggle(false, false, res.args)
+  end, { nargs = "?", complete = "dir" })
   api.nvim_create_user_command("NvimTreeFocus", M.focus, {})
   api.nvim_create_user_command("NvimTreeRefresh", reloaders.reload_explorer, {})
   api.nvim_create_user_command("NvimTreeClipboard", copy_paste.print_clipboard, {})
   api.nvim_create_user_command("NvimTreeFindFile", function()
     M.find_file(true)
   end, {})
-  api.nvim_create_user_command("NvimTreeFindFileToggle", function()
-    M.toggle(true)
-  end, {})
+  api.nvim_create_user_command("NvimTreeFindFileToggle", function(res)
+    M.toggle(true, false, res.args)
+  end, { nargs = "?", complete = "dir" })
   api.nvim_create_user_command("NvimTreeResize", function(res)
     M.resize(res.args)
   end, { nargs = 1 })


### PR DESCRIPTION
This just passes the path argument to NvimTreeOpen and ignores it if NvimTreeClose is called.