### PR TITLE
feat(explorer): add experimental watchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,14 +182,14 @@ require'nvim-tree'.setup { -- BEGIN_DEFAULT_OPTS
     custom = {},
     exclude = {},
   },
+  filesystem_watchers = {
+    enable = false,
+    interval = 100,
+  },
   git = {
     enable = true,
     ignore = true,
     timeout = 400,
-    watcher = {
-      enable = false,
-      interval = 100,
-    },
   },
   actions = {
     use_system_clipboard = true,

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ require'nvim-tree'.setup { -- BEGIN_DEFAULT_OPTS
       profile = false,
     },
   },
+  experimental_watchers = false,
 } -- END_DEFAULT_OPTS
 ```
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ require'nvim-tree'.setup { -- BEGIN_DEFAULT_OPTS
     enable = true,
     ignore = true,
     timeout = 400,
+    watcher = {
+      enable = false,
+      interval = 100,
+    },
   },
   actions = {
     use_system_clipboard = true,
@@ -231,9 +235,9 @@ require'nvim-tree'.setup { -- BEGIN_DEFAULT_OPTS
       diagnostics = false,
       git = false,
       profile = false,
+      watcher = false,
     },
   },
-  experimental_watchers = false,
 } -- END_DEFAULT_OPTS
 ```
 

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -200,14 +200,14 @@ Values may be functions. Warning: this may result in unexpected behaviour.
         custom = {},
         exclude = {},
       },
+      filesystem_watchers = {
+        enable = false,
+        interval = 100,
+      },
       git = {
         enable = true,
         ignore = true,
         timeout = 400,
-        watcher = {
-          enable = false,
-          interval = 100,
-        },
       },
       actions = {
         use_system_clipboard = true,
@@ -414,21 +414,6 @@ Git integration with icons and colors.
     Kills the git process after some time if it takes too long.
       Type: `number`, Default: `400` (ms)
 
-    *nvim-tree.git.watcher*
-    Will use file system watcher (libuv fs_poll) to watch the tree.
-    All the manual filesystem sync and git sync will be disabled.
-    This will be experimental for a few weeks and will become the default.
-
-        *nvim-tree.git.watcher.enable*
-        Enable / disable the feature.
-          Type: `boolean`, Default: `false`
-
-        *nvim-tree.git.watcher.interval*
-        Milliseconds between polls for each directory.
-        Increase to at least 1000ms if changes are not visible. See
-        https://github.com/luvit/luv/blob/master/docs.md#uvfs_poll_startfs_poll-path-interval-callback
-          Type: `number`, Default: `100` (ms)
-
   You will still need to set |renderer.icons.show.git| `= true` or
   |renderer.highlight_git| `= true` to be able to see things in the
   tree. This will be changed in the future versions.
@@ -438,6 +423,26 @@ Git integration with icons and colors.
   The git integration is blocking, so if your timeout is too long (like not in
   milliseconds but a few seconds), it will not render anything until the git
   process returned the data.
+
+
+*nvim-tree.filesystem_watchers*
+Will use file system watcher (libuv fs_poll) to watch the filesystem for
+changes.
+Using this will disable BufEnter / BufWritePost events in nvim-tree which
+were used to update the whole tree. With this feature, the tree will be
+updated only for the appropriate folder change, resulting in better
+performance.
+This will be experimental for a few weeks and will become the default.
+
+    *nvim-tree.filesystem_watchers.enable*
+    Enable / disable the feature.
+      Type: `boolean`, Default: `false`
+
+    *nvim-tree.filesystem_watchers.interval*
+    Milliseconds between polls for each directory.
+    Increase to at least 1000ms if changes are not visible. See
+    https://github.com/luvit/luv/blob/master/docs.md#uvfs_poll_startfs_poll-path-interval-callback
+      Type: `number`, Default: `100` (ms)
 
 *nvim-tree.view*
 Window / buffer setup.

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -204,6 +204,10 @@ Values may be functions. Warning: this may result in unexpected behaviour.
         enable = true,
         ignore = true,
         timeout = 400,
+        watcher = {
+          enable = false,
+          interval = 100,
+        },
       },
       actions = {
         use_system_clipboard = true,
@@ -249,9 +253,9 @@ Values may be functions. Warning: this may result in unexpected behaviour.
           diagnostics = false,
           git = false,
           profile = false,
+          watcher = false,
         },
       },
-      experimental_watchers = false,
     } -- END_DEFAULT_OPTS
 <
 
@@ -323,12 +327,6 @@ Automatically reloads the tree on `BufEnter` nvim-tree.
 
 *nvim-tree.respect_buf_cwd*
 Will change cwd of nvim-tree to that of new buffer's when opening nvim-tree.
-  Type: `boolean`, Default: `false`
-
-*nvim-tree.experimental_watchers*
-Will use watchers (libuv fs_poll) to watch the tree.
-All the manual filesystem sync and git sync will be disabled.
-This will be in effect for a few weeks and will become the default.
   Type: `boolean`, Default: `false`
 
 *nvim-tree.hijack_directories*
@@ -415,6 +413,19 @@ Git integration with icons and colors.
     *nvim-tree.git.timeout*
     Kills the git process after some time if it takes too long.
       Type: `number`, Default: `400` (ms)
+
+    *nvim-tree.git.watcher*
+    Will use file system watcher (libuv fs_poll) to watch the tree.
+    All the manual filesystem sync and git sync will be disabled.
+    This will be experimental for a few weeks and will become the default.
+
+        *nvim-tree.git.watcher.enable*
+        Enable / disable the feature.
+          Type: `boolean`, Default: `false`
+
+        *nvim-tree.git.watcher.interval*
+        Interval between polls for each directory.
+          Type: `number`, Default: `100` (ms)
 
   You will still need to set |renderer.icons.show.git| `= true` or
   |renderer.highlight_git| `= true` to be able to see things in the

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -424,7 +424,9 @@ Git integration with icons and colors.
           Type: `boolean`, Default: `false`
 
         *nvim-tree.git.watcher.interval*
-        Interval between polls for each directory.
+        Milliseconds between polls for each directory.
+        Increase to at least 1000ms if changes are not visible. See
+        https://github.com/luvit/luv/blob/master/docs.md#uvfs_poll_startfs_poll-path-interval-callback
           Type: `number`, Default: `100` (ms)
 
   You will still need to set |renderer.icons.show.git| `= true` or

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -326,7 +326,7 @@ Will change cwd of nvim-tree to that of new buffer's when opening nvim-tree.
   Type: `boolean`, Default: `false`
 
 *nvim-tree.experimental_watchers*
