### PR TITLE
fix(actions): close_node doesn't close for grouped node

### DIFF
--- a/lua/nvim-tree/actions/movements.lua
+++ b/lua/nvim-tree/actions/movements.lua
@@ -33,6 +33,12 @@ function M.parent_node(should_close)
 
     local parent = node.parent
 
+    if renderer.config.group_empty and parent then
+      while parent.parent and parent.parent.group_next do
+        parent = parent.parent
+      end
+    end
+
     if not parent or not parent.parent then
       return view.set_cursor { 1, 0 }
     end


### PR DESCRIPTION
When `group_empty` option is enabled, parent_node and close_node dosen't close correctly.

example:
![image](https://user-images.githubusercontent.com/26727562/176879685-8f1d89ba-78c6-4cf2-a965-898efb40eeb9.png)

after call close_node on node d.go expect: 
![image](https://user-images.githubusercontent.com/26727562/176880006-0ed041c9-72bb-4c55-8e99-929259f17499.png)

actual:
![image](https://user-images.githubusercontent.com/26727562/176879963-1378fb03-363a-4d17-ab95-7e366d9565f4.png)

So I look up until the first group node, and close it will be expected.
