### PR TITLE
chore(setup): make setup idempotent

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -13,6 +13,7 @@ local core = require "nvim-tree.core"
 local reloaders = require "nvim-tree.actions.reloaders"
 local copy_paste = require "nvim-tree.actions.copy-paste"
 local collapse_all = require "nvim-tree.actions.collapse-all"
+local git = require "nvim-tree.git"
 
 local _config = {}
 
@@ -323,7 +324,7 @@ function M.change_dir(name)
 end
 
 local function setup_autocommands(opts)
-  local augroup_id = api.nvim_create_augroup("NvimTree", {})
+  local augroup_id = api.nvim_create_augroup("NvimTree", { clear = true })
   local function create_nvim_tree_autocmd(name, custom_opts)
     local default_opts = { group = augroup_id }
     api.nvim_create_autocmd(name, vim.tbl_extend("force", default_opts, custom_opts))
@@ -389,6 +390,16 @@ local function setup_autocommands(opts)
           api.nvim_feedkeys(keys, "n", true)
         end)
       end,
+    })
+  end
+
+  if opts.diagnostics.enable then
+    create_nvim_tree_autocmd("DiagnosticChanged", {
+      callback = require("nvim-tree.diagnostics").update,
+    })
+    create_nvim_tree_autocmd("User", {
+      pattern = "CocDiagnosticChange",
+      callback = require("nvim-tree.diagnostics").update,
     })
   end
 end
@@ -624,11 +635,6 @@ function M.setup(conf)
     return
   end
 
-  if M.setup_called then
-    utils.warn "nvim-tree.lua setup called multiple times"
-    return
-  end
-  M.setup_called = true
   M.init_root = vim.fn.getcwd()
 
   legacy.migrate_legacy_options(conf or {})
@@ -669,8 +675,24 @@ function M.setup(conf)
     require("nvim-web-devicons").setup()
   end
 
-  setup_vim_commands()
   setup_autocommands(opts)