-Will use watchers (libuv fs_event) to watch the tree.
+Will use watchers (libuv fs_poll) to watch the tree.
 All the manual filesystem sync and git sync will be disabled.
 This will be in effect for a few weeks and will become the default.
   Type: `boolean`, Default: `false`

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -251,6 +251,7 @@ Values may be functions. Warning: this may result in unexpected behaviour.
           profile = false,
         },
       },
+      experimental_watchers = false,
     } -- END_DEFAULT_OPTS
 <
 
@@ -322,6 +323,12 @@ Automatically reloads the tree on `BufEnter` nvim-tree.
 
 *nvim-tree.respect_buf_cwd*
 Will change cwd of nvim-tree to that of new buffer's when opening nvim-tree.
+  Type: `boolean`, Default: `false`
+
+*nvim-tree.experimental_watchers*
+Will use watchers (libuv fs_event) to watch the tree.
+All the manual filesystem sync and git sync will be disabled.
+This will be in effect for a few weeks and will become the default.
   Type: `boolean`, Default: `false`
 
 *nvim-tree.hijack_directories*

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -256,7 +256,7 @@ local function manage_netrw(disable_netrw, hijack_netrw)
   end
 end
 
-local function setup_vim_commands(opts)
+local function setup_vim_commands()
   api.nvim_create_user_command("NvimTreeOpen", function(res)
     M.open(res.args)
   end, { nargs = "?", complete = "dir" })
@@ -614,7 +614,7 @@ function M.setup(conf)
     require("nvim-web-devicons").setup()
   end
 
-  setup_vim_commands(opts)
+  setup_vim_commands()
   setup_autocommands(opts)
 
   vim.schedule(function()

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -300,11 +300,13 @@ local function setup_autocommands(opts)
   -- reset highlights when colorscheme is changed
   create_nvim_tree_autocmd("ColorScheme", { callback = M.reset_highlight })
 
-  if opts.auto_reload_on_write and (not opts.git.watcher.enable or not opts.git.enable) then
+  local has_watchers = opts.filesystem_watchers.enable
+
+  if opts.auto_reload_on_write and not has_watchers then
     create_nvim_tree_autocmd("BufWritePost", { callback = reloaders.reload_explorer })
   end
 
-  if not opts.git.watcher.enable or not opts.git.enable then
+  if not has_watchers and opts.git.enable then
     create_nvim_tree_autocmd("User", {
       pattern = { "FugitiveChanged", "NeogitStatusRefreshed" },
       callback = reloaders.reload_git,
@@ -342,7 +344,7 @@ local function setup_autocommands(opts)
     create_nvim_tree_autocmd({ "BufEnter", "BufNewFile" }, { callback = M.open_on_directory })
   end
 
-  if opts.reload_on_bufenter and (not opts.git.watcher.enable or not opts.git.enable) then
+  if opts.reload_on_bufenter and not has_watchers then
     create_nvim_tree_autocmd("BufEnter", { pattern = "NvimTree_*", callback = reloaders.reload_explorer })
   end
 end
@@ -459,14 +461,14 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
     custom = {},
     exclude = {},
   },
+  filesystem_watchers = {
+    enable = false,
+    interval = 100,
+  },
   git = {
     enable = true,
     ignore = true,
     timeout = 400,
-    watcher = {
-      enable = false,
-      interval = 100,
-    },
   },
   actions = {
     use_system_clipboard = true,

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -265,10 +265,7 @@ local function setup_vim_commands(opts)
     M.toggle(false, false, res.args)
   end, { nargs = "?", complete = "dir" })
   api.nvim_create_user_command("NvimTreeFocus", M.focus, {})
-  -- TODO we still want this one, for external file changes, and git reload does not hurt
-  if not opts.git.watcher.enable then
-    api.nvim_create_user_command("NvimTreeRefresh", reloaders.reload_explorer, {})
-  end
+  api.nvim_create_user_command("NvimTreeRefresh", reloaders.reload_explorer, {})
   api.nvim_create_user_command("NvimTreeClipboard", copy_paste.print_clipboard, {})
   api.nvim_create_user_command("NvimTreeFindFile", function()
     M.find_file(true)

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -265,7 +265,7 @@ local function setup_vim_commands(opts)
     M.toggle(false, false, res.args)
   end, { nargs = "?", complete = "dir" })
   api.nvim_create_user_command("NvimTreeFocus", M.focus, {})
-  if not opts.experimental_watchers then
+  if not opts.git.watcher.enable then
     api.nvim_create_user_command("NvimTreeRefresh", reloaders.reload_explorer, {})
   end
   api.nvim_create_user_command("NvimTreeClipboard", copy_paste.print_clipboard, {})
@@ -302,11 +302,11 @@ local function setup_autocommands(opts)
   -- reset highlights when colorscheme is changed
   create_nvim_tree_autocmd("ColorScheme", { callback = M.reset_highlight })
 
-  if opts.auto_reload_on_write and not opts.experimental_watchers then
+  if opts.auto_reload_on_write and not opts.git.watcher.enable then
     create_nvim_tree_autocmd("BufWritePost", { callback = reloaders.reload_explorer })
   end
 
-  if not opts.experimental_watchers then
+  if not opts.git.watcher.enable then
     create_nvim_tree_autocmd("User", {
       pattern = { "FugitiveChanged", "NeogitStatusRefreshed" },
       callback = reloaders.reload_git,
@@ -344,7 +344,7 @@ local function setup_autocommands(opts)
     create_nvim_tree_autocmd({ "BufEnter", "BufNewFile" }, { callback = M.open_on_directory })
   end
 
-  if opts.reload_on_bufenter and not opts.experimental_watchers then
+  if opts.reload_on_bufenter and not opts.git.watcher.enable then
     create_nvim_tree_autocmd("BufEnter", { pattern = "NvimTree_*", callback = reloaders.reload_explorer })
   end
 end
@@ -465,6 +465,10 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
     enable = true,
     ignore = true,
     timeout = 400,
+    watcher = {
+      enable = false,
+      interval = 100,
+    },
   },
   actions = {
     use_system_clipboard = true,
@@ -513,7 +517,6 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
       watcher = false,
     },
   },
-  experimental_watchers = false,
 } -- END_DEFAULT_OPTS
 
 local function merge_options(conf)

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -510,6 +510,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
       diagnostics = false,
       git = false,
       profile = false,
+      watcher = false,
     },
   },
   experimental_watchers = false,

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -265,6 +265,7 @@ local function setup_vim_commands(opts)
     M.toggle(false, false, res.args)
   end, { nargs = "?", complete = "dir" })
   api.nvim_create_user_command("NvimTreeFocus", M.focus, {})
