### PR TITLE
feat(#1389): add git.show_on_dirs

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -276,6 +276,7 @@ Subsequent calls to setup will replace the previous configuration.
       git = {
         enable = true,
         ignore = true,
+        show_on_dirs = true,
         timeout = 400,
       },
       actions = {
@@ -464,8 +465,7 @@ Show LSP and COC diagnostics in the signcolumn
       Type: `boolean`, Default: `false`
 
     *nvim-tree.diagnostics.show_on_dirs*
-    If the node with diagnostic is not visible, then show diagnostic in the
-    parent directory.
+    Show diagnostic icons on parent directories.
       Type: `boolean`, Default: `false`
 
     *nvim-tree.diagnostics.icons*
@@ -489,6 +489,10 @@ Git integration with icons and colors.
     *nvim-tree.git.ignore*
     Ignore files based on `.gitignore`. Requires |git.enable| `= true`
     Toggle via the `toggle_git_ignored` action, default mapping `I`.
+      Type: `boolean`, Default: `true`
+
+    *nvim-tree.git.show_on_dirs*
+    Show status icons of children when directory itself has no status icon.
       Type: `boolean`, Default: `true`
 
     *nvim-tree.git.timeout*

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -529,6 +529,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
   git = {
     enable = true,
     ignore = true,
+    show_on_dirs = true,
     timeout = 400,
   },
   actions = {

--- a/lua/nvim-tree/explorer/common.lua
+++ b/lua/nvim-tree/explorer/common.lua
@@ -6,9 +6,15 @@ local function get_dir_git_status(parent_ignored, status, absolute_path)
   if parent_ignored then
     return "!!"
   end
-  local dir_status = status.dirs and status.dirs[absolute_path]
+
   local file_status = status.files and status.files[absolute_path]
-  return dir_status or file_status
+  if file_status then
+    return file_status
+  end
+
+  if M.config.git.show_on_dirs then
+    return status.dirs and status.dirs[absolute_path]
+  end
 end
 
 local function get_git_status(parent_ignored, status, absolute_path)
@@ -35,6 +41,12 @@ function M.update_git_status(node, parent_ignored, status)
       node.git_status = get_git_status(parent_ignored, status, node.link_to)
     end
   end
+end
+
+function M.setup(opts)
+  M.config = {
+    git = opts.git,
+  }
 end
 
 return M

--- a/lua/nvim-tree/explorer/init.lua
+++ b/lua/nvim-tree/explorer/init.lua
@@ -52,6 +52,7 @@ function Explorer:_clear_watchers()
 end
 
 function M.setup(opts)
+  require("nvim-tree.explorer.common").setup(opts)
   require("nvim-tree.explorer.explore").setup(opts)
   require("nvim-tree.explorer.filters").setup(opts)
   require("nvim-tree.explorer.sorters").setup(opts)


### PR DESCRIPTION
Adds behaviour similar to diagnostic folders.

I considered doing this in the renderer but that became complicated. Please consider if this approach is appropriate.