### PR TITLE
feat(watcher): debounce FS watchers

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -273,6 +273,7 @@ Setup may only be run once; subsequent calls will result in a warning.
       filesystem_watchers = {
         enable = false,
         interval = 100,
+        debounce = 50,
       },
       git = {
         enable = true,
@@ -523,6 +524,10 @@ This will be experimental for a few weeks and will become the default.
     Increase to at least 1000ms if changes are not visible. See
     https://github.com/luvit/luv/blob/master/docs.md#uvfs_poll_startfs_poll-path-interval-callback
       Type: `number`, Default: `100` (ms)
+
+    *nvim-tree.filesystem_watchers.debounce*
+    Idle milliseconds between filesystem change and action.
+      Type: `number`, Default: `50` (ms)
 
 *nvim-tree.view*
 Window / buffer setup.

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -273,7 +273,7 @@ Setup may only be run once; subsequent calls will result in a warning.
       filesystem_watchers = {
         enable = false,
         interval = 100,
-        debounce = 50,
+        debounce_delay = 50,
       },
       git = {
         enable = true,
@@ -525,7 +525,7 @@ This will be experimental for a few weeks and will become the default.
     https://github.com/luvit/luv/blob/master/docs.md#uvfs_poll_startfs_poll-path-interval-callback
       Type: `number`, Default: `100` (ms)
 
-    *nvim-tree.filesystem_watchers.debounce*
+    *nvim-tree.filesystem_watchers.debounce_delay*
     Idle milliseconds between filesystem change and action.
       Type: `number`, Default: `50` (ms)
 

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -513,7 +513,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
   filesystem_watchers = {
     enable = false,
     interval = 100,
-    debounce = 50,
+    debounce_delay = 50,
   },
   git = {
     enable = true,

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -513,6 +513,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
   filesystem_watchers = {
     enable = false,
     interval = 100,
+    debounce = 50,
   },
   git = {
     enable = true,

--- a/lua/nvim-tree/explorer/watch.lua
+++ b/lua/nvim-tree/explorer/watch.lua
@@ -3,9 +3,7 @@ local utils = require "nvim-tree.utils"
 local git = require "nvim-tree.git"
 local Watcher = require("nvim-tree.watcher").Watcher
 
-local M = {
-  refreshing_paths = {},
-}
+local M = {}
 
 local function reload_and_get_git_project(path)
   local project_root = git.get_project_root(path)
@@ -31,20 +29,12 @@ local function refresh_path(path)
   end
   log.line("watcher", "node event '%s'", path)
 
-  if M.refreshing_paths[path] then
-    log.line("watcher", "node event already running")
-    return
-  end
-  M.refreshing_paths[path] = true
-
   local node = utils.get_parent_of_group(n)
   local project_root, project = reload_and_get_git_project(path)
   require("nvim-tree.explorer.reload").reload(node, project)
   update_parent_statuses(node, project, project_root)
 
   require("nvim-tree.renderer").draw()
-
-  M.refreshing_paths[path] = nil
 end
 
 function M.create_watcher(absolute_path)
@@ -60,7 +50,7 @@ function M.create_watcher(absolute_path)
     absolute_path = absolute_path,
     interval = M.interval,
     on_event = function(path)
-      utils.debounce("explorer:watcher:" .. path, M.debounce, function()
+      utils.debounce("explorer:watch:" .. path, M.debounce, function()
         refresh_path(path)
       end)
     end,

--- a/lua/nvim-tree/explorer/watch.lua
+++ b/lua/nvim-tree/explorer/watch.lua
@@ -49,10 +49,10 @@ function M.create_watcher(absolute_path)
   Watcher.new {
     absolute_path = absolute_path,
     interval = M.interval,
-    on_event = function(path)
-      log.line("watcher", "node event scheduled '%s'", path)
-      utils.debounce("explorer:watch:" .. path, M.debounce_delay, function()
-        refresh_path(path)
+    on_event = function(opts)
+      log.line("watcher", "node event scheduled '%s'", opts.absolute_path)
+      utils.debounce("explorer:watch:" .. opts.absolute_path, M.debounce_delay, function()
+        refresh_path(opts.absolute_path)
       end)
     end,
   }

--- a/lua/nvim-tree/explorer/watch.lua
+++ b/lua/nvim-tree/explorer/watch.lua
@@ -23,11 +23,11 @@ local function is_git(path)
 end
 
 local function refresh_path(path)
+  log.line("watcher", "node event executing '%s'", path)
   local n = utils.get_node_from_path(path)
   if not n then
     return
   end
-  log.line("watcher", "node event '%s'", path)
 
   local node = utils.get_parent_of_group(n)
   local project_root, project = reload_and_get_git_project(path)
@@ -50,6 +50,7 @@ function M.create_watcher(absolute_path)
     absolute_path = absolute_path,
     interval = M.interval,
     on_event = function(path)
+      log.line("watcher", "node event scheduled '%s'", path)
       utils.debounce("explorer:watch:" .. path, M.debounce, function()
         refresh_path(path)
       end)

--- a/lua/nvim-tree/explorer/watch.lua
+++ b/lua/nvim-tree/explorer/watch.lua
@@ -51,7 +51,7 @@ function M.create_watcher(absolute_path)
     interval = M.interval,
     on_event = function(path)
       log.line("watcher", "node event scheduled '%s'", path)
-      utils.debounce("explorer:watch:" .. path, M.debounce, function()
+      utils.debounce("explorer:watch:" .. path, M.debounce_delay, function()
         refresh_path(path)
       end)
     end,
@@ -61,7 +61,7 @@ end
 function M.setup(opts)
   M.enabled = opts.filesystem_watchers.enable
   M.interval = opts.filesystem_watchers.interval
-  M.debounce = opts.filesystem_watchers.debounce
+  M.debounce_delay = opts.filesystem_watchers.debounce_delay
 end
 
 return M

--- a/lua/nvim-tree/git/init.lua
+++ b/lua/nvim-tree/git/init.lua
@@ -5,13 +5,13 @@ local Runner = require "nvim-tree.git.runner"
 local Watcher = require("nvim-tree.watcher").Watcher
 
 local M = {
-  config = nil,
+  config = {},
   projects = {},
   cwd_to_project_root = {},
 }
 
 function M.reload()
-  if not M.config.enable then
+  if not M.config.git.enable then
     return {}
   end
 
@@ -24,7 +24,7 @@ end
 
 function M.reload_project(project_root, path)
   local project = M.projects[project_root]
-  if not project or not M.config.enable then
+  if not project or not M.config.git.enable then
     return
   end
 
@@ -37,7 +37,7 @@ function M.reload_project(project_root, path)
     path = path,
     list_untracked = git_utils.should_show_untracked(project_root),
     list_ignored = true,
-    timeout = M.config.timeout,
+    timeout = M.config.git.timeout,
   }
 
   if path then
@@ -71,7 +71,8 @@ function M.get_project_root(cwd)
   return project_root
 end
 
-function M.reload_tree_at(project_root)
+local function reload_tree_at(project_root)
+  log.line("watcher", "git event executing '%s'", project_root)
   local root_node = utils.get_node_from_path(project_root)
   if not root_node then
     return
@@ -98,10 +99,12 @@ function M.reload_tree_at(project_root)
   end
 
   iterate(root_node)
+
+  require("nvim-tree.renderer").draw()
 end
 
 function M.load_project_status(cwd)
-  if not M.config.enable then
+  if not M.config.git.enable then
     return {}
   end
 
@@ -120,19 +123,25 @@ function M.load_project_status(cwd)
     project_root = project_root,
     list_untracked = git_utils.should_show_untracked(project_root),
     list_ignored = true,
-    timeout = M.config.timeout,
+    timeout = M.config.git.timeout,
   }
 
   local watcher = nil
-  if M.config.watcher.enable then
+  if M.config.filesystem_watchers.enable then
     log.line("watcher", "git start")
     watcher = Watcher.new {
       absolute_path = utils.path_join { project_root, ".git" },
-      interval = M.config.watcher.interval,
-      on_event = function()
+      project_root = project_root,
+      interval = M.config.filesystem_watchers.interval,
+      on_event = function(opts)
+        log.line("watcher", "git event scheduled '%s'", opts.project_root)
+        utils.debounce("git:watcher:" .. opts.project_root, M.config.filesystem_watchers.debounce_delay, function()
+          reload_tree_at(opts.project_root)
+        end)
+      end,
+      on_event0 = function()
         log.line("watcher", "git event")
         M.reload_tree_at(project_root)
-        require("nvim-tree.renderer").draw()
       end,
     }
   end
@@ -146,8 +155,8 @@ function M.load_project_status(cwd)
 end
 
 function M.setup(opts)
-  M.config = opts.git
-  M.config.watcher = opts.filesystem_watchers
+  M.config.git = opts.git
+  M.config.filesystem_watchers = opts.filesystem_watchers
 end
 
 return M

--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -330,11 +330,11 @@ function M.key_by(tbl, key)
   return keyed
 end
 
----Execute fn timeout ms after the last invocation with context
+---Execute callback timeout ms after the lastest invocation with context. Waiting invocations for that context will be discarded. Caller should this ensure that callback performs the same or functionally equivalent actions.
 ---@param context string identifies the callback to debounce
 ---@param timeout number ms to wait
----@param fn function callback to execute on completion
-function M.debounce(context, timeout, fn)
+---@param callback function to execute on completion
+function M.debounce(context, timeout, callback)
   if M.debouncers[context] then
     M.debouncers[context]:close()
   end
@@ -346,7 +346,7 @@ function M.debounce(context, timeout, fn)
     vim.schedule_wrap(function()
       M.debouncers[context]:close()
       M.debouncers[context] = nil
-      fn()
+      callback()
     end)
   )
 end

--- a/lua/nvim-tree/utils.lua
+++ b/lua/nvim-tree/utils.lua
@@ -336,7 +336,7 @@ end
 ---@param callback function to execute on completion
 function M.debounce(context, timeout, callback)
   if M.debouncers[context] then
-    M.debouncers[context]:close()
+    pcall(uv.close, M.debouncers[context])
   end
 
   M.debouncers[context] = uv.new_timer()

--- a/lua/nvim-tree/watcher.lua
+++ b/lua/nvim-tree/watcher.lua
@@ -48,7 +48,7 @@ function Watcher:start()
     if err then
       log.line("watcher", "poll_cb for %s fail : %s", self._opts.absolute_path, err)
     else
-      self._opts.on_event(self._opts.absolute_path)
+      self._opts.on_event(self._opts)
     end
   end)
 


### PR DESCRIPTION
requires #1373 

Not very useful until we move to fs_event as fs_poll is aready throttled.

I have played around a few options but was not happy:
1. Abandon refresh when there is a refresh in progress for that directory - can miss actual changes
2. Queue one refresh when there is one in progress - can result in two refreshes, which will be a big problem when we move to real time FS events

Debounce refreshes by absolute path seems the best option.
Having multiple refresh events running for different paths is OK, as we are only looking at the FS and git for that path.