### PR TITLE
feat: display node whose name length is wider than the width of nvim-tree window in floating window.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ require'nvim-tree'.setup { -- BEGIN_DEFAULT_OPTS
     add_trailing = false,
     group_empty = false,
     highlight_git = false,
+    full_name = false,
     highlight_opened_files = "none",
     root_folder_modifier = ":~",
     indent_markers = {

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -124,6 +124,7 @@ Values may be functions. Warning: this may result in unexpected behaviour.
         add_trailing = false,
         group_empty = false,
         highlight_git = false,
+        full_name = false,
         highlight_opened_files = "none",
         root_folder_modifier = ":~",
         indent_markers = {
@@ -514,6 +515,10 @@ UI rendering setup
 
     *nvim-tree.renderer.group_empty*
     Compact folders that only contain a single folder into one node in the file tree.
+      Type: `boolean`, Default: `false`
+
+    *nvim-tree.renderer.full_name*
+    Display node whose name length is wider than the width of nvim-tree window in floating window.
       Type: `boolean`, Default: `false`
 
     *nvim-tree.renderer.highlight_git*

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -385,6 +385,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
     add_trailing = false,
     group_empty = false,
     highlight_git = false,
+    full_name = false,
     highlight_opened_files = "none",
     root_folder_modifier = ":~",
     indent_markers = {

--- a/lua/nvim-tree/renderer/components/full-name.lua
+++ b/lua/nvim-tree/renderer/components/full-name.lua
@@ -1,0 +1,83 @@
+local M = {}
+
+local api = vim.api
+local fn = vim.fn
+
+local function hide(win)
+  if win then
+    if api.nvim_win_is_valid(win) then
+      api.nvim_win_close(win, true)
+    end
+  end
+end
+
+local function show()
+  local line_nr = api.nvim_win_get_cursor(0)[1]
+  if line_nr == 1 and require("nvim-tree.view").is_root_folder_visible() then
+    return
+  end
+  if vim.wo.wrap then
+    return
+  end
+  -- only work for left tree
+  if vim.api.nvim_win_get_position(0)[2] ~= 0 then
+    return
+  end
+
+  local line = fn.getline "."
+  local leftcol = fn.winsaveview().leftcol
+  -- hide full name if left column of node in nvim-tree win is not zero
+  if leftcol ~= 0 then
+    return
+  end
+
+  local width = fn.strdisplaywidth(fn.substitute(line, "[^[:print:]]*$", "", "g"))
+  if width < fn.winwidth(0) then
+    return
+  end
+  M.popup_win = api.nvim_open_win(api.nvim_create_buf(false, false), false, {
+    relative = "win",
+    bufpos = { fn.line "." - 2, 0 },
+    width = math.min(width, vim.o.columns - 2),
+    height = 1,
+    noautocmd = true,
+    style = "minimal",
+  })
+
+  local ns_id = api.nvim_get_namespaces()["NvimTreeHighlights"]
+  local extmarks = api.nvim_buf_get_extmarks(0, ns_id, { line_nr - 1, 0 }, { line_nr - 1, -1 }, { details = 1 })
+  api.nvim_win_call(M.popup_win, function()
+    fn.setbufline("%", 1, line)
+    for _, extmark in ipairs(extmarks) do
+      local hl = extmark[4]
+      api.nvim_buf_add_highlight(0, ns_id, hl.hl_group, 0, extmark[3], hl.end_col)
+    end
+    vim.cmd [[ setlocal nowrap cursorline noswapfile nobuflisted buftype=nofile bufhidden=hide ]]
+  end)
+end
+
+M.setup = function(opts)
+  M.config = opts.renderer
+  if not M.config.full_name then
+    return
+  end
+
+  local group = api.nvim_create_augroup("nvim_tree_floating_node", { clear = true })
+  api.nvim_create_autocmd({ "BufLeave", "CursorMoved" }, {
+    group = group,
+    pattern = { "NvimTree_*" },
+    callback = function()
+      hide(M.popup_win)
+    end,
+  })
+
+  api.nvim_create_autocmd({ "CursorMoved" }, {
+    group = group,
+    pattern = { "NvimTree_*" },
+    callback = function()
+      show()
+    end,
+  })
+end
+
+return M

--- a/lua/nvim-tree/renderer/init.lua
+++ b/lua/nvim-tree/renderer/init.lua
@@ -5,6 +5,7 @@ local view = require "nvim-tree.view"
 
 local _padding = require "nvim-tree.renderer.components.padding"
 local icon_component = require "nvim-tree.renderer.components.icons"
+local full_name = require "nvim-tree.renderer.components.full-name"
 local help = require "nvim-tree.renderer.help"
 local git = require "nvim-tree.renderer.components.git"
 local Builder = require "nvim-tree.renderer.builder"
@@ -104,6 +105,7 @@ function M.setup(opts)
   M.config = opts.renderer
 
   _padding.setup(opts)
+  full_name.setup(opts)
   git.setup(opts)
   icon_component.setup(opts)
 end


### PR DESCRIPTION
Referencing #1297

TODO:
- ~~add an option in `require'nvim-tree'.setup`~~
- ~~show floating window when `winsaveview().leftcol` is not zero~~