### PR TITLE
feat(trash): default command 'trash' -> 'gio trash'

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ require'nvim-tree'.setup { -- BEGIN_DEFAULT_OPTS
     },
   },
   trash = {
-    cmd = "trash",
+    cmd = "gio trash",
     require_confirm = true,
   },
   live_filter = {

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -237,7 +237,7 @@ Values may be functions. Warning: this may result in unexpected behaviour.
         },
       },
       trash = {
-        cmd = "trash",
+        cmd = "gio trash",
         require_confirm = true,
       },
       live_filter = {
@@ -652,7 +652,8 @@ Configuration options for trashing.
 
     *nvim-tree.trash.cmd*
     The command used to trash items (must be installed on your system).
-      Type: `string`, Default: `"trash"`
+    The default is shipped with glib2 which is a common linux package.
+      Type: `string`, Default: `"gio trash"`
 
     *nvim-tree.trash.require_confirm*
     Show a prompt before trashing takes place.

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -498,7 +498,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
     },
   },
   trash = {
-    cmd = "trash",
+    cmd = "gio trash",
     require_confirm = true,
   },
   live_filter = {


### PR DESCRIPTION
This makes sense since most linux distros already ship with glib2 instead of requiring the user to tweak or install 3rd party dependencies.