### PR TITLE
new option: close windows displaying removed files

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ require'nvim-tree'.setup {
 require'nvim-tree'.setup { -- BEGIN_DEFAULT_OPTS
   auto_reload_on_write = true,
   create_in_closed_folder = false,
+  remove_file_close_window = true,
   disable_netrw = false,
   hijack_cursor = false,
   hijack_netrw = true,

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ require'nvim-tree'.setup {
 require'nvim-tree'.setup { -- BEGIN_DEFAULT_OPTS
   auto_reload_on_write = true,
   create_in_closed_folder = false,
-  remove_file_close_window = true,
   disable_netrw = false,
   hijack_cursor = false,
   hijack_netrw = true,
@@ -202,6 +201,9 @@ require'nvim-tree'.setup { -- BEGIN_DEFAULT_OPTS
           buftype = { "nofile", "terminal", "help" },
         },
       },
+    },
+    remove_file = {
+      close_window = true,
     },
   },
   trash = {

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -88,7 +88,6 @@ Values may be functions. Warning: this may result in unexpected behaviour.
     require("nvim-tree").setup { -- BEGIN_DEFAULT_OPTS
       auto_reload_on_write = true,
       create_in_closed_folder = false,
-      remove_file_close_window = true,
       disable_netrw = false,
       hijack_cursor = false,
       hijack_netrw = true,
@@ -221,6 +220,9 @@ Values may be functions. Warning: this may result in unexpected behaviour.
             },
           },
         },
+        remove_file = {
+          close_window = true,
+        },
       },
       trash = {
         cmd = "trash",
@@ -284,10 +286,6 @@ Reloads the explorer every time a buffer is written to.
 Creating a file when the cursor is on a closed folder will set the
 path to be inside the closed folder, otherwise the parent folder.
   Type: `boolean`, Default: `false`
-
-*nvim-tree.remove_file_close_window*
-Close any window displaying a file when removing the file from the tree.
-  Type: `boolean`, Default: `true`
 
 *nvim-tree.open_on_tab*
 Opens the tree automatically when switching tabpage or opening a new tabpage
@@ -668,6 +666,10 @@ Configuration for various actions.
           `filetype = { "notify", "packer", "qf", "diff", "fugitive", "fugitiveblame", },`
           `buftype  = { "nofile", "terminal", "help", }`
         `}`
+
+    *nvim-tree.actions.remove_file.close_window*
+    Close any window displaying a file when removing the file from the tree.
+      Type: `boolean`, Default: `true`
 
     *nvim-tree.actions.use_system_clipboard*
     A boolean value that toggle the use of system clipboard when copy/paste

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -88,6 +88,7 @@ Values may be functions. Warning: this may result in unexpected behaviour.
     require("nvim-tree").setup { -- BEGIN_DEFAULT_OPTS
       auto_reload_on_write = true,
       create_in_closed_folder = false,
+      remove_file_close_window = true,
       disable_netrw = false,
       hijack_cursor = false,
       hijack_netrw = true,
@@ -283,6 +284,10 @@ Reloads the explorer every time a buffer is written to.
 Creating a file when the cursor is on a closed folder will set the
 path to be inside the closed folder, otherwise the parent folder.
   Type: `boolean`, Default: `false`
+
+*nvim-tree.remove_file_close_window*
+Close any window displaying a file when removing the file from the tree.
+  Type: `boolean`, Default: `true`
 
 *nvim-tree.open_on_tab*
 Opens the tree automatically when switching tabpage or opening a new tabpage

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -345,7 +345,6 @@ end
 local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
   auto_reload_on_write = true,
   create_in_closed_folder = false,
-  remove_file_close_window = true,
   disable_netrw = false,
   hijack_cursor = false,
   hijack_netrw = true,
@@ -477,6 +476,9 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
           buftype = { "nofile", "terminal", "help" },
         },
       },
+    },
+    remove_file = {
+      close_window = true,
     },
   },
   trash = {

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -345,6 +345,7 @@ end
 local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
   auto_reload_on_write = true,
   create_in_closed_folder = false,
+  remove_file_close_window = true,
   disable_netrw = false,
   hijack_cursor = false,
   hijack_netrw = true,

--- a/lua/nvim-tree/actions/init.lua
+++ b/lua/nvim-tree/actions/init.lua
@@ -235,6 +235,7 @@ function M.setup(opts)
   require("nvim-tree.actions.trash").setup(opts.trash)
   require("nvim-tree.actions.open-file").setup(opts)
   require("nvim-tree.actions.change-dir").setup(opts)
+  require("nvim-tree.actions.remove-file").setup(opts)
   require("nvim-tree.actions.copy-paste").setup(opts)
   require("nvim-tree.actions.create-file").setup(opts)
 

--- a/lua/nvim-tree/actions/remove-file.lua
+++ b/lua/nvim-tree/actions/remove-file.lua
@@ -25,7 +25,9 @@ local function clear_buffer(absolute_path)
         a.nvim_set_current_win(winnr)
       end
       a.nvim_buf_delete(buf.bufnr, { force = true })
-      close_windows(buf.windows)
+      if M.config.remove_file_close_window then
+          close_windows(buf.windows)
+      end
       return
     end
   end
@@ -86,6 +88,10 @@ function M.fn(node)
     end
     require("nvim-tree.actions.reloaders").reload_explorer()
   end
+end
+
+function M.setup(opts)
+  M.config = opts
 end
 
 return M

--- a/lua/nvim-tree/actions/remove-file.lua
+++ b/lua/nvim-tree/actions/remove-file.lua
@@ -25,8 +25,8 @@ local function clear_buffer(absolute_path)
         a.nvim_set_current_win(winnr)
       end
       a.nvim_buf_delete(buf.bufnr, { force = true })
-      if M.config.remove_file_close_window then
-          close_windows(buf.windows)
+      if M.close_window then
+        close_windows(buf.windows)
       end
       return
     end
@@ -91,7 +91,7 @@ function M.fn(node)
 end
 
 function M.setup(opts)
-  M.config = opts
+  M.close_window = opts.actions.remove_file.close_window
 end
 
 return M


### PR DESCRIPTION
This issue was already mentioned in the past, at least in https://github.com/kyazdani42/nvim-tree.lua/issues/1012

I have set up my neovim to not close windows when I close buffers, using [qpkorr/vim-bufkill](https://github.com/qpkorr/vim-bufkill)

The way nvim-tree explicitely closes the window after closing the buffer breaks that workflow for me (note that older versions of nvim-tree didn't do that, I believe 5d8453dfbd34ab00cb3e8ce39660f9a54cdd35f3 didn't do that).

So I added a new option, `remove_file_close_window`, defaulting to true -- the current behavior. When I change it to false, it fixes my issue.