### PR TITLE
docs(readme.md): add setup in vimrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Setup may only be run once; subsequent calls will result in a warning. Do not in
 
 ```vim
 " vimrc
+lua require'nvim-tree'.setup {}
 nnoremap <C-n> :NvimTreeToggle<CR>
 nnoremap <leader>r :NvimTreeRefresh<CR>
 nnoremap <leader>n :NvimTreeFindFile<CR>


### PR DESCRIPTION
I followed the readme with Neovim 7.0 and vim plug and it did not worked out of the box

Turns out according to this https://github.com/kyazdani42/nvim-tree.lua/issues/767

i had to add the following in my vim.init (vimscript)

`lua require'nvim-tree'.setup {}`

Added this in the readme so its up to date 