### PR TITLE
feat(actions): expand_all 'exclude' option

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -287,6 +287,7 @@ Subsequent calls to setup will replace the previous configuration.
         },
         expand_all = {
           max_folder_discovery = 300,
+          exclude = {},
         },
         open_file = {
           quit_on_open = false,
@@ -770,10 +771,18 @@ Configuration for various actions.
         Restrict changing to a directory above the global current working directory.
           Type: `boolean`, Default: `false`
 
-    *nvim-tree.actions.expand_all.max_folder_discovery*
-    Limit the number of folders being explored when expanding every folders.
-    Avoids hanging neovim when running this action on very large folders.
-      Type: `number`, Default: `300`
+    *nvim-tree.actions.expand_all*
+    Configuration for expand_all behaviour.
+
+        *nvim-tree.actions.expand_all.max_folder_discovery*
+        Limit the number of folders being explored when expanding every folders.
+        Avoids hanging neovim when running this action on very large folders.
+          Type: `number`, Default: `300`
+
+        *nvim-tree.actions.expand_all.exclude*
+        A list of directories that should not be expanded automatically.
+        E.g `{ ".git", "target", "build" }` etc.
+          Type: `table`, Default: `{}`
 
     *nvim-tree.actions.open_file*
     Configuration options for opening a file from nvim-tree.

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -540,6 +540,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
     },
     expand_all = {
       max_folder_discovery = 300,
+      exclude = {},
     },
     open_file = {
       quit_on_open = false,

--- a/lua/nvim-tree/actions/expand-all.lua
+++ b/lua/nvim-tree/actions/expand-all.lua
@@ -4,6 +4,15 @@ local utils = require "nvim-tree.utils"
 
 local M = {}
 
+local function to_lookup_table(list)
+  local table = {}
+  for _, element in ipairs(list) do
+    table[element] = true
+  end
+
+  return table
+end
+
 local function expand(node)
   node.open = true
   if #node.nodes == 0 then
@@ -25,7 +34,7 @@ local function gen_iterator()
     end
 
     for _, node in pairs(parent.nodes) do
-      if node.nodes and not node.open then
+      if node.nodes and not node.open and not M.EXCLUDE[node.name] then
         expansion_count = expansion_count + 1
         expand(node)
       end
@@ -51,6 +60,7 @@ end
 
 function M.setup(opts)
   M.MAX_FOLDER_DISCOVERY = opts.actions.expand_all.max_folder_discovery
+  M.EXCLUDE = to_lookup_table(opts.actions.expand_all.exclude)
 end
 
 return M


### PR DESCRIPTION
Hello, guys !

A small proposal from me - an 'exclude' option to the expand_all action.

I find it useful when recursively expanding child nodes. Say you have nested '.git', or you don't want to expand some kind of 'build' directories.
This also helps if you 'expand_all' while you have selected a file, which has siblings you don't want to expand.
Dunno is it a common use case, that is why I defaulted to an empty table value.
