### PR TITLE
Ignore case mappings

### DIFF
--- a/lua/nvim-tree/actions/init.lua
+++ b/lua/nvim-tree/actions/init.lua
@@ -193,14 +193,14 @@ local function merge_mappings(user_mappings)
     if type(map.key) == "table" then
       local filtered_keys = {}
       for _, key in pairs(map.key) do
-        if not vim.tbl_contains(user_keys, key) and not vim.tbl_contains(removed_keys, key) then
+        if not vim.tbl_contains(user_keys, key:lower()) and not vim.tbl_contains(removed_keys, key:lower()) then
           table.insert(filtered_keys, key)
         end
       end
       map.key = filtered_keys
       return not vim.tbl_isempty(map.key)
     else
-      return not vim.tbl_contains(user_keys, map.key) and not vim.tbl_contains(removed_keys, map.key)
+      return not vim.tbl_contains(user_keys, map.key:lower()) and not vim.tbl_contains(removed_keys, map.key:lower())
     end
   end, M.mappings)
 

--- a/lua/nvim-tree/actions/init.lua
+++ b/lua/nvim-tree/actions/init.lua
@@ -193,14 +193,16 @@ local function merge_mappings(user_mappings)
     if type(map.key) == "table" then
       local filtered_keys = {}
       for _, key in pairs(map.key) do
-        if not vim.tbl_contains(user_keys, key:lower()) and not vim.tbl_contains(removed_keys, key:lower()) then
+        local lhs = string.find(key:lower(), "^<.*>$") and key:lower() or key
+        if not vim.tbl_contains(user_keys, lhs) and not vim.tbl_contains(removed_keys, lhs) then
           table.insert(filtered_keys, key)
         end
       end
       map.key = filtered_keys
       return not vim.tbl_isempty(map.key)
     else
-      return not vim.tbl_contains(user_keys, map.key:lower()) and not vim.tbl_contains(removed_keys, map.key:lower())
+      local lhs = string.find(map.key:lower(), "^<.*>$") and map.key:lower() or key
+      return not vim.tbl_contains(user_keys, lhs) and not vim.tbl_contains(removed_keys, lhs)
     end
   end, M.mappings)
 


### PR DESCRIPTION
Ughh that was a nightmare!
I've been trying to restore my original <c-r> mapping and not until I dug into the code I found that the comparison is case sensitive which doesn't make sense in vim keymaps.
So hence this PR.
Thanks.