### PR TITLE
fix(#1356): view.close switch_buf_if_last_buf prefers alt buf

### DIFF
--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -130,16 +130,29 @@ local function open_window()
   set_window_options_and_buffer()
 end
 
-local function get_existing_buffers()
-  return vim.tbl_filter(function(buf)
-    return a.nvim_buf_is_valid(buf) and vim.fn.buflisted(buf) == 1
-  end, a.nvim_list_bufs())
+local function get_alt_or_next_buf()
+  local alt_bufnr = vim.fn.bufnr "#"
+
+  local alt_buf = nil
+  local next_buf = nil
+
+  for _, buf in ipairs(a.nvim_list_bufs()) do
+    if a.nvim_buf_is_valid(buf) and vim.fn.buflisted(buf) == 1 then
+      next_buf = next_buf or buf
+      if buf == alt_bufnr then
+        alt_buf = buf
+      end
+    end
+  end
+
+  return alt_buf or next_buf
 end
 
 local function switch_buf_if_last_buf()
   if #a.nvim_list_wins() == 1 then
-    if #get_existing_buffers() > 0 then
-      vim.cmd "sbnext"
+    local buf = get_alt_or_next_buf()
+    if buf then
+      vim.cmd("sb" .. buf)
     else
       vim.cmd "new"
     end

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -130,22 +130,24 @@ local function open_window()
   set_window_options_and_buffer()
 end
 
+local function is_buf_displayed(buf)
+  return a.nvim_buf_is_valid(buf) and vim.fn.buflisted(buf) == 1
+end
+
 local function get_alt_or_next_buf()
-  local alt_bufnr = vim.fn.bufnr "#"
+  local alt_buf = vim.fn.bufnr "#"
+  if is_buf_displayed(alt_buf) then
+    return alt_buf
+  end
 
-  local alt_buf = nil
   local next_buf = nil
-
   for _, buf in ipairs(a.nvim_list_bufs()) do
-    if a.nvim_buf_is_valid(buf) and vim.fn.buflisted(buf) == 1 then
+    if is_buf_displayed(buf) then
       next_buf = next_buf or buf
-      if buf == alt_bufnr then
-        alt_buf = buf
-      end
     end
   end
 
-  return alt_buf or next_buf
+  return next_buf
 end
 
 local function switch_buf_if_last_buf()


### PR DESCRIPTION
closes #1356 

Use `#` if available when closing last buf, falling back to next as per previous behaviour.