+  require("nvim-tree.watcher").purge_watchers()
+
+  if not M.setup_called then
+    setup_vim_commands()
+  end
+
+  if M.setup_called and view.is_visible() then
+    view.close()
+    view.abandon_current_window()
+  end
+
+  if M.setup_called and core.get_explorer() ~= nil then
+    git.purge_state()
+    TreeExplorer = nil
+  end
+
+  M.setup_called = true
 
   vim.schedule(function()
     M.on_enter(netrw_disabled)

--- a/lua/nvim-tree/actions/init.lua
+++ b/lua/nvim-tree/actions/init.lua
@@ -6,7 +6,8 @@ local view = require "nvim-tree.view"
 local util = require "nvim-tree.utils"
 local nvim_tree_callback = require("nvim-tree.config").nvim_tree_callback
 
-local DEFAULT_MAPPINGS = { -- BEGIN_DEFAULT_MAPPINGS
+-- BEGIN_DEFAULT_MAPPINGS
+local DEFAULT_MAPPINGS = {
   {
     key = { "<CR>", "o", "<2-LeftMouse>" },
     action = "edit",
@@ -217,7 +218,8 @@ local DEFAULT_MAPPINGS = { -- BEGIN_DEFAULT_MAPPINGS
     action = "toggle_help",
     desc = "toggle help",
   },
-} -- END_DEFAULT_MAPPINGS
+}
+-- END_DEFAULT_MAPPINGS
 
 local M = {
   mappings = {},

--- a/lua/nvim-tree/actions/init.lua
+++ b/lua/nvim-tree/actions/init.lua
@@ -6,223 +6,223 @@ local view = require "nvim-tree.view"
 local util = require "nvim-tree.utils"
 local nvim_tree_callback = require("nvim-tree.config").nvim_tree_callback
 
--- BEGIN_DEFAULT_MAPPINGS
-local M = {
-  mappings = {
-    {
-      key = { "<CR>", "o", "<2-LeftMouse>" },
-      action = "edit",
-      desc = "open a file or folder; root will cd to the above directory",
-    },
-    {
-      key = "<C-e>",
-      action = "edit_in_place",
-      desc = "edit the file in place, effectively replacing the tree explorer",
-    },
-    {
-      key = "O",
-      action = "edit_no_picker",
-      desc = "same as (edit) with no window picker",
-    },
-    {
-      key = { "<C-]>", "<2-RightMouse>" },
-      action = "cd",
-      desc = "cd in the directory under the cursor",
-    },
-    {
-      key = "<C-v>",
-      action = "vsplit",
-      desc = "open the file in a vertical split",
-    },
-    {
-      key = "<C-x>",
-      action = "split",
-      desc = "open the file in a horizontal split",
-    },
-    {
-      key = "<C-t>",
-      action = "tabnew",
-      desc = "open the file in a new tab",
-    },
-    {
-      key = "<",
-      action = "prev_sibling",
-      desc = "navigate to the previous sibling of current file/directory",
-    },
-    {
-      key = ">",
-      action = "next_sibling",
-      desc = "navigate to the next sibling of current file/directory",
-    },
-    {
-      key = "P",
-      action = "parent_node",
-      desc = "move cursor to the parent directory",
-    },
-    {
-      key = "<BS>",
-      action = "close_node",
-      desc = "close current opened directory or parent",
-    },
-    {
-      key = "<Tab>",
-      action = "preview",
-      desc = "open the file as a preview (keeps the cursor in the tree)",
-    },
-    {
-      key = "K",
-      action = "first_sibling",
-      desc = "navigate to the first sibling of current file/directory",
-    },
-    {
-      key = "J",
-      action = "last_sibling",
-      desc = "navigate to the last sibling of current file/directory",
-    },
-    {
-      key = "I",
-      action = "toggle_git_ignored",
-      desc = "toggle visibility of files/folders hidden via |git.ignore| option",
-    },
-    {
-      key = "H",
-      action = "toggle_dotfiles",
-      desc = "toggle visibility of dotfiles via |filters.dotfiles| option",
-    },
-    {
-      key = "U",
-      action = "toggle_custom",
-      desc = "toggle visibility of files/folders hidden via |filters.custom| option",
-    },
-    {
-      key = "R",
-      action = "refresh",
-      desc = "refresh the tree",
-    },
-    {
-      key = "a",
-      action = "create",
-      desc = "add a file; leaving a trailing `/` will add a directory",
-    },
-    {
-      key = "d",
-      action = "remove",
-      desc = "delete a file (will prompt for confirmation)",
-    },
-    {
-      key = "D",
-      action = "trash",
-      desc = "trash a file via |trash| option",
-    },
-    {
-      key = "r",
-      action = "rename",
-      desc = "rename a file",
-    },
-    {
-      key = "<C-r>",
-      action = "full_rename",
-      desc = "rename a file and omit the filename on input",
-    },
-    {
-      key = "x",
-      action = "cut",
-      desc = "add/remove file/directory to cut clipboard",
-    },
-    {
-      key = "c",
-      action = "copy",
-      desc = "add/remove file/directory to copy clipboard",
-    },
-    {
-      key = "p",
-      action = "paste",
-      desc = "paste from clipboard; cut clipboard has precedence over copy; will prompt for confirmation",
-    },
-    {
-      key = "y",
-      action = "copy_name",
-      desc = "copy name to system clipboard",
-    },
-    {
-      key = "Y",
-      action = "copy_path",
-      desc = "copy relative path to system clipboard",
-    },
-    {
-      key = "gy",
-      action = "copy_absolute_path",
-      desc = "copy absolute path to system clipboard",
-    },
-    {
-      key = "[c",
-      action = "prev_git_item",
-      desc = "go to next git item",
-    },
-    {
-      key = "]c",
-      action = "next_git_item",
-      desc = "go to prev git item",
-    },
-    {
-      key = "-",
-      action = "dir_up",
-      desc = "navigate up to the parent directory of the current file/directory",
-    },
-    {
-      key = "s",
-      action = "system_open",
-      desc = "open a file with default system application or a folder with default file manager, using |system_open| option",
-    },
-    {
-      key = "f",
-      action = "live_filter",
-      desc = "live filter nodes dynamically based on regex matching.",
-    },
-    {
-      key = "F",
-      action = "clear_live_filter",
-      desc = "clear live filter",
-    },
-    {
-      key = "q",
-      action = "close",
-      desc = "close tree window",
-    },
-    {
-      key = "W",
-      action = "collapse_all",
-      desc = "collapse the whole tree",
-    },
-    {
-      key = "E",
-      action = "expand_all",
-      desc = "expand the whole tree, stopping after expanding |actions.expand_all.max_folder_discovery| folders; this might hang neovim for a while if running on a big folder",
-    },
-    {
-      key = "S",
-      action = "search_node",
-      desc = "prompt the user to enter a path and then expands the tree to match the path",
-    },
-    {
-      key = ".",
-      action = "run_file_command",
-      desc = "enter vim command mode with the file the cursor is on",
-    },
-    {
-      key = "<C-k>",
-      action = "toggle_file_info",
-      desc = "toggle a popup with file infos about the file under the cursor",
-    },
-    {
-      key = "g?",
-      action = "toggle_help",
-      desc = "toggle help",
-    },
+local DEFAULT_MAPPINGS = { -- BEGIN_DEFAULT_MAPPINGS
+  {
+    key = { "<CR>", "o", "<2-LeftMouse>" },
+    action = "edit",
+    desc = "open a file or folder; root will cd to the above directory",
   },
+  {
+    key = "<C-e>",
+    action = "edit_in_place",
+    desc = "edit the file in place, effectively replacing the tree explorer",
+  },
+  {
+    key = "O",
+    action = "edit_no_picker",
+    desc = "same as (edit) with no window picker",
+  },
+  {
+    key = { "<C-]>", "<2-RightMouse>" },
+    action = "cd",
+    desc = "cd in the directory under the cursor",
+  },
+  {
+    key = "<C-v>",
+    action = "vsplit",
+    desc = "open the file in a vertical split",
+  },
+  {
+    key = "<C-x>",
+    action = "split",
+    desc = "open the file in a horizontal split",
+  },
+  {
+    key = "<C-t>",
+    action = "tabnew",
+    desc = "open the file in a new tab",
+  },
+  {
+    key = "<",
+    action = "prev_sibling",
+    desc = "navigate to the previous sibling of current file/directory",
+  },
+  {
+    key = ">",
+    action = "next_sibling",
+    desc = "navigate to the next sibling of current file/directory",
+  },
+  {
+    key = "P",
+    action = "parent_node",
+    desc = "move cursor to the parent directory",
+  },
+  {
+    key = "<BS>",
+    action = "close_node",
+    desc = "close current opened directory or parent",
+  },
+  {
+    key = "<Tab>",
+    action = "preview",
+    desc = "open the file as a preview (keeps the cursor in the tree)",
+  },
+  {
+    key = "K",
+    action = "first_sibling",
+    desc = "navigate to the first sibling of current file/directory",
+  },
+  {
+    key = "J",
+    action = "last_sibling",
+    desc = "navigate to the last sibling of current file/directory",
+  },
+  {
+    key = "I",
+    action = "toggle_git_ignored",
+    desc = "toggle visibility of files/folders hidden via |git.ignore| option",
+  },
+  {
+    key = "H",
+    action = "toggle_dotfiles",
+    desc = "toggle visibility of dotfiles via |filters.dotfiles| option",
+  },
+  {
+    key = "U",
+    action = "toggle_custom",
+    desc = "toggle visibility of files/folders hidden via |filters.custom| option",
+  },
+  {
+    key = "R",
+    action = "refresh",
+    desc = "refresh the tree",
+  },
+  {
+    key = "a",
+    action = "create",
+    desc = "add a file; leaving a trailing `/` will add a directory",
+  },
+  {
+    key = "d",
+    action = "remove",
+    desc = "delete a file (will prompt for confirmation)",
+  },
+  {
+    key = "D",
+    action = "trash",
+    desc = "trash a file via |trash| option",
+  },
+  {
+    key = "r",
+    action = "rename",
+    desc = "rename a file",
+  },
+  {
+    key = "<C-r>",
+    action = "full_rename",
+    desc = "rename a file and omit the filename on input",
+  },
+  {
+    key = "x",
+    action = "cut",
+    desc = "add/remove file/directory to cut clipboard",
+  },
+  {
+    key = "c",
+    action = "copy",
+    desc = "add/remove file/directory to copy clipboard",
+  },
+  {
+    key = "p",
+    action = "paste",
+    desc = "paste from clipboard; cut clipboard has precedence over copy; will prompt for confirmation",
+  },
+  {
+    key = "y",
+    action = "copy_name",
+    desc = "copy name to system clipboard",
+  },
+  {
+    key = "Y",
+    action = "copy_path",
+    desc = "copy relative path to system clipboard",
+  },
+  {
+    key = "gy",
+    action = "copy_absolute_path",
+    desc = "copy absolute path to system clipboard",
+  },
+  {
+    key = "[c",
+    action = "prev_git_item",
+    desc = "go to next git item",
+  },
+  {
+    key = "]c",
+    action = "next_git_item",
+    desc = "go to prev git item",
+  },
+  {
+    key = "-",
+    action = "dir_up",
+    desc = "navigate up to the parent directory of the current file/directory",
+  },
+  {
+    key = "s",
+    action = "system_open",
+    desc = "open a file with default system application or a folder with default file manager, using |system_open| option",
+  },
+  {
+    key = "f",
+    action = "live_filter",
+    desc = "live filter nodes dynamically based on regex matching.",
+  },
+  {
+    key = "F",
+    action = "clear_live_filter",
+    desc = "clear live filter",
+  },
+  {
+    key = "q",
+    action = "close",
+    desc = "close tree window",
+  },
+  {
+    key = "W",
+    action = "collapse_all",
+    desc = "collapse the whole tree",
+  },
+  {
+    key = "E",
+    action = "expand_all",
+    desc = "expand the whole tree, stopping after expanding |actions.expand_all.max_folder_discovery| folders; this might hang neovim for a while if running on a big folder",
+  },
+  {
+    key = "S",
+    action = "search_node",
+    desc = "prompt the user to enter a path and then expands the tree to match the path",
+  },
+  {
+    key = ".",
+    action = "run_file_command",
+    desc = "enter vim command mode with the file the cursor is on",
+  },
+  {
+    key = "<C-k>",
+    action = "toggle_file_info",
+    desc = "toggle a popup with file infos about the file under the cursor",
+  },
+  {
+    key = "g?",
+    action = "toggle_help",
+    desc = "toggle help",
+  },
+} -- END_DEFAULT_MAPPINGS
+
+local M = {
+  mappings = {},
   custom_keypress_funcs = {},
 }
--- END_DEFAULT_MAPPINGS
 
 local keypress_funcs = {
   close = view.close,
@@ -397,6 +397,22 @@ local function copy_mappings(user_mappings)
   return user_mappings
 end
 
+local function cleanup_existing_mappings()
+  local bufnr = view.get_bufnr()
+  if bufnr == nil or not a.nvim_buf_is_valid(bufnr) then
+    return
+  end
+  for _, b in pairs(M.mappings) do
+    if type(b.key) == "table" then
+      for _, key in pairs(b.key) do
+        a.nvim_buf_del_keymap(bufnr, b.mode or "n", key)
+      end
+    else
+      a.nvim_buf_del_keymap(bufnr, b.mode or "n", b.key)
+    end
+  end
+end
+
 local DEFAULT_MAPPING_CONFIG = {
   custom_only = false,
   list = {},
@@ -412,6 +428,9 @@ function M.setup(opts)
   require("nvim-tree.actions.remove-file").setup(opts)
   require("nvim-tree.actions.copy-paste").setup(opts)
   require("nvim-tree.actions.expand-all").setup(opts)
+
+  cleanup_existing_mappings()
+  M.mappings = vim.deepcopy(DEFAULT_MAPPINGS)
 
   local user_map_config = (opts.view or {}).mappings or {}
   local options = vim.tbl_deep_extend("force", DEFAULT_MAPPING_CONFIG, user_map_config)

--- a/lua/nvim-tree/explorer/filters.lua
+++ b/lua/nvim-tree/explorer/filters.lua
@@ -64,6 +64,7 @@ function M.setup(opts)
     filter_git_ignored = opts.git.ignore,
   }
 
+  M.ignore_list = {}
   M.exclude_list = opts.filters.exclude
 
   local custom_filter = opts.filters.custom

--- a/lua/nvim-tree/git/init.lua
+++ b/lua/nvim-tree/git/init.lua
@@ -134,6 +134,11 @@ function M.load_project_status(cwd)
   return M.projects[project_root]
 end
 
+function M.purge_state()
+  M.projects = {}
+  M.cwd_to_project_root = {}
+end
+
 function M.setup(opts)
   M.config = opts.git
   M.config.watcher = opts.filesystem_watchers

--- a/lua/nvim-tree/watcher.lua
+++ b/lua/nvim-tree/watcher.lua
@@ -3,14 +3,14 @@ local uv = vim.loop
 local log = require "nvim-tree.log"
 local utils = require "nvim-tree.utils"
 
-local M = {}
-local Watcher = {
+local M = {
   _watchers = {},
 }
+local Watcher = {}
 Watcher.__index = Watcher
 
 function Watcher.new(opts)
-  for _, existing in ipairs(Watcher._watchers) do
+  for _, existing in ipairs(M._watchers) do
     if existing._opts.absolute_path == opts.absolute_path then
       log.line("watcher", "Watcher:new using existing '%s'", opts.absolute_path)
       return existing
@@ -25,7 +25,7 @@ function Watcher.new(opts)
 
   watcher = watcher:start()
 
-  table.insert(Watcher._watchers, watcher)
+  table.insert(M._watchers, watcher)
 
   return watcher
 end
@@ -73,5 +73,12 @@ function Watcher:stop()
 end
 
 M.Watcher = Watcher
+
+function M.purge_watchers()
+  for _, watcher in pairs(M._watchers) do
+    watcher:stop()
+  end
+  M._watchers = {}
+end
 
 return M

--- a/scripts/generate_default_mappings.lua
+++ b/scripts/generate_default_mappings.lua
@@ -9,7 +9,7 @@ local max_action_help = 0
 local outs_help = {}
 local outs_lua = {}
 
-for _, m in pairs(M.mappings) do
+for _, m in pairs(DEFAULT_MAPPINGS) do
   local out
   if type(m.key) == "table" then
     local first = true


### PR DESCRIPTION
I'm not a 100% sure this works as expected for every user configuration, but tested on mine and didn't notice weird behavior.
Autocmd clear properly and set up properly on 2nd setup call
git cleared whenever tree is loaded
view is closed and reopened if open on setup is true in 2nd setup call.

fixes #1338 
superseeds #1333 
