### PR TITLE
draft / ideas for git job concurrency protection

### DIFF
--- a/lua/nvim-tree/git/init.lua
+++ b/lua/nvim-tree/git/init.lua
@@ -119,9 +119,10 @@ function M.load_project_status(cwd)
       absolute_path = utils.path_join { project_root, ".git" },
       interval = M.config.watcher.interval,
       on_event = function()
-        log.line("watcher", "git event")
-        M.reload_tree_at(project_root)
-        require("nvim-tree.renderer").draw()
+        -- TODO extract common functionaly from watch create_watcher to guard together
+        -- log.line("watcher", "git event")
+        -- M.reload_tree_at(project_root)
+        -- require("nvim-tree.renderer").draw()
       end,
     }
   end


### PR DESCRIPTION
I toyed with protecting at the git runner level, however that resulted in a lot of unwanted drawing etc, with outdated information that may "flash" incorrect information.

Exiting the node watcher early results in only the successful task reloading/drawing etc. with the latest git data.

At most 2 git jobs will be run when queueing occurs. That can be debounced away if we want to optimise further.

TODO: refactor git / node watchers to use one common, guarded function.