+  -- TODO we still want this one, for external file changes, and git reload does not hurt
   if not opts.git.watcher.enable then
     api.nvim_create_user_command("NvimTreeRefresh", reloaders.reload_explorer, {})
   end

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -300,11 +300,11 @@ local function setup_autocommands(opts)
   -- reset highlights when colorscheme is changed
   create_nvim_tree_autocmd("ColorScheme", { callback = M.reset_highlight })
 
-  if opts.auto_reload_on_write and not opts.git.watcher.enable then
+  if opts.auto_reload_on_write and (not opts.git.watcher.enable or not opts.git.enable) then
     create_nvim_tree_autocmd("BufWritePost", { callback = reloaders.reload_explorer })
   end
 
-  if not opts.git.watcher.enable then
+  if not opts.git.watcher.enable or not opts.git.enable then
     create_nvim_tree_autocmd("User", {
       pattern = { "FugitiveChanged", "NeogitStatusRefreshed" },
       callback = reloaders.reload_git,
@@ -342,7 +342,7 @@ local function setup_autocommands(opts)
     create_nvim_tree_autocmd({ "BufEnter", "BufNewFile" }, { callback = M.open_on_directory })
   end
 
-  if opts.reload_on_bufenter and not opts.git.watcher.enable then
+  if opts.reload_on_bufenter and (not opts.git.watcher.enable or not opts.git.enable) then
     create_nvim_tree_autocmd("BufEnter", { pattern = "NvimTree_*", callback = reloaders.reload_explorer })
   end
 end
@@ -609,7 +609,6 @@ function M.setup(conf)
   require("nvim-tree.view").setup(opts)
   require("nvim-tree.lib").setup(opts)
   require("nvim-tree.renderer").setup(opts)
-  require("nvim-tree.watcher").setup(opts)
   require("nvim-tree.live-filter").setup(opts)
   if M.config.renderer.icons.show.file and pcall(require, "nvim-web-devicons") then
     require("nvim-web-devicons").setup()

--- a/lua/nvim-tree/actions/copy-paste.lua
+++ b/lua/nvim-tree/actions/copy-paste.lua
@@ -244,7 +244,7 @@ end
 
 function M.setup(opts)
   M.use_system_clipboard = opts.actions.use_system_clipboard
-  M.enable_reload = not opts.git.watcher.enable
+  M.enable_reload = not opts.git.watcher.enable or not opts.git.enable
 end
 
 return M

--- a/lua/nvim-tree/actions/copy-paste.lua
+++ b/lua/nvim-tree/actions/copy-paste.lua
@@ -244,7 +244,7 @@ end
 
 function M.setup(opts)
   M.use_system_clipboard = opts.actions.use_system_clipboard
-  M.enable_reload = not opts.experimental_watchers
+  M.enable_reload = not opts.git.watcher.enable
 end
 
 return M

--- a/lua/nvim-tree/actions/copy-paste.lua
+++ b/lua/nvim-tree/actions/copy-paste.lua
@@ -165,7 +165,9 @@ local function do_paste(node, action_type, action_fn)
   end
 
   clipboard[action_type] = {}
-  return require("nvim-tree.actions.reloaders").reload_explorer()
+  if not M.enable_reload then
+    return require("nvim-tree.actions.reloaders").reload_explorer()
+  end
 end
 
 local function do_cut(source, destination)
@@ -242,6 +244,7 @@ end
 
 function M.setup(opts)
   M.use_system_clipboard = opts.actions.use_system_clipboard
+  M.enable_reload = not opts.experimental_watchers
 end
 
 return M

--- a/lua/nvim-tree/actions/copy-paste.lua
+++ b/lua/nvim-tree/actions/copy-paste.lua
@@ -244,7 +244,7 @@ end
 
 function M.setup(opts)
   M.use_system_clipboard = opts.actions.use_system_clipboard
-  M.enable_reload = not opts.git.watcher.enable or not opts.git.enable
+  M.enable_reload = not opts.filesystem_watchers.enable
 end
 
 return M

--- a/lua/nvim-tree/actions/create-file.lua
+++ b/lua/nvim-tree/actions/create-file.lua
@@ -42,7 +42,7 @@ local function get_num_nodes(iter)
 end
 
 local function get_containing_folder(node)
-  local is_open = M.config.create_in_closed_folder or node.open
+  local is_open = M.create_in_closed_folder or node.open
   if node.nodes ~= nil and is_open then
     return utils.path_add_trailing(node.absolute_path)
   end
@@ -107,13 +107,19 @@ function M.fn(node)
       a.nvim_out_write(new_file_path .. " was properly created\n")
     end
     events._dispatch_folder_created(new_file_path)
-    require("nvim-tree.actions.reloaders").reload_explorer()
-    focus_file(new_file_path)
+    if M.enable_reload then
+      require("nvim-tree.actions.reloaders").reload_explorer()
+    end
+    -- INFO: defer needed when reload is automatic (watchers)
+    vim.defer_fn(function()
+      focus_file(new_file_path)
+    end, 50)
   end)
 end
 
 function M.setup(opts)
-  M.config = opts
+  M.create_in_closed_folder = opts.create_in_closed_folder
+  M.enable_reload = not opts.experimental_watchers
 end
 
 return M

--- a/lua/nvim-tree/actions/create-file.lua
+++ b/lua/nvim-tree/actions/create-file.lua
@@ -119,7 +119,7 @@ end
 
 function M.setup(opts)
   M.create_in_closed_folder = opts.create_in_closed_folder
-  M.enable_reload = not opts.git.watcher.enable or not opts.git.enable
+  M.enable_reload = not opts.filesystem_watchers.enable
 end
 
 return M

--- a/lua/nvim-tree/actions/create-file.lua
+++ b/lua/nvim-tree/actions/create-file.lua
@@ -119,7 +119,7 @@ end
 
 function M.setup(opts)
   M.create_in_closed_folder = opts.create_in_closed_folder
-  M.enable_reload = not opts.git.watcher.enable
+  M.enable_reload = not opts.git.watcher.enable or not opts.git.enable
 end
 
 return M

--- a/lua/nvim-tree/actions/create-file.lua
+++ b/lua/nvim-tree/actions/create-file.lua
@@ -119,7 +119,7 @@ end
 
 function M.setup(opts)
   M.create_in_closed_folder = opts.create_in_closed_folder
-  M.enable_reload = not opts.experimental_watchers
+  M.enable_reload = not opts.git.watcher.enable
 end
 
 return M

--- a/lua/nvim-tree/actions/init.lua
+++ b/lua/nvim-tree/actions/init.lua
@@ -403,13 +403,14 @@ local DEFAULT_MAPPING_CONFIG = {
 }
 
 function M.setup(opts)
-  require("nvim-tree.actions.system-open").setup(opts.system_open)
-  require("nvim-tree.actions.trash").setup(opts.trash)
+  require("nvim-tree.actions.system-open").setup(opts)
+  require("nvim-tree.actions.trash").setup(opts)
   require("nvim-tree.actions.open-file").setup(opts)
   require("nvim-tree.actions.change-dir").setup(opts)
+  require("nvim-tree.actions.create-file").setup(opts)
+  require("nvim-tree.actions.rename-file").setup(opts)
   require("nvim-tree.actions.remove-file").setup(opts)
   require("nvim-tree.actions.copy-paste").setup(opts)
-  require("nvim-tree.actions.create-file").setup(opts)
   require("nvim-tree.actions.expand-all").setup(opts)
 
   local user_map_config = (opts.view or {}).mappings or {}

--- a/lua/nvim-tree/actions/remove-file.lua
+++ b/lua/nvim-tree/actions/remove-file.lua
@@ -93,7 +93,7 @@ function M.fn(node)
 end
 
 function M.setup(opts)
-  M.enable_reload = not opts.experimental_watchers
+  M.enable_reload = not opts.git.watcher.enable
   M.close_window = opts.actions.remove_file.close_window
 end
 

--- a/lua/nvim-tree/actions/remove-file.lua
+++ b/lua/nvim-tree/actions/remove-file.lua
@@ -93,7 +93,7 @@ function M.fn(node)
 end
 
 function M.setup(opts)
-  M.enable_reload = not opts.git.watcher.enable
+  M.enable_reload = not opts.git.watcher.enable or not opts.git.enable
   M.close_window = opts.actions.remove_file.close_window
 end
 

--- a/lua/nvim-tree/actions/remove-file.lua
+++ b/lua/nvim-tree/actions/remove-file.lua
@@ -93,7 +93,7 @@ function M.fn(node)
 end
 
 function M.setup(opts)
-  M.enable_reload = not opts.git.watcher.enable or not opts.git.enable
+  M.enable_reload = not opts.filesystem_watchers.enable
   M.close_window = opts.actions.remove_file.close_window
 end
 

--- a/lua/nvim-tree/actions/remove-file.lua
+++ b/lua/nvim-tree/actions/remove-file.lua
@@ -86,11 +86,14 @@ function M.fn(node)
       events._dispatch_file_removed(node.absolute_path)
       clear_buffer(node.absolute_path)
     end
-    require("nvim-tree.actions.reloaders").reload_explorer()
+    if M.enable_reload then
+      require("nvim-tree.actions.reloaders").reload_explorer()
+    end
   end
 end
 
 function M.setup(opts)
+  M.enable_reload = not opts.experimental_watchers
   M.close_window = opts.actions.remove_file.close_window
 end
 

--- a/lua/nvim-tree/actions/rename-file.lua
+++ b/lua/nvim-tree/actions/rename-file.lua
@@ -45,7 +45,7 @@ function M.fn(with_sub)
 end
 
 function M.setup(opts)
-  M.enable_reload = not opts.git.watcher.enable
+  M.enable_reload = not opts.git.watcher.enable or not opts.git.enable
 end
 
 return M

--- a/lua/nvim-tree/actions/rename-file.lua
+++ b/lua/nvim-tree/actions/rename-file.lua
@@ -45,7 +45,7 @@ function M.fn(with_sub)
 end
 
 function M.setup(opts)
-  M.enable_reload = not opts.experimental_watchers
+  M.enable_reload = not opts.git.watcher.enable
 end
 
 return M

--- a/lua/nvim-tree/actions/rename-file.lua
+++ b/lua/nvim-tree/actions/rename-file.lua
@@ -37,9 +37,15 @@ function M.fn(with_sub)
       a.nvim_out_write(node.absolute_path .. " ➜ " .. new_file_path .. "\n")
       utils.rename_loaded_buffers(node.absolute_path, new_file_path)
       events._dispatch_node_renamed(abs_path, new_file_path)
-      require("nvim-tree.actions.reloaders").reload_explorer()
+      if M.enable_reload then
+        require("nvim-tree.actions.reloaders").reload_explorer()
+      end
     end)
   end
