### PR TITLE
feat: guard against multiple setup calls

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -16,7 +16,9 @@ local collapse_all = require "nvim-tree.actions.collapse-all"
 
 local _config = {}
 
-local M = {}
+local M = {
+  setup_called = false,
+}
 
 function M.focus()
   M.open()
@@ -560,6 +562,12 @@ function M.setup(conf)
     utils.warn "nvim-tree.lua requires Neovim 0.7 or higher"
     return
   end
+
+  if M.setup_called then
+    utils.warn "nvim-tree.lua setup called multiple times"
+    return
+  end
+  M.setup_called = true
 
   legacy.migrate_legacy_options(conf or {})
 


### PR DESCRIPTION
closes #1306

We have had a few cases where users have done this.

We could make nvim-tree capable of "resetting itself" and applying new config, however that doesn't seem worth the effort. We would have to tear down the autocommands etc. etc.