### PR TITLE
fix(#1354): add missing :hi NvimTreeFileIgnored

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1021,23 +1021,25 @@ Example (in your `init.vim`):
 You should have 'termguicolors' enabled, otherwise, colors will not be
 applied.
 
+Default linked group follows name.
+
 NvimTreeSymlink
-NvimTreeFolderName
+NvimTreeFolderName          (Directory)
 NvimTreeRootFolder
 NvimTreeFolderIcon
 NvimTreeFileIcon
-NvimTreeEmptyFolderName
-NvimTreeOpenedFolderName
+NvimTreeEmptyFolderName     (Directory)
+NvimTreeOpenedFolderName    (Directory)
 NvimTreeExecFile
 NvimTreeOpenedFile
 NvimTreeSpecialFile
 NvimTreeImageFile
 NvimTreeIndentMarker
 
-LspDiagnosticsError
-LspDiagnosticsWarning
-LspDiagnosticsInformation
-LspDiagnosticsHint
+NvimTreeLspDiagnosticsError         (DiagnosticError)
+NvimTreeLspDiagnosticsWarning       (DiagnosticWarn)
+NvimTreeLspDiagnosticsInformation   (DiagnosticInfo)
+NvimTreeLspDiagnosticsHint          (DiagnosticHint)
 
 NvimTreeGitDirty
 NvimTreeGitStaged
@@ -1045,27 +1047,28 @@ NvimTreeGitMerge
 NvimTreeGitRenamed
 NvimTreeGitNew
 NvimTreeGitDeleted
+NvimTreeGitIgnored      (Comment)
 
 NvimTreeWindowPicker
 
 There are also links to normal bindings to style the tree itself.
 
 NvimTreeNormal
-NvimTreeEndOfBuffer
-NvimTreeCursorLine
-NvimTreeVertSplit (deprecated, use NvimTreeWinSeparator)
-NvimTreeWinSeparator
-NvimTreeCursorColumn
+NvimTreeEndOfBuffer     (NonText)
+NvimTreeCursorLine      (CursorLine)
+NvimTreeVertSplit       (VertSplit)     [deprecated, use NvimTreeWinSeparator]
+NvimTreeWinSeparator    (VertSplit)
+NvimTreeCursorColumn    (CursorColumn)
 
-There are also links for file highlight with git properties
-These all link to there Git equivalent
+There are also links for file highlight with git properties, linked to their
+Git equivalent:
 
-NvimTreeFileDirty
-NvimTreeFileStaged
-NvimTreeFileMerge
-NvimTreeFileRenamed
-NvimTreeFileNew
-NvimTreeFileDeleted
+NvimTreeFileDirty       (NvimTreeGitDirty)
+NvimTreeFileStaged      (NvimTreeGitStaged)
+NvimTreeFileMerge       (NvimTreeGitMerge)
+NvimTreeFileRenamed     (NvimTreeGitRenamed)
+NvimTreeFileNew         (NvimTreeGitNew)
+NvimTreeFileDeleted     (NvimTreeGitDeleted)
 
 There are 2 highlight groups for the live filter feature
 

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -1069,6 +1069,7 @@ NvimTreeFileMerge       (NvimTreeGitMerge)
 NvimTreeFileRenamed     (NvimTreeGitRenamed)
 NvimTreeFileNew         (NvimTreeGitNew)
 NvimTreeFileDeleted     (NvimTreeGitDeleted)
+NvimTreeFileIgnored     (NvimTreeGitIgnored)
 
 There are 2 highlight groups for the live filter feature
 

--- a/lua/nvim-tree/colors.lua
+++ b/lua/nvim-tree/colors.lua
@@ -74,6 +74,7 @@ local function get_links()
     FileMerge = "NvimTreeGitMerge",
     FileStaged = "NvimTreeGitStaged",
     FileDeleted = "NvimTreeGitDeleted",
+    FileIgnored = "NvimTreeGitIgnored",
     Popup = "Normal",
     GitIgnored = "Comment",
     StatusLine = "StatusLine",

--- a/lua/nvim-tree/renderer/components/git.lua
+++ b/lua/nvim-tree/renderer/components/git.lua
@@ -120,7 +120,7 @@ local git_hl = {
   ["R "] = "NvimTreeFileRenamed",
   ["RM"] = "NvimTreeFileRenamed",
   [" R"] = "NvimTreeFileRenamed",
-  ["!!"] = "NvimTreeGitIgnored",
+  ["!!"] = "NvimTreeFileIgnored",
   [" A"] = "none",
 }
 


### PR DESCRIPTION
closes #1354 

Document highlight group links.

Add missing `NvimTreeFileIgnored` group.