+end
+
+function M.setup(opts)
+  M.enable_reload = not opts.experimental_watchers
 end
 
 return M

--- a/lua/nvim-tree/actions/rename-file.lua
+++ b/lua/nvim-tree/actions/rename-file.lua
@@ -45,7 +45,7 @@ function M.fn(with_sub)
 end
 
 function M.setup(opts)
-  M.enable_reload = not opts.git.watcher.enable or not opts.git.enable
+  M.enable_reload = not opts.filesystem_watchers.enable
 end
 
 return M

--- a/lua/nvim-tree/actions/system-open.lua
+++ b/lua/nvim-tree/actions/system-open.lua
@@ -51,7 +51,7 @@ function M.fn(node)
 end
 
 function M.setup(opts)
-  M.config.system_open = opts or {}
+  M.config.system_open = opts.system_open or {}
 
   if #M.config.system_open.cmd == 0 then
     if M.config.is_windows then

--- a/lua/nvim-tree/actions/trash.lua
+++ b/lua/nvim-tree/actions/trash.lua
@@ -89,7 +89,7 @@ end
 
 function M.setup(opts)
   M.config.trash = opts.trash or {}
-  M.enable_reload = not opts.git.watcher.enable
+  M.enable_reload = not opts.git.watcher.enable or not opts.git.enable
 end
 
 return M

--- a/lua/nvim-tree/actions/trash.lua
+++ b/lua/nvim-tree/actions/trash.lua
@@ -71,20 +71,25 @@ function M.fn(node)
     if node.nodes ~= nil and not node.link_to then
       trash_path(function()
         events._dispatch_folder_removed(node.absolute_path)
-        require("nvim-tree.actions.reloaders").reload_explorer()
+        if M.enable_reload then
+          require("nvim-tree.actions.reloaders").reload_explorer()
+        end
       end)
     else
       trash_path(function()
         events._dispatch_file_removed(node.absolute_path)
         clear_buffer(node.absolute_path)
-        require("nvim-tree.actions.reloaders").reload_explorer()
+        if M.enable_reload then
+          require("nvim-tree.actions.reloaders").reload_explorer()
+        end
       end)
     end
   end
 end
 
 function M.setup(opts)
-  M.config.trash = opts or {}
+  M.config.trash = opts.trash or {}
+  M.enable_reload = not opts.experimental_watchers
 end
 
 return M

