### PR TITLE
feat: wrapped the setup recall guard in an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Setup should be run in a lua file or in a lua heredoc (`:help lua-heredoc`) if u
 
 Legacy `g:` options have been migrated to the setup function. See [this issue](https://github.com/kyazdani42/nvim-tree.lua/issues/674) for information on migrating your configuration.
 
-Setup may only be run once; subsequent calls will result in a warning. Do not invoke from, say, a packer config function and then call it again later. You can suppress the warning using the `suppress_setup_recall_warning` option.
+Setup may only be run once; subsequent calls will be a NOP and will result a warning. Do not invoke from, say, a packer config function and then call it again later. You can suppress the warning using the `suppress_setup_recall_warning` option.
 
 ```vim
 " vimrc

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Setup should be run in a lua file or in a lua heredoc (`:help lua-heredoc`) if u
 
 Legacy `g:` options have been migrated to the setup function. See [this issue](https://github.com/kyazdani42/nvim-tree.lua/issues/674) for information on migrating your configuration.
 
-Setup may only be run once; subsequent calls will result in a warning. Do not invoke from, say, a packer config function and then call it again later.
+Setup may only be run once; subsequent calls will result in a warning. Do not invoke from, say, a packer config function and then call it again later. You can suppress the warning using the `suppress_setup_recall_warning` option.
 
 ```vim
 " vimrc
@@ -77,6 +77,7 @@ require'nvim-tree'.setup { -- BEGIN_DEFAULT_OPTS
   hijack_cursor = false,
   hijack_netrw = true,
   hijack_unnamed_buffer_when_opening = false,
+  suppress_setup_recall_warning = false,
   ignore_buffer_on_setup = false,
   open_on_setup = false,
   open_on_setup_file = false,

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -83,8 +83,10 @@ SETUP                                                *nvim-tree.setup*
 To configure the tree (and make it runnable), you should call the setup
 function.
 
-Setup may only be run once; subsequent calls will result in a warning. Do not
-invoke from, say, a packer config function and then call it again later.
+Setup may only be run once; subsequent calls will be a NOP and will result a
+warning. Do not invoke from, say, a packer config function and then call it
+again later. You can suppress the warning using the `suppress_setup_recall_warning`
+option.
 
 Values may be functions. Warning: this may result in unexpected behaviour.
 >
@@ -95,6 +97,7 @@ Values may be functions. Warning: this may result in unexpected behaviour.
       hijack_cursor = false,
       hijack_netrw = true,
       hijack_unnamed_buffer_when_opening = false,
+      suppress_setup_recall_warning = false,
       ignore_buffer_on_setup = false,
       open_on_setup = false,
       open_on_setup_file = false,
@@ -314,6 +317,11 @@ Can be one of 'name', 'case_sensitive', 'modification_time' or 'extension'.
 
 *nvim-tree.hijack_unnamed_buffer_when_opening*
 Opens in place of the unnamed buffer if it's empty.
+  Type: `boolean`, Default: `false`
+
+*nvim-tree.suppress_setup_recall_warning*
+Suppresses the warning that's displayed when setup is called multiple times.
+When suppressed, subsequent setup calls will still result in a NOP.
   Type: `boolean`, Default: `false`
 
 *nvim-tree.hijack_cursor*

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -368,6 +368,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
   hijack_cursor = false,
   hijack_netrw = true,
   hijack_unnamed_buffer_when_opening = false,
+  suppress_setup_recall_warning = false,
   ignore_buffer_on_setup = false,
   open_on_setup = false,
   open_on_setup_file = false,
@@ -589,17 +590,18 @@ function M.setup(conf)
     return
   end
 
-  if M.setup_called then
-    utils.warn "nvim-tree.lua setup called multiple times"
-    return
-  end
-  M.setup_called = true
-
   legacy.migrate_legacy_options(conf or {})
 
   validate_options(conf)
 
   local opts = merge_options(conf)
+
+  if not opts.suppress_setup_recall_warning and M.setup_called then
+    utils.warn "nvim-tree.lua setup called multiple times"
+    return
+  end
+  M.setup_called = true
+
   local netrw_disabled = opts.disable_netrw or opts.hijack_netrw
 
   _config.update_focused_file = opts.update_focused_file

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -596,8 +596,10 @@ function M.setup(conf)
 
   local opts = merge_options(conf)
 
-  if not opts.suppress_setup_recall_warning and M.setup_called then
-    utils.warn "nvim-tree.lua setup called multiple times"
+  if M.setup_called then
+    if not opts.suppress_setup_recall_warning then
+      utils.warn "nvim-tree.lua setup called multiple times"
+    end
     return
   end
   M.setup_called = true


### PR DESCRIPTION
Following points raised in https://github.com/kyazdani42/nvim-tree.lua/issues/1313, this change wraps the setup call guard (from https://github.com/kyazdani42/nvim-tree.lua/commit/b1ecb75a6cf0bc83ec64d987c7f4128ada3c254e) in an option named `suppress_setup_recall_warning`.

While it makes sense to inform the user that they shouldn't recall `setup`, forcibly warning them every time via the UI is intrusive.

Note that this PR doesn't alter the default behaviour of always warning. The user must explicitly set `suppress_setup_recall_warning` to `true` to suppress the messages. 

The option also prevents the early return. If it's preferable to keep the early return in place, the block ought to be changed to:

```
  if M.setup_called then
    if not opts.suppress_setup_recall_warning then
      utils.warn "nvim-tree.lua setup called multiple times"
    end
    return
  end
```
