### PR TITLE
feat(renderer): indent_markers add a item icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ require'nvim-tree'.setup { -- BEGIN_DEFAULT_OPTS
       icons = {
         corner = "└ ",
         edge = "│ ",
+        item = "│ ",
         none = "  ",
       },
     },

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -131,6 +131,7 @@ Values may be functions. Warning: this may result in unexpected behaviour.
           icons = {
             corner = "└ ",
             edge = "│ ",
+            item = "│ ",
             none = "  ",
           },
         },
@@ -514,7 +515,7 @@ UI rendering setup
 
     *nvim-tree.renderer.indent_markers.icons*
     Icons shown before the file/directory.
-      Type: `table`, Default: `{ corner = "└ ", edge = "│ ", none = "  ", }`
+      Type: `table`, Default: `{ corner = "└ ", edge = "│ ", item = "│ ", none = "  ", }`
 
     *nvim-tree.renderer.icons*
     Configuration options for icons.

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -387,6 +387,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
       icons = {
         corner = "└ ",
         edge = "│ ",
+        item = "│ ",
         none = "  ",
       },
     },

--- a/lua/nvim-tree/renderer/components/padding.lua
+++ b/lua/nvim-tree/renderer/components/padding.lua
@@ -22,6 +22,8 @@ local function get_padding_indent_markers(depth, idx, nodes_number, _, markers)
     for i = 1, rdepth do
       if idx == nodes_number and i == rdepth then
         padding = padding .. M.config.indent_markers.icons.corner
+      elseif markers[i] and i == rdepth then
+        padding = padding .. M.config.indent_markers.icons.item
       elseif markers[i] then
         padding = padding .. M.config.indent_markers.icons.edge
       else


### PR DESCRIPTION
I add a item icon for indent_markers, make it possible to make nvim-tree view like tree command output.

When we config indent_markers to this:

```lua
render.indent_markers = {
    enable = true,
    icons = {
        corner = "└─",
        item = "├─",
        edge = "│ ",
        none = "  ",
    },
},
```

nvim-tree view:

![image](https://user-images.githubusercontent.com/26727562/172048242-135cf84c-e6f4-4e61-b2e1-b7a2ee40165b.png)