--- a/lua/nvim-tree/actions/trash.lua
+++ b/lua/nvim-tree/actions/trash.lua
@@ -89,7 +89,7 @@ end
 
 function M.setup(opts)
   M.config.trash = opts.trash or {}
-  M.enable_reload = not opts.git.watcher.enable or not opts.git.enable
+  M.enable_reload = not opts.filesystem_watchers.enable
 end
 
 return M

--- a/lua/nvim-tree/actions/trash.lua
+++ b/lua/nvim-tree/actions/trash.lua
@@ -89,7 +89,7 @@ end
 
 function M.setup(opts)
   M.config.trash = opts.trash or {}
-  M.enable_reload = not opts.experimental_watchers
+  M.enable_reload = not opts.git.watcher.enable
 end
 
 return M

--- a/lua/nvim-tree/core.lua
+++ b/lua/nvim-tree/core.lua
@@ -9,6 +9,9 @@ TreeExplorer = nil
 local first_init_done = false
 
 function M.init(foldername)
+  if TreeExplorer then
+    TreeExplorer:_clear_watchers()
+  end
   TreeExplorer = explorer.Explorer.new(foldername)
   if not first_init_done then
     events._dispatch_ready()

--- a/lua/nvim-tree/explorer/init.lua
+++ b/lua/nvim-tree/explorer/init.lua
@@ -1,6 +1,7 @@
 local uv = vim.loop
 
 local git = require "nvim-tree.git"
+local watch = require "nvim-tree.explorer.watch"
 
 local M = {}
 
@@ -15,6 +16,8 @@ function Explorer.new(cwd)
   local explorer = setmetatable({
     absolute_path = cwd,
     nodes = {},
+    watcher = watch.create_watcher(cwd),
+    open = true,
   }, Explorer)
   explorer:_load(explorer)
   return explorer
@@ -28,6 +31,20 @@ end
 
 function Explorer:expand(node)
   self:_load(node)
+end
+
+function Explorer:_clear_watchers()
+  local function iterate(node)
+    if node.watcher then
+      node.watcher:stop()
+      for _, node_ in pairs(node.nodes) do
+        if node_.watcher then
+          iterate(node_)
+        end
+      end
+    end
+  end
+  iterate(self)
 end
 
 function M.setup(opts)

--- a/lua/nvim-tree/explorer/init.lua
+++ b/lua/nvim-tree/explorer/init.lua
@@ -33,18 +33,22 @@ function Explorer:expand(node)
   self:_load(node)
 end
 
-function Explorer:_clear_watchers()
+function Explorer.clear_watchers_for(root_node)
   local function iterate(node)
     if node.watcher then
       node.watcher:stop()
-      for _, node_ in pairs(node.nodes) do
-        if node_.watcher then
-          iterate(node_)
+      for _, child in pairs(node.nodes) do
+        if child.watcher then
+          iterate(child)
         end
       end
     end
   end
-  iterate(self)
+  iterate(root_node)
+end
+
+function Explorer:_clear_watchers()
+  Explorer.clear_watchers_for(self)
 end
 
 function M.setup(opts)

--- a/lua/nvim-tree/explorer/init.lua
+++ b/lua/nvim-tree/explorer/init.lua
@@ -52,6 +52,7 @@ function M.setup(opts)
   require("nvim-tree.explorer.filters").setup(opts)
   require("nvim-tree.explorer.sorters").setup(opts)
   require("nvim-tree.explorer.reload").setup(opts)
+  require("nvim-tree.explorer.watch").setup(opts)
 end
 
 M.Explorer = Explorer

--- a/lua/nvim-tree/explorer/node-builders.lua
+++ b/lua/nvim-tree/explorer/node-builders.lua
@@ -1,5 +1,6 @@
 local uv = vim.loop
 local utils = require "nvim-tree.utils"
+local watch = require "nvim-tree.explorer.watch"
 
 local M = {
   is_windows = vim.fn.has "win32" == 1,
@@ -18,6 +19,7 @@ function M.folder(parent, absolute_path, name)
     nodes = {},
     open = false,
     parent = parent,
+    watcher = watch.create_watcher(absolute_path),
   }
 end
 
@@ -49,12 +51,13 @@ end
 function M.link(parent, absolute_path, name)
   --- I dont know if this is needed, because in my understanding, there isnt hard links in windows, but just to be sure i changed it.
   local link_to = uv.fs_realpath(absolute_path)
-  local open, nodes, has_children
+  local open, nodes, has_children, watcher
   if (link_to ~= nil) and uv.fs_stat(link_to).type == "directory" then
     local handle = uv.fs_scandir(link_to)
     has_children = handle and uv.fs_scandir_next(handle) ~= nil
     open = false
     nodes = {}
+    watcher = watch.create_watcher(link_to)
   end
 
   return {
@@ -67,6 +70,7 @@ function M.link(parent, absolute_path, name)
     nodes = nodes,
     open = open,
     parent = parent,
+    watcher = watcher,
   }
 end
 

--- a/lua/nvim-tree/explorer/watch.lua
+++ b/lua/nvim-tree/explorer/watch.lua
@@ -1,0 +1,39 @@
+local utils = require "nvim-tree.utils"
+local git = require "nvim-tree.git"
+local Watcher = require("nvim-tree.watcher").Watcher
+
+local M = {}
+
+local function reload_and_get_git_project(path)
+  local project_root = git.get_project_root(path)
+  git.reload_project(project_root)
+  return project_root, git.get_project(project_root) or {}
+end
+
+local function update_parent_statuses(node, project, root)
+  while project and node and node.absolute_path ~= root do
+    require("nvim-tree.explorer.common").update_git_status(node, false, project)
+    node = node.parent
+  end
+end
+
+function M.create_watcher(absolute_path)
+  Watcher.new {
+    absolute_path = absolute_path,
+    on_event = function(path)
+      local n = utils.get_node_from_path(absolute_path)
+      if not n then
+        return
+      end
+
+      local node = utils.get_parent_of_group(n)
+      local project_root, project = reload_and_get_git_project(path)
+      require("nvim-tree.explorer.reload").reload(node, project)
+      update_parent_statuses(node, project, project_root)
+
+      require("nvim-tree.renderer").draw()
+    end,
+  }
+end
+
+return M

--- a/lua/nvim-tree/explorer/watch.lua
+++ b/lua/nvim-tree/explorer/watch.lua
@@ -18,7 +18,15 @@ local function update_parent_statuses(node, project, root)
   end
 end
 
+local function is_git(path)
+  return path:match "%.git$" ~= nil or path:match(utils.path_add_trailing ".git") ~= nil
+end
+
 function M.create_watcher(absolute_path)
+  if is_git(absolute_path) then
+    return nil
+  end
+
   log.line("watcher", "node start    '%s'", absolute_path)
   Watcher.new {
     absolute_path = absolute_path,

--- a/lua/nvim-tree/explorer/watch.lua
+++ b/lua/nvim-tree/explorer/watch.lua
@@ -52,8 +52,8 @@ function M.create_watcher(absolute_path)
 end
 
 function M.setup(opts)
-  M.enabled = opts.git.watcher.enable and opts.git.enable
-  M.interval = opts.git.watcher.interval
+  M.enabled = opts.filesystem_watchers.enable
+  M.interval = opts.filesystem_watchers.interval
 end
 
 return M

--- a/lua/nvim-tree/explorer/watch.lua
+++ b/lua/nvim-tree/explorer/watch.lua
@@ -1,3 +1,4 @@
+local log = require "nvim-tree.log"
 local utils = require "nvim-tree.utils"
 local git = require "nvim-tree.git"
 local Watcher = require("nvim-tree.watcher").Watcher
@@ -25,6 +26,7 @@ function M.create_watcher(absolute_path)
       if not n then
         return
       end
+      log.line("watcher", "node '%s'", path)
 
       local node = utils.get_parent_of_group(n)
       local project_root, project = reload_and_get_git_project(path)

--- a/lua/nvim-tree/explorer/watch.lua
+++ b/lua/nvim-tree/explorer/watch.lua
@@ -23,6 +23,9 @@ local function is_git(path)
 end
 
 function M.create_watcher(absolute_path)
+  if not M.enabled then
+    return nil
+  end
   if is_git(absolute_path) then
     return nil
   end
@@ -30,6 +33,7 @@ function M.create_watcher(absolute_path)
   log.line("watcher", "node start '%s'", absolute_path)
   Watcher.new {
     absolute_path = absolute_path,
+    interval = M.interval,
     on_event = function(path)
       local n = utils.get_node_from_path(absolute_path)
       if not n then
@@ -45,6 +49,11 @@ function M.create_watcher(absolute_path)
       require("nvim-tree.renderer").draw()
     end,
   }
+end
+
+function M.setup(opts)
+  M.enabled = opts.git.watcher.enable and opts.git.enable
+  M.interval = opts.git.watcher.interval
 end
 
 return M

--- a/lua/nvim-tree/explorer/watch.lua
+++ b/lua/nvim-tree/explorer/watch.lua
@@ -19,6 +19,7 @@ local function update_parent_statuses(node, project, root)
 end
 
 function M.create_watcher(absolute_path)
+  log.line("watcher", "node start    '%s'", absolute_path)
   Watcher.new {
     absolute_path = absolute_path,
     on_event = function(path)
@@ -26,7 +27,7 @@ function M.create_watcher(absolute_path)
       if not n then
         return
       end
-      log.line("watcher", "node '%s'", path)
+      log.line("watcher", "node event '%s'", path)
 
       local node = utils.get_parent_of_group(n)
       local project_root, project = reload_and_get_git_project(path)

--- a/lua/nvim-tree/explorer/watch.lua
+++ b/lua/nvim-tree/explorer/watch.lua
@@ -27,7 +27,7 @@ function M.create_watcher(absolute_path)
     return nil
   end
 
-  log.line("watcher", "node start    '%s'", absolute_path)
+  log.line("watcher", "node start '%s'", absolute_path)
   Watcher.new {
     absolute_path = absolute_path,
     on_event = function(path)

--- a/lua/nvim-tree/git/init.lua
+++ b/lua/nvim-tree/git/init.lua
@@ -1,5 +1,7 @@
+local utils = require "nvim-tree.utils"
 local git_utils = require "nvim-tree.git.utils"
 local Runner = require "nvim-tree.git.runner"
+local Watcher = require("nvim-tree.watcher").Watcher
 
 local M = {
   config = nil,
@@ -13,20 +15,35 @@ function M.reload()
   end
 
   for project_root in pairs(M.projects) do
-    M.projects[project_root] = {}
-    local git_status = Runner.run {
-      project_root = project_root,
-      list_untracked = git_utils.should_show_untracked(project_root),
-      list_ignored = true,
-      timeout = M.config.timeout,
-    }
-    M.projects[project_root] = {
-      files = git_status,
-      dirs = git_utils.file_status_to_dir_status(git_status, project_root),
-    }
+    M.reload_project(project_root)
   end
 
   return M.projects
+end
+
+function M.reload_project(project_root)
+  local project = M.projects[project_root]
+  if not project or not M.config.enable then
+    return
+  end
+
+  local watcher = M.projects[project_root].watcher
+  M.projects[project_root] = {}
+  local git_status = Runner.run {
+    project_root = project_root,
+    list_untracked = git_utils.should_show_untracked(project_root),
+    list_ignored = true,
+    timeout = M.config.timeout,
+  }
+  M.projects[project_root] = {
+    files = git_status,
+    dirs = git_utils.file_status_to_dir_status(git_status, project_root),
+    watcher = watcher,
+  }
+end
+
+function M.get_project(project_root)
+  return M.projects[project_root]
 end
 
 function M.get_project_root(cwd)
@@ -40,6 +57,35 @@ function M.get_project_root(cwd)
 
   local project_root = git_utils.get_toplevel(cwd)
   return project_root
+end
+
+function M.reload_tree_at(project_root)
+  local root_node = utils.get_node_from_path(project_root)
+  if not root_node then
+    return
+  end
+
+  M.reload_project(project_root)
+  local project = M.get_project(project_root)
+
+  local project_files = project.files and project.files or {}
+  local project_dirs = project.dirs and project.dirs or {}
+
+  local function iterate(n)
+    local parent_ignored = n.git_status == "!!"
+    for _, node in pairs(n.nodes) do
+      node.git_status = project_dirs[node.absolute_path] or project_files[node.absolute_path]
+      if not node.git_status and parent_ignored then
+        node.git_status = "!!"
+      end
+
+      if node.nodes and #node.nodes > 0 then
+        iterate(node)
+      end
+    end
+  end
+
+  iterate(root_node)
 end
 
 function M.load_project_status(cwd)
@@ -67,6 +113,15 @@ function M.load_project_status(cwd)
   M.projects[project_root] = {
     files = git_status,
     dirs = git_utils.file_status_to_dir_status(git_status, project_root),
+    watcher = Watcher.new {
+      absolute_path = utils.path_join { project_root, ".git" },
+      on_event = function()
+        utils.debounce(200, function()
+          M.reload_tree_at(project_root)
+          require("nvim-tree.renderer").draw()
+        end)
+      end,
+    },
   }
   return M.projects[project_root]
 end

--- a/lua/nvim-tree/git/init.lua
+++ b/lua/nvim-tree/git/init.lua
@@ -111,12 +111,13 @@ function M.load_project_status(cwd)
     list_ignored = true,
     timeout = M.config.timeout,
   }
-  log.line("watcher", "git start")
-  M.projects[project_root] = {
-    files = git_status,
-    dirs = git_utils.file_status_to_dir_status(git_status, project_root),
+
+  local watcher = nil
+  if M.config.watcher.enable then
+    log.line("watcher", "git start")
     watcher = Watcher.new {
       absolute_path = utils.path_join { project_root, ".git" },
+      interval = M.config.watcher.interval,
       on_event = function()
         log.line("watcher", "git event")
         utils.debounce(200, function()
@@ -124,7 +125,13 @@ function M.load_project_status(cwd)
           require("nvim-tree.renderer").draw()
         end)
       end,
-    },
+    }
+  end
+
+  M.projects[project_root] = {
+    files = git_status,
+    dirs = git_utils.file_status_to_dir_status(git_status, project_root),
+    watcher = watcher,
   }
   return M.projects[project_root]
 end

--- a/lua/nvim-tree/git/init.lua
+++ b/lua/nvim-tree/git/init.lua
@@ -120,10 +120,8 @@ function M.load_project_status(cwd)
       interval = M.config.watcher.interval,
       on_event = function()
         log.line("watcher", "git event")
-        utils.debounce(200, function()
-          M.reload_tree_at(project_root)
-          require("nvim-tree.renderer").draw()
-        end)
+        M.reload_tree_at(project_root)
+        require("nvim-tree.renderer").draw()
       end,
     }
   end
@@ -138,6 +136,7 @@ end
 
 function M.setup(opts)
   M.config = opts.git
+  M.config.watcher = opts.filesystem_watchers
 end
 
 return M

--- a/lua/nvim-tree/git/init.lua
+++ b/lua/nvim-tree/git/init.lua
@@ -111,13 +111,14 @@ function M.load_project_status(cwd)
     list_ignored = true,
     timeout = M.config.timeout,
   }
+  log.line("watcher", "git start")
   M.projects[project_root] = {
     files = git_status,
     dirs = git_utils.file_status_to_dir_status(git_status, project_root),
     watcher = Watcher.new {
       absolute_path = utils.path_join { project_root, ".git" },
       on_event = function()
-        log.line("watcher", "git")
+        log.line("watcher", "git event")
         utils.debounce(200, function()
           M.reload_tree_at(project_root)
           require("nvim-tree.renderer").draw()

--- a/lua/nvim-tree/git/init.lua
+++ b/lua/nvim-tree/git/init.lua
@@ -1,3 +1,4 @@
+local log = require "nvim-tree.log"
 local utils = require "nvim-tree.utils"
 local git_utils = require "nvim-tree.git.utils"
 local Runner = require "nvim-tree.git.runner"
@@ -116,6 +117,7 @@ function M.load_project_status(cwd)
     watcher = Watcher.new {
       absolute_path = utils.path_join { project_root, ".git" },
       on_event = function()
+        log.line("watcher", "git")
         utils.debounce(200, function()
           M.reload_tree_at(project_root)
           require("nvim-tree.renderer").draw()

--- a/lua/nvim-tree/git/runner.lua
+++ b/lua/nvim-tree/git/runner.lua
@@ -53,7 +53,9 @@ end
 
 function Runner:_log_raw_output(output)
   if output and type(output) == "string" then
-    log.raw("git", "%s", output)
+    -- TODO put this back after watcher feature completed
+    -- log.raw("git", "%s", output)
+    log.line("git", "done")
   end
 end
 

--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -96,7 +96,8 @@ function M.get_user_input_char()
   return vim.fn.nr2char(c)
 end
 
--- get the node from the tree that matches the predicate
+-- get the node and index of the node from the tree that matches the predicate.
+-- The explored nodes are those displayed on the view.
 -- @param nodes list of node
 -- @param fn    function(node): boolean
 function M.find_node(nodes, fn)
@@ -124,6 +125,46 @@ function M.find_node(nodes, fn)
   i = require("nvim-tree.view").is_root_folder_visible() and i or i - 1
   i = require("nvim-tree.live-filter").filter and i + 1 or i
   return node, i
+end
+
+-- get the node in the tree state depending on the absolute path of the node
+-- (grouped or hidden too)
+function M.get_node_from_path(path)
+  local explorer = require("nvim-tree.core").get_explorer()
+  if explorer.absolute_path == path then
+    return explorer
+  end
+
+  local function iterate(nodes)
+    for _, node in pairs(nodes) do
+      if node.absolute_path == path or node.link_to == path then
+        return node
+      end
+      if node.nodes then
+        local res = iterate(node.nodes)
+        if res then
+          return res
+        end
+      end
+      if node.group_next then
+        local res = iterate { node.group_next }
+        if res then
+          return res
+        end
+      end
+    end
+  end
+
+  return iterate(explorer.nodes)
+end
+
+-- get the highest parent of grouped nodes
+function M.get_parent_of_group(node_)
+  local node = node_
+  while node.parent and node.parent.group_next do
+    node = node.parent
+  end
+  return node
 end
 
 -- return visible nodes indexed by line
@@ -244,6 +285,23 @@ function M.key_by(tbl, key)
     keyed[val[key]] = val
   end
   return keyed
+end
+
+local TIMER = nil
+function M.debounce(timeout, fn)
+  if TIMER then
+    TIMER:close()
+  end
+  TIMER = uv.new_timer()
+  TIMER:start(
+    timeout,
+    0,
+    vim.schedule_wrap(function()
+      TIMER:close()
+      TIMER = nil
+      fn()
+    end)
+  )
 end
 
 return M

--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -287,21 +287,4 @@ function M.key_by(tbl, key)
   return keyed
 end
 
-local TIMER = nil
-function M.debounce(timeout, fn)
-  if TIMER then
-    TIMER:close()
-  end
-  TIMER = uv.new_timer()
-  TIMER:start(
-    timeout,
-    0,
-    vim.schedule_wrap(function()
-      TIMER:close()
-      TIMER = nil
-      fn()
-    end)
-  )
-end
-
 return M

--- a/lua/nvim-tree/watcher.lua
+++ b/lua/nvim-tree/watcher.lua
@@ -29,11 +29,13 @@ end
 function Watcher:start()
   log.line("watcher", "Watcher:start '%s'", self._opts.absolute_path)
 
-  local rc, name
+  local rc, _, name
 
   self._p, _, name = uv.new_fs_poll()
   if not self._p then
-    utils.warn(string.format("Could not initialize an fs_poll watcher for path %s : %s", self._opts.absolute_path, name))
+    utils.warn(
+      string.format("Could not initialize an fs_poll watcher for path %s : %s", self._opts.absolute_path, name)
+    )
     return nil
   end
 

--- a/lua/nvim-tree/watcher.lua
+++ b/lua/nvim-tree/watcher.lua
@@ -1,5 +1,6 @@
 local uv = vim.loop
 
+local log = require "nvim-tree.log"
 local utils = require "nvim-tree.utils"
 
 local M = {}
@@ -10,6 +11,7 @@ function Watcher.new(opts)
   if not M.enabled then
     return nil
   end
+  log.line("watcher", "Watcher:new   '%s'", opts.absolute_path)
 
   local ok, fs_event = pcall(uv.new_fs_event)
   if not ok then
@@ -26,6 +28,7 @@ function Watcher.new(opts)
 end
 
 function Watcher:start(opts)
+  log.line("watcher", "Watcher:start '%s'", self._path)
   local ok = pcall(
     uv.fs_event_start,
     self._w,
@@ -44,6 +47,7 @@ function Watcher:start(opts)
 end
 
 function Watcher:stop()
+  log.line("watcher", "Watcher:stop  '%s'", self._path)
   if self._w then
     uv.fs_event_stop(self._w)
   end

--- a/lua/nvim-tree/watcher.lua
+++ b/lua/nvim-tree/watcher.lua
@@ -72,11 +72,6 @@ function Watcher:stop()
   end
 end
 
-function Watcher:restart()
-  self:stop()
-  return self:start()
-end
-
 M.Watcher = Watcher
 
 return M

--- a/lua/nvim-tree/watcher.lua
+++ b/lua/nvim-tree/watcher.lua
@@ -1,0 +1,63 @@
+local uv = vim.loop
+
+local utils = require "nvim-tree.utils"
+
+local M = {}
+local Watcher = {}
+Watcher.__index = Watcher
+
+function Watcher.new(opts)
+  if not M.enabled then
+    return nil
+  end
+
+  local ok, fs_event = pcall(uv.new_fs_event)
+  if not ok then
+    utils.warn(string.format("Could not initialize a watcher for path %s", opts.absolute_path))
+    return nil
+  end
+
+  local watcher = setmetatable({
+    _path = opts.absolute_path,
+    _w = fs_event,
+  }, Watcher)
+
+  return watcher:start(opts)
+end
+
+function Watcher:start(opts)
+  local ok = pcall(
+    uv.fs_event_start,
+    self._w,
+    self._path,
+    {},
+    vim.schedule_wrap(function()
+      opts.on_event(self._path)
+    end)
+  )
+  if not ok then
+    utils.warn(string.format("Could not start the watcher for path %s", self._path))
+    return nil
+  end
+
+  return self
+end
+
+function Watcher:stop()
+  if self._w then
+    uv.fs_event_stop(self._w)
+  end
+end
+
+function Watcher:restart()
+  self:stop()
+  return self:start()
+end
+
+function M.setup(opts)
+  M.enabled = opts.experimental_watchers
+end
+
+M.Watcher = Watcher
+
+return M

--- a/lua/nvim-tree/watcher.lua
+++ b/lua/nvim-tree/watcher.lua
@@ -4,21 +4,34 @@ local log = require "nvim-tree.log"
 local utils = require "nvim-tree.utils"
 
 local M = {}
-local Watcher = {}
+local Watcher = {
+  _watchers = {},
+}
 Watcher.__index = Watcher
 
--- TODO check for a Watcher with the same opts.absolute_path and return that
 function Watcher.new(opts)
   if not M.enabled then
     return nil
   end
-  log.line("watcher", "Watcher:new   '%s'", opts.absolute_path)
+
+  for _, existing in ipairs(Watcher._watchers) do
+    if existing._opts.absolute_path == opts.absolute_path then
+      log.line("watcher", "Watcher:new using existing '%s'", opts.absolute_path)
+      return existing
+    end
+  end
+
+  log.line("watcher", "Watcher:new '%s'", opts.absolute_path)
 
   local watcher = setmetatable({
     _opts = opts,
   }, Watcher)
 
-  return watcher:start()
+  watcher = watcher:start()
+
+  table.insert(Watcher._watchers, watcher)
+
+  return watcher
 end
 
 function Watcher:start()

--- a/lua/nvim-tree/watcher.lua
+++ b/lua/nvim-tree/watcher.lua
@@ -10,10 +10,6 @@ local Watcher = {
 Watcher.__index = Watcher
 
 function Watcher.new(opts)
-  if not M.enabled then
-    return nil
-  end
-
   for _, existing in ipairs(Watcher._watchers) do
     if existing._opts.absolute_path == opts.absolute_path then
       log.line("watcher", "Watcher:new using existing '%s'", opts.absolute_path)
@@ -56,7 +52,7 @@ function Watcher:start()
     end
   end)
 
-  rc, _, name = uv.fs_poll_start(self._p, self._opts.absolute_path, M.interval, poll_cb)
+  rc, _, name = uv.fs_poll_start(self._p, self._opts.absolute_path, self._opts.interval, poll_cb)
   if rc ~= 0 then
     utils.warn(string.format("Could not start the fs_poll watcher for path %s : %s", self._opts.absolute_path, name))
     return nil
@@ -79,11 +75,6 @@ end
 function Watcher:restart()
   self:stop()
   return self:start()
-end
-
-function M.setup(opts)
-  M.enabled = opts.git.watcher.enable
-  M.interval = opts.git.watcher.interval
 end
 
 M.Watcher = Watcher


### PR DESCRIPTION
This commit introduces watchers to update the tree.
This behavior is introduced behind an "experimental_watchers" option which should prevent instabilities.
It also adds watchers on the git module that will allow git to be updated whenever the `.git` folder changes.
It will become the default at some point.

To check:
- make sure everything is reliably connected
- let 2/3 people test this before merging
- a proper code review

Bugs encountered so far:
- not fixable apparently: git updates the index a LOT (on BufEnter < which is strange, when running git status... etcetc)

Also after some debugging, i've noticed a bug in the reloader.
New nodes where not applying git status modification on explorer reload, which caused the tree to get out of sync with git, which i've observed quite a few times these last weeks.
Also this caused an issue i've noticed when refreshing git-ignored files, which lose the ignored icon when running explorer . reload for a few milliseconds, and then reset by git reload, which was causing a weird UI behavior.

This PR fixes it too.