### PR TITLE
feat: add cwd arg and fallback to open_replacing_current_buffer

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -53,18 +53,22 @@ function M.open(cwd)
   end
 end
 
-function M.open_replacing_current_buffer()
+function M.open_replacing_current_buffer(cwd)
   if view.is_visible() then
     return
   end
 
   local buf = api.nvim_get_current_buf()
   local bufname = api.nvim_buf_get_name(buf)
-  if bufname == "" or vim.loop.fs_stat(bufname) == nil then
-    return
+
+  if cwd == "" or cwd == nil then
+    if bufname ~= "" and vim.loop.fs_stat(bufname) ~= nil then
+      cwd = vim.fn.fnamemodify(bufname, ":p:h")
+    else
+      return
+    end
   end
 
-  local cwd = vim.fn.fnamemodify(bufname, ":p:h")
   if not core.get_explorer() or cwd ~= core.get_cwd() then
     core.init(cwd)
   end


### PR DESCRIPTION
Make `open_replacing_current_buffer` reach feature parity with `open`

- Accept `cwd` argument
- Fallback to `vim.loop.cwd()` instead of `return`