### PR TITLE
feat(view): ability to centralize node initially

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ require'nvim-tree'.setup { -- BEGIN_DEFAULT_OPTS
   respect_buf_cwd = false,
   view = {
     adaptive_size = false,
+    centralize_selection = false,
     width = 30,
     height = 30,
     hide_root_folder = false,

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -105,6 +105,7 @@ Values may be functions. Warning: this may result in unexpected behaviour.
       respect_buf_cwd = false,
       view = {
         adaptive_size = false,
+        centralize_selection = false,
         width = 30,
         height = 30,
         hide_root_folder = false,
@@ -452,6 +453,11 @@ Window / buffer setup.
     *nvim-tree.view.adaptive_size*
     Resize the window on each draw based on the longest line.
     Only works when |nvim-tree.view.side| is `left` or `right`.
+      Type: `boolean`, Default: `false`
+
+    *nvim-tree.view.centralize_selection*
+    When entering nvim-tree, reposition the view so that the current node is
+    initially centralized, see |zz|.
       Type: `boolean`, Default: `false`
 
     *nvim-tree.view.hide_root_folder*

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -347,6 +347,18 @@ local function setup_autocommands(opts)
   if opts.reload_on_bufenter and not has_watchers then
     create_nvim_tree_autocmd("BufEnter", { pattern = "NvimTree_*", callback = reloaders.reload_explorer })
   end
+
+  if opts.view.centralize_selection then
+    create_nvim_tree_autocmd("BufEnter", {
+      pattern = "NvimTree_*",
+      callback = function()
+        vim.schedule(function()
+          local keys = api.nvim_replace_termcodes("zz", true, false, true)
+          api.nvim_feedkeys(keys, "n", true)
+        end)
+      end,
+    })
+  end
 end
 
 local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
@@ -366,6 +378,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
   respect_buf_cwd = false,
   view = {
     adaptive_size = false,
+    centralize_selection = false,
     width = 30,
     height = 30,
     hide_root_folder = false,

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -6,6 +6,7 @@ local events = require "nvim-tree.events"
 
 M.View = {
   adaptive_size = false,
+  centralize_selection = false,
   tabpages = {},
   cursors = {},
   hide_root_folder = false,
@@ -394,6 +395,7 @@ end
 function M.setup(opts)
   local options = opts.view or {}
   M.View.adaptive_size = options.adaptive_size
+  M.View.centralize_selection = options.centralize_selection
   M.View.side = options.side
   M.View.width = options.width
   M.View.height = options.height


### PR DESCRIPTION
This is only relevant for large nested folders, but I find it easier when the first selection is centered.

```help
    *nvim-tree.view.centralize_selection*
    Reposition the view so that the current node is initially centralized, see |zz|.
      Type: `boolean`, Default: `false`
```

Hopefully this is useful for others :smile:
