### PR TITLE
Ignore case when removing default mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Options are currently being migrated into the setup function, you need to run `r
 Setup should be run in a lua file or in a lua heredoc (`:help lua-heredoc`) if using in a vim file.
 Note that options under the `g:` command should be set **BEFORE** running the setup function.
 These are being migrated to the setup function incrementally, check [this issue](https://github.com/kyazdani42/nvim-tree.lua/issues/674) if you encounter any problems related to configs not working after update.
+
 ```vim
 " vimrc
 let g:nvim_tree_git_hl = 1 "0 by default, will enable file highlight for git attributes (can be used without the icons).
@@ -128,6 +129,9 @@ require'nvim-tree'.setup { -- BEGIN_DEFAULT_OPTS
   open_on_tab = false,
   sort_by = "name",
   update_cwd = false,
+  menu = {
+    actions = {}
+  },
   reload_on_bufenter = false,
   view = {
     width = 30,
@@ -279,6 +283,7 @@ require'nvim-tree'.setup { -- BEGIN_DEFAULT_OPTS
 ### Settings
 
 The `list` option in `view.mappings.list` is a table of
+
 ```lua
 -- key can be either a string or a table of string (lhs)
 -- action is the name of the action, set to `""` to remove default action
@@ -300,6 +305,7 @@ local list = {
 ```
 
 These are the default bindings:
+
 ```lua
 
 -- default mappings
@@ -357,6 +363,7 @@ You can toggle the help UI by pressing `g?`.
 4. You can allow nvim-tree to behave like vinegar (see `:help nvim-tree-vinegar`).
 5. If you `:set nosplitright`, the files will open on the left side of the tree, placing the tree window in the right side of the file you opened.
 6. You can automatically close the tab/vim when nvim-tree is the last window in the tab. WARNING: other plugins or automation may interfere with this:
+
 ```vim
 autocmd BufEnter * ++nested if winnr('$') == 1 && bufname() == 'NvimTree_' . tabpagenr() | quit | endif
 ```
@@ -382,15 +389,15 @@ log = {
 
 Please attach `$XDG_CACHE_HOME/nvim/nvim-tree.log` if you raise an issue.
 
-*Performance Tips:*
+_Performance Tips:_
 
-* If you are using fish as an editor shell (which might be fixed in the future), try set `shell=/bin/bash` in your vim config. Alternatively, you can [prevent fish from loading interactive configuration in a non-interactive shell](https://github.com/kyazdani42/nvim-tree.lua/issues/549#issuecomment-1127394585).
+- If you are using fish as an editor shell (which might be fixed in the future), try set `shell=/bin/bash` in your vim config. Alternatively, you can [prevent fish from loading interactive configuration in a non-interactive shell](https://github.com/kyazdani42/nvim-tree.lua/issues/549#issuecomment-1127394585).
 
-* Try manually running the git command (see the logs) in your shell e.g. `git --no-optional-locks status --porcelain=v1 --ignored=matching -u`.
+- Try manually running the git command (see the logs) in your shell e.g. `git --no-optional-locks status --porcelain=v1 --ignored=matching -u`.
 
-* Huge git repositories may timeout after the default `git.timeout` of 400ms. Try increasing that in your setup if you see `[git] job timed out` in the logs.
+- Huge git repositories may timeout after the default `git.timeout` of 400ms. Try increasing that in your setup if you see `[git] job timed out` in the logs.
 
-* Try temporarily disabling git integration by setting `git.enable = false` in your setup.
+- Try temporarily disabling git integration by setting `git.enable = false` in your setup.
 
 ## Screenshots
 

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -97,6 +97,9 @@ Values may be functions. Warning: this may result in unexpected behaviour.
       open_on_tab = false,
       sort_by = "name",
       update_cwd = false,
+      menu = {
+        actions = {}
+      },
       reload_on_bufenter = false,
       view = {
         width = 30,

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -1,18 +1,18 @@
 local luv = vim.loop
 local api = vim.api
 
-local lib = require "nvim-tree.lib"
-local log = require "nvim-tree.log"
-local colors = require "nvim-tree.colors"
-local renderer = require "nvim-tree.renderer"
-local view = require "nvim-tree.view"
-local utils = require "nvim-tree.utils"
-local change_dir = require "nvim-tree.actions.change-dir"
-local legacy = require "nvim-tree.legacy"
-local core = require "nvim-tree.core"
-local reloaders = require "nvim-tree.actions.reloaders"
-local copy_paste = require "nvim-tree.actions.copy-paste"
-local collapse_all = require "nvim-tree.actions.collapse-all"
+local lib = require 'nvim-tree.lib'
+local log = require 'nvim-tree.log'
+local colors = require 'nvim-tree.colors'
+local renderer = require 'nvim-tree.renderer'
+local view = require 'nvim-tree.view'
+local utils = require 'nvim-tree.utils'
+local change_dir = require 'nvim-tree.actions.change-dir'
+local legacy = require 'nvim-tree.legacy'
+local core = require 'nvim-tree.core'
+local reloaders = require 'nvim-tree.actions.reloaders'
+local copy_paste = require 'nvim-tree.actions.copy-paste'
+local collapse_all = require 'nvim-tree.actions.collapse-all'
 
 local _config = {}
 
@@ -24,7 +24,7 @@ function M.focus()
 end
 
 ---@deprecated
-M.on_keypress = require("nvim-tree.actions").on_keypress
+M.on_keypress = require('nvim-tree.actions').on_keypress
 
 function M.toggle(find_file, no_focus, cwd)
   if view.is_visible() then
@@ -36,13 +36,13 @@ function M.toggle(find_file, no_focus, cwd)
       M.find_file(false, previous_buf)
     end
     if no_focus then
-      vim.cmd "noautocmd wincmd p"
+      vim.cmd 'noautocmd wincmd p'
     end
   end
 end
 
 function M.open(cwd)
-  cwd = cwd ~= "" and cwd or nil
+  cwd = cwd ~= '' and cwd or nil
   if view.is_visible() then
     lib.set_target_win()
     view.focus()
@@ -58,44 +58,44 @@ function M.open_replacing_current_buffer()
 
   local buf = api.nvim_get_current_buf()
   local bufname = api.nvim_buf_get_name(buf)
-  if bufname == "" or vim.loop.fs_stat(bufname) == nil then
+  if bufname == '' or vim.loop.fs_stat(bufname) == nil then
     return
   end
 
-  local cwd = vim.fn.fnamemodify(bufname, ":p:h")
+  local cwd = vim.fn.fnamemodify(bufname, ':p:h')
   if not core.get_explorer() or cwd ~= core.get_cwd() then
     core.init(cwd)
   end
   view.open_in_current_win { hijack_current_buf = false, resize = false }
-  require("nvim-tree.renderer").draw()
-  require("nvim-tree.actions.find-file").fn(bufname)
+  require('nvim-tree.renderer').draw()
+  require('nvim-tree.actions.find-file').fn(bufname)
 end
 
 function M.tab_change()
   if view.is_visible { any_tabpage = true } then
     local bufname = api.nvim_buf_get_name(0)
-    if bufname:match "Neogit" ~= nil or bufname:match "--graph" ~= nil then
+    if bufname:match 'Neogit' ~= nil or bufname:match '--graph' ~= nil then
       return
     end
     view.open { focus_tree = false }
-    require("nvim-tree.renderer").draw()
+    require('nvim-tree.renderer').draw()
   end
 end
 
 local function find_existing_windows()
   return vim.tbl_filter(function(win)
     local buf = api.nvim_win_get_buf(win)
-    return api.nvim_buf_get_name(buf):match "NvimTree" ~= nil
+    return api.nvim_buf_get_name(buf):match 'NvimTree' ~= nil
   end, api.nvim_list_wins())
 end
 
 local function is_file_readable(fname)
   local stat = luv.fs_stat(fname)
-  return stat and stat.type == "file" and luv.fs_access(fname, "R")
+  return stat and stat.type == 'file' and luv.fs_access(fname, 'R')
 end
 
 local function update_base_dir_with_filepath(filepath, bufnr)
-  local ft = api.nvim_buf_get_option(bufnr, "filetype") or ""
+  local ft = api.nvim_buf_get_option(bufnr, 'filetype') or ''
   for _, value in pairs(_config.update_focused_file.ignore_list) do
     if utils.str_find(filepath, value) or utils.str_find(ft, value) then
       return
@@ -103,7 +103,7 @@ local function update_base_dir_with_filepath(filepath, bufnr)
   end
 
   if not vim.startswith(filepath, core.get_explorer().cwd) then
-    change_dir.fn(vim.fn.fnamemodify(filepath, ":p:h"))
+    change_dir.fn(vim.fn.fnamemodify(filepath, ':p:h'))
   end
 end
 
@@ -114,7 +114,7 @@ function M.find_file(with_open, bufnr)
 
   bufnr = bufnr or api.nvim_get_current_buf()
   local bufname = api.nvim_buf_get_name(bufnr)
-  local filepath = utils.canonical_path(vim.fn.fnamemodify(bufname, ":p"))
+  local filepath = utils.canonical_path(vim.fn.fnamemodify(bufname, ':p'))
   if not is_file_readable(filepath) then
     return
   end
@@ -128,7 +128,7 @@ function M.find_file(with_open, bufnr)
     if _config.update_focused_file.update_cwd then
       update_base_dir_with_filepath(filepath, bufnr)
     end
-    require("nvim-tree.actions.find-file").fn(filepath)
+    require('nvim-tree.actions.find-file').fn(filepath)
   end)
 end
 
@@ -163,7 +163,7 @@ function M.place_cursor_on_node()
   prev_line = l
 
   local node = lib.get_node_at_cursor()
-  if not node or node.name == ".." then
+  if not node or node.name == '..' then
     return
   end
 
@@ -179,24 +179,24 @@ end
 function M.on_enter(netrw_disabled)
   local bufnr = api.nvim_get_current_buf()
   local bufname = api.nvim_buf_get_name(bufnr)
-  local buftype = api.nvim_buf_get_option(bufnr, "filetype")
+  local buftype = api.nvim_buf_get_option(bufnr, 'filetype')
   local ft_ignore = _config.ignore_ft_on_setup
 
   local stats = luv.fs_stat(bufname)
-  local is_dir = stats and stats.type == "directory"
-  local is_file = stats and stats.type == "file"
+  local is_dir = stats and stats.type == 'directory'
+  local is_file = stats and stats.type == 'file'
   local cwd
   if is_dir then
     cwd = vim.fn.expand(bufname)
     -- INFO: could potentially conflict with rooter plugins
-    vim.cmd("noautocmd cd " .. cwd)
+    vim.cmd('noautocmd cd ' .. cwd)
   end
 
   local lines = not is_dir and api.nvim_buf_get_lines(bufnr, 0, -1, false) or {}
-  local buf_has_content = #lines > 1 or (#lines == 1 and lines[1] ~= "")
+  local buf_has_content = #lines > 1 or (#lines == 1 and lines[1] ~= '')
 
   local buf_is_dir = is_dir and netrw_disabled
-  local buf_is_empty = bufname == "" and not buf_has_content
+  local buf_is_empty = bufname == '' and not buf_has_content
   local should_be_preserved = vim.tbl_contains(ft_ignore, buftype)
 
   local should_open = false
@@ -215,10 +215,7 @@ function M.on_enter(netrw_disabled)
     end
   end
 
-  local should_hijack = _config.hijack_directories.enable
-    and _config.hijack_directories.auto_open
-    and is_dir
-    and not should_be_preserved
+  local should_hijack = _config.hijack_directories.enable and _config.hijack_directories.auto_open and is_dir and not should_be_preserved
 
   -- Session that left a NvimTree Buffer opened, reopen with it
   local existing_tree_wins = find_existing_windows()
@@ -230,7 +227,7 @@ function M.on_enter(netrw_disabled)
     lib.open(cwd)
 
     if should_focus_other_window then
-      vim.cmd "noautocmd wincmd p"
+      vim.cmd 'noautocmd wincmd p'
       if should_find then
         M.find_file(false)
       end
@@ -245,8 +242,8 @@ end
 
 local function manage_netrw(disable_netrw, hijack_netrw)
   if hijack_netrw then
-    vim.cmd "silent! autocmd! FileExplorer *"
-    vim.cmd "autocmd VimEnter * ++once silent! autocmd! FileExplorer *"
+    vim.cmd 'silent! autocmd! FileExplorer *'
+    vim.cmd 'autocmd VimEnter * ++once silent! autocmd! FileExplorer *'
   end
   if disable_netrw then
     vim.g.loaded_netrw = 1
@@ -255,27 +252,27 @@ local function manage_netrw(disable_netrw, hijack_netrw)
 end
 
 local function setup_vim_commands()
-  api.nvim_create_user_command("NvimTreeOpen", function(res)
+  api.nvim_create_user_command('NvimTreeOpen', function(res)
     M.open(res.args)
-  end, { nargs = "?", complete = "dir" })
-  api.nvim_create_user_command("NvimTreeClose", view.close, {})
-  api.nvim_create_user_command("NvimTreeToggle", function(res)
+  end, { nargs = '?', complete = 'dir' })
+  api.nvim_create_user_command('NvimTreeClose', view.close, {})
+  api.nvim_create_user_command('NvimTreeToggle', function(res)
     M.toggle(false, false, res.args)
-  end, { nargs = "?", complete = "dir" })
-  api.nvim_create_user_command("NvimTreeFocus", M.focus, {})
-  api.nvim_create_user_command("NvimTreeRefresh", reloaders.reload_explorer, {})
-  api.nvim_create_user_command("NvimTreeClipboard", copy_paste.print_clipboard, {})
-  api.nvim_create_user_command("NvimTreeFindFile", function()
+  end, { nargs = '?', complete = 'dir' })
+  api.nvim_create_user_command('NvimTreeFocus', M.focus, {})
+  api.nvim_create_user_command('NvimTreeRefresh', reloaders.reload_explorer, {})
+  api.nvim_create_user_command('NvimTreeClipboard', copy_paste.print_clipboard, {})
+  api.nvim_create_user_command('NvimTreeFindFile', function()
     M.find_file(true)
   end, {})
-  api.nvim_create_user_command("NvimTreeFindFileToggle", function(res)
+  api.nvim_create_user_command('NvimTreeFindFileToggle', function(res)
     M.toggle(true, false, res.args)
-  end, { nargs = "?", complete = "dir" })
-  api.nvim_create_user_command("NvimTreeResize", function(res)
+  end, { nargs = '?', complete = 'dir' })
+  api.nvim_create_user_command('NvimTreeResize', function(res)
     M.resize(res.args)
   end, { nargs = 1 })
-  api.nvim_create_user_command("NvimTreeCollapse", collapse_all.fn, {})
-  api.nvim_create_user_command("NvimTreeCollapseKeepBuffers", function()
+  api.nvim_create_user_command('NvimTreeCollapse', collapse_all.fn, {})
+  api.nvim_create_user_command('NvimTreeCollapseKeepBuffers', function()
     collapse_all.fn(true)
   end, {})
 end
@@ -289,38 +286,38 @@ function M.change_dir(name)
 end
 
 local function setup_autocommands(opts)
-  local augroup_id = api.nvim_create_augroup("NvimTree", {})
+  local augroup_id = api.nvim_create_augroup('NvimTree', {})
   local function create_nvim_tree_autocmd(name, custom_opts)
     local default_opts = { group = augroup_id }
-    api.nvim_create_autocmd(name, vim.tbl_extend("force", default_opts, custom_opts))
+    api.nvim_create_autocmd(name, vim.tbl_extend('force', default_opts, custom_opts))
   end
 
   -- reset highlights when colorscheme is changed
-  create_nvim_tree_autocmd("ColorScheme", { callback = M.reset_highlight })
+  create_nvim_tree_autocmd('ColorScheme', { callback = M.reset_highlight })
 
   if opts.auto_reload_on_write then
-    create_nvim_tree_autocmd("BufWritePost", { callback = reloaders.reload_explorer })
+    create_nvim_tree_autocmd('BufWritePost', { callback = reloaders.reload_explorer })
   end
-  create_nvim_tree_autocmd("User", {
-    pattern = { "FugitiveChanged", "NeogitStatusRefreshed" },
+  create_nvim_tree_autocmd('User', {
+    pattern = { 'FugitiveChanged', 'NeogitStatusRefreshed' },
     callback = reloaders.reload_git,
   })
 
   if opts.open_on_tab then
-    create_nvim_tree_autocmd("TabEnter", { callback = M.tab_change })
+    create_nvim_tree_autocmd('TabEnter', { callback = M.tab_change })
   end
   if opts.hijack_cursor then
-    create_nvim_tree_autocmd("CursorMoved", { pattern = "NvimTree_*", callback = M.place_cursor_on_node })
+    create_nvim_tree_autocmd('CursorMoved', { pattern = 'NvimTree_*', callback = M.place_cursor_on_node })
   end
   if opts.update_cwd then
-    create_nvim_tree_autocmd("DirChanged", {
+    create_nvim_tree_autocmd('DirChanged', {
       callback = function()
         M.change_dir(vim.loop.cwd())
       end,
     })
   end
   if opts.update_focused_file.enable then
-    create_nvim_tree_autocmd("BufEnter", {
+    create_nvim_tree_autocmd('BufEnter', {
       callback = function()
         M.find_file(false)
       end,
@@ -328,17 +325,17 @@ local function setup_autocommands(opts)
   end
 
   if not opts.actions.open_file.quit_on_open then
-    create_nvim_tree_autocmd("BufWipeout", { pattern = "NvimTree_*", callback = view._prevent_buffer_override })
+    create_nvim_tree_autocmd('BufWipeout', { pattern = 'NvimTree_*', callback = view._prevent_buffer_override })
   else
-    create_nvim_tree_autocmd("BufWipeout", { pattern = "NvimTree_*", callback = view.abandon_current_window })
+    create_nvim_tree_autocmd('BufWipeout', { pattern = 'NvimTree_*', callback = view.abandon_current_window })
   end
 
   if opts.hijack_directories.enable then
-    create_nvim_tree_autocmd({ "BufEnter", "BufNewFile" }, { callback = M.open_on_directory })
+    create_nvim_tree_autocmd({ 'BufEnter', 'BufNewFile' }, { callback = M.open_on_directory })
   end
 
   if opts.reload_on_bufenter then
-    create_nvim_tree_autocmd("BufEnter", { pattern = "NvimTree_*", callback = reloaders.reload_explorer })
+    create_nvim_tree_autocmd('BufEnter', { pattern = 'NvimTree_*', callback = reloaders.reload_explorer })
   end
 end
 
@@ -352,18 +349,24 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
   open_on_setup = false,
   open_on_setup_file = false,
   open_on_tab = false,
-  sort_by = "name",
+  sort_by = 'name',
   update_cwd = false,
+  menu = {
+    actions = {
+      ['Copy File Path'] = 'copy_path',
+      ['Copy File Name'] = 'copy_name',
+    },
+  },
   reload_on_bufenter = false,
   view = {
     width = 30,
     height = 30,
     hide_root_folder = false,
-    side = "left",
+    side = 'left',
     preserve_window_proportions = false,
     number = false,
     relativenumber = false,
-    signcolumn = "yes",
+    signcolumn = 'yes',
     mappings = {
       custom_only = false,
       list = {
@@ -375,14 +378,14 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
     indent_markers = {
       enable = false,
       icons = {
-        corner = "└ ",
-        edge = "│ ",
-        none = "  ",
+        corner = '└ ',
+        edge = '│ ',
+        none = '  ',
       },
     },
     icons = {
       webdev_colors = true,
-      git_placement = "before",
+      git_placement = 'before',
     },
   },
   hijack_directories = {
@@ -396,17 +399,17 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
   },
   ignore_ft_on_setup = {},
   system_open = {
-    cmd = "",
+    cmd = '',
     args = {},
   },
   diagnostics = {
     enable = false,
     show_on_dirs = false,
     icons = {
-      hint = "",
-      info = "",
-      warning = "",
-      error = "",
+      hint = '',
+      info = '',
+      warning = '',
+      error = '',
     },
   },
   filters = {
@@ -431,20 +434,20 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
       resize_window = true,
       window_picker = {
         enable = true,
-        chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
+        chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890',
         exclude = {
-          filetype = { "notify", "packer", "qf", "diff", "fugitive", "fugitiveblame" },
-          buftype = { "nofile", "terminal", "help" },
+          filetype = { 'notify', 'packer', 'qf', 'diff', 'fugitive', 'fugitiveblame' },
+          buftype = { 'nofile', 'terminal', 'help' },
         },
       },
     },
   },
   trash = {
-    cmd = "trash",
+    cmd = 'trash',
     require_confirm = true,
   },
   live_filter = {
-    prefix = "[FILTER]: ",
+    prefix = '[FILTER]: ',
     always_show_folders = true,
   },
   log = {
@@ -462,12 +465,12 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
 } -- END_DEFAULT_OPTS
 
 local function merge_options(conf)
-  return vim.tbl_deep_extend("force", DEFAULT_OPTS, conf or {})
+  return vim.tbl_deep_extend('force', DEFAULT_OPTS, conf or {})
 end
 
 local FIELD_OVERRIDE_TYPECHECK = {
-  width = { string = true, ["function"] = true, number = true },
-  height = { string = true, ["function"] = true, number = true },
+  width = { string = true, ['function'] = true, number = true },
+  height = { string = true, ['function'] = true, number = true },
 }
 
 local function validate_options(conf)
@@ -475,7 +478,7 @@ local function validate_options(conf)
 
   local function validate(user, def, prefix)
     -- only compare tables with contents that are not integer indexed
-    if type(user) ~= "table" or type(def) ~= "table" or not next(def) or type(next(def)) == "number" then
+    if type(user) ~= 'table' or type(def) ~= 'table' or not next(def) or type(next(def)) == 'number' then
       return
     end
 
@@ -484,26 +487,26 @@ local function validate_options(conf)
       local override_typecheck = FIELD_OVERRIDE_TYPECHECK[k] or {}
       if def[k] == nil then
         -- option does not exist
-        invalid = string.format("unknown option: %s%s", prefix, k)
+        invalid = string.format('unknown option: %s%s', prefix, k)
       elseif type(v) ~= type(def[k]) and not override_typecheck[type(v)] then
         -- option is of the wrong type and is not a function
-        invalid = string.format("invalid option: %s%s expected: %s actual: %s", prefix, k, type(def[k]), type(v))
+        invalid = string.format('invalid option: %s%s expected: %s actual: %s', prefix, k, type(def[k]), type(v))
       end
 
       if invalid then
         if msg then
-          msg = string.format("%s | %s", msg, invalid)
+          msg = string.format('%s | %s', msg, invalid)
         else
-          msg = string.format("%s", invalid)
+          msg = string.format('%s', invalid)
         end
         user[k] = nil
       else
-        validate(v, def[k], prefix .. k .. ".")
+        validate(v, def[k], prefix .. k .. '.')
       end
     end
   end
 
-  validate(conf, DEFAULT_OPTS, "")
+  validate(conf, DEFAULT_OPTS, '')
 
   if msg then
     utils.warn(msg)
@@ -511,8 +514,8 @@ local function validate_options(conf)
 end
 
 function M.setup(conf)
-  if vim.fn.has "nvim-0.7" == 0 then
-    utils.warn "nvim-tree.lua requires Neovim 0.7 or higher"
+  if vim.fn.has 'nvim-0.7' == 0 then
+    utils.warn 'nvim-tree.lua requires Neovim 0.7 or higher'
     return
   end
 
@@ -534,20 +537,21 @@ function M.setup(conf)
   manage_netrw(opts.disable_netrw, opts.hijack_netrw)
 
   M.config = opts
-  require("nvim-tree.log").setup(opts)
+  require('nvim-tree.log').setup(opts)
 
-  log.line("config", "default config + user")
-  log.raw("config", "%s\n", vim.inspect(opts))
+  log.line('config', 'default config + user')
+  log.raw('config', '%s\n', vim.inspect(opts))
 
-  require("nvim-tree.actions").setup(opts)
-  require("nvim-tree.colors").setup()
-  require("nvim-tree.diagnostics").setup(opts)
-  require("nvim-tree.explorer").setup(opts)
-  require("nvim-tree.git").setup(opts)
-  require("nvim-tree.view").setup(opts)
-  require("nvim-tree.lib").setup(opts)
-  require("nvim-tree.renderer").setup(opts)
-  require("nvim-tree.live-filter").setup(opts)
+  require('nvim-tree.actions').setup(opts)
+  require('nvim-tree.colors').setup()
+  require('nvim-tree.diagnostics').setup(opts)
+  require('nvim-tree.explorer').setup(opts)
+  require('nvim-tree.git').setup(opts)
+  require('nvim-tree.view').setup(opts)
+  require('nvim-tree.lib').setup(opts)
+  require('nvim-tree.popup-menu').setup(opts)
+  require('nvim-tree.renderer').setup(opts)
+  require('nvim-tree.live-filter').setup(opts)
 
   setup_vim_commands()
   setup_autocommands(opts)

--- a/lua/nvim-tree/actions/copy-paste.lua
+++ b/lua/nvim-tree/actions/copy-paste.lua
@@ -241,7 +241,8 @@ function M.copy_absolute_path(node)
 end
 
 function M.setup(opts)
-  M.use_system_clipboard = opts.actions.use_system_clipboard
+  M.use_sys_clipboard = opts.actions.use_sys_clipboard
+  if M.use_sys_clipboard == nil then M.use_sys_clipboard = true end
 end
 
 return M

--- a/lua/nvim-tree/actions/init.lua
+++ b/lua/nvim-tree/actions/init.lua
@@ -193,14 +193,14 @@ local function merge_mappings(user_mappings)
     if type(map.key) == "table" then
       local filtered_keys = {}
       for _, key in pairs(map.key) do
-        if not vim.tbl_contains(user_keys, key) and not vim.tbl_contains(removed_keys, key) then
+        if not vim.tbl_contains(user_keys, key:lower()) and not vim.tbl_contains(removed_keys, key:lower()) then
           table.insert(filtered_keys, key)
         end
       end
       map.key = filtered_keys
       return not vim.tbl_isempty(map.key)
     else
-      return not vim.tbl_contains(user_keys, map.key) and not vim.tbl_contains(removed_keys, map.key)
+      return not vim.tbl_contains(user_keys, map.key:lower()) and not vim.tbl_contains(removed_keys, map.key:lower())
     end
   end, M.mappings)
 

--- a/lua/nvim-tree/actions/init.lua
+++ b/lua/nvim-tree/actions/init.lua
@@ -8,6 +8,7 @@ local nvim_tree_callback = require("nvim-tree.config").nvim_tree_callback
 
 local M = {
   mappings = {
+    { key = "M", action = "open_popup_menu"},
     { key = { "<CR>", "o", "<2-LeftMouse>" }, action = "edit" },
     { key = "<C-e>", action = "edit_in_place" },
     { key = "O", action = "edit_no_picker" },
@@ -53,7 +54,8 @@ local M = {
   custom_keypress_funcs = {},
 }
 
-local keypress_funcs = {
+M.keypress_funcs = {
+  open_popup_menu = require("nvim-tree.popup-menu").open_window,
   close = view.close,
   close_node = require("nvim-tree.actions.movements").parent_node(true),
   collapse_all = require("nvim-tree.actions.collapse-all").fn,
@@ -107,7 +109,7 @@ function M.on_keypress(action)
   end
 
   local custom_function = M.custom_keypress_funcs[action]
-  local default_function = keypress_funcs[action]
+  local default_function = M.keypress_funcs[action]
 
   if type(custom_function) == "function" then
     return custom_function(node)

--- a/lua/nvim-tree/popup-menu/README.md
+++ b/lua/nvim-tree/popup-menu/README.md
@@ -1,0 +1,23 @@
+## File Management Menu [WIP]
+A simple popup menu UI for NvimTreeExplorer.
+
+As now the only two options that work for sure is `copy_path` and `copy_name`.
+
+My personal idea is to let the user choose the title of options to be displayed and connect them to an actions to be executed on current node.
+At this point is possible to bind only actions that come from `nvim-tree.actions.mappings`.
+You can customize via a table in setup function like:
+
+```lua
+setup {
+  menu = {
+    actions = {
+      ['title_of_options'] = 'actions_to_exec',
+      titleOfOptions = 'actions_to_exec'
+    }
+  }
+}
+```
+I hope that you can understand mostly from comment how this things work.
+The team behind NvimTree have a good docs and comment so you can try to figure out how the actual actions execution work.
+
+I keep working on this, you can always open an issue on THIS specific branch and I try my best to answer.

--- a/lua/nvim-tree/popup-menu/default_actions.lua
+++ b/lua/nvim-tree/popup-menu/default_actions.lua
@@ -1,0 +1,8 @@
+local M = {}
+
+M.actions = {
+  ["Copy File Name"] = "copy_name",
+  ["Copy File Path"] = "copy_absolute_path",
+}
+
+return M

--- a/lua/nvim-tree/popup-menu/init.lua
+++ b/lua/nvim-tree/popup-menu/init.lua
@@ -1,0 +1,108 @@
+local a = vim.api
+
+local M = {}
+
+-- TODO: we need to test/fix this when we are using multiple tabs
+--       as pointed at:
+--       https://github.com/kyazdani42/nvim-tree.lua/pull/1162/files/be376a7cbf7164a4a19535834d9019bc97559d4d#r850952305
+--[[local function get_node()
+  local get_node_at_cursor = require("nvim-tree.lib").get_node_at_cursor
+
+  local current_node = get_node_at_cursor()
+  return current_node
+end]]
+
+local current_popup = nil
+
+function get_current_action(_winnr, _bufnr)
+  local node = current_popup.current_node
+  local cur_pos = a.nvim_win_get_cursor(_winnr)[1]
+  local current_action = a.nvim_buf_get_lines(_bufnr, cur_pos - 1, cur_pos, false)[1]
+
+  local run_fn = M.actions[current_action]
+
+  for _, v in pairs(require("nvim-tree.actions").mappings) do
+    if v.action == run_fn then
+      require("nvim-tree.actions").keypress_funcs[run_fn](node)
+    end
+    M.close_window()
+  end
+end
+
+local function setup_mappings()
+  -- TODO: pass mappings as arguments from setup or default
+  a.nvim_buf_set_keymap(
+    bufnr,
+    "n",
+    "<CR>",
+    string.format([[:lua get_current_action(%s, %s)<CR>]], current_popup.winnr, current_popup.bufnr),
+    { noremap = true, silent = true }
+  )
+  a.nvim_buf_set_keymap(
+    bufnr,
+    "n",
+    "<Esc>",
+    [[:lua require("nvim-tree.popup-menu").close_window()<CR>]],
+    { noremap = true, silent = true }
+  )
+end
+
+local function setup_window(actions)
+  local max_width = vim.fn.max(vim.tbl_map(function(n)
+    return #n
+  end, vim.tbl_keys(actions)))
+  winnr = a.nvim_open_win(0, true, {
+    col = 0,
+    row = 1,
+    relative = "cursor",
+
+    width = max_width + 1,
+    height = vim.tbl_count(actions),
+    style = "minimal",
+  })
+
+  bufnr = a.nvim_create_buf(false, true)
+  a.nvim_buf_set_lines(bufnr, 0, -1, false, vim.tbl_keys(actions))
+  a.nvim_win_set_buf(winnr, bufnr)
+
+  current_popup = {
+    winnr = winnr,
+    bufnr = bufnr,
+    current_node = require"nvim-tree.lib".get_node_at_cursor(),
+  }
+
+  -- this take care of closing the menu if for some reason lose focus
+  vim.cmd [[augroup NvimTreeCloseMenu ]]
+  vim.cmd(
+    string.format(
+      [[autocmd BufLeave,FocusLost <buffer=%s> :lua require'nvim-tree.popup-menu'.close_window()]],
+      current_popup.bufnr
+    )
+  )
+  vim.cmd [[augroup END]]
+end
+
+function M.open_window()
+  setup_window(M.actions)
+  setup_mappings()
+end
+
+function M.close_window()
+  if current_popup ~= nil then
+    a.nvim_win_close(current_popup.winnr, { force = true })
+
+    current_popup = nil
+  end
+end
+
+function M.setup(opts)
+  if M.actions == nil then
+    M.actions = require("nvim-tree.popup-menu.default_actions").actions
+  else
+    -- maybe we need to pass an option so the user can keep
+    -- the default and add the custom actions
+    M.actions = opts.menu.actions
+  end
+end
+
+return M


### PR DESCRIPTION
Ughh that was a nightmare!
I've been trying to restore my original `<c-r>` mapping and not until I dug into the code I found that the comparison is case sensitive which doesn't make sense in vim keymaps.
So hence this PR.
Thanks.