### PR TITLE
fix(view): do not close window when NvimTree buffer is replaced

### DIFF
--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -285,7 +285,6 @@ function M.abandon_current_window()
 end
 
 function M.quit_on_open()
-  M._prevent_buffer_override()
   M.abandon_current_window()
 end
 


### PR DESCRIPTION
With `actions.open_file` enabled, when an NvimTree buffer is changed to some other buffer, the window in which that buffer swap occurs is closed.

Since the `quit_on_open` function runs on `NvimTree` `BufWipeout`, there should not be a need to close the window that holds that buffer. Looking at the code, it seemed sensible to not to call `_prevent_buffer_override` if `quit_on_open` is enabled, since at best it's a no-op, and at worst it will accidentally modify the window layout.

This issue could be reproduced by:

1. Opening an existing file `:e firstfile.txt`
2. `:vs`
3. `:lua require("nvim-tree").open_replacing_current_buffer()`
4. Replacing the NvimTree buffer with some other buffer by
   `:e somefile.txt`

The window containing the buffer opened in the first step would be closed. There would be only a single window with `somefile.txt` on that tab page.


https://user-images.githubusercontent.com/889383/177036047-42dbdd38-1f25-4619-92b2-643572406730.mp4


With this fix, that window is retained and the tab now contains `firstfile.txt` in the left window and `somefile.txt` in the right
window.

https://user-images.githubusercontent.com/889383/177036048-e60de2ef-2f18-4b36-9f6e-422d090b820c.mp4