### PR TITLE
fix(actions): change_dir to wrong directory

### DIFF
--- a/lua/nvim-tree/actions/change-dir.lua
+++ b/lua/nvim-tree/actions/change-dir.lua
@@ -48,7 +48,7 @@ function M.fn(input_cwd, with_open)
 end
 
 local function cd(global, path)
-  vim.cmd(global and "cd" or "lcd", vim.fn.fnameescape(path))
+  vim.cmd((global and "cd" or "lcd") .. vim.fn.fnameescape(path))
 end
 
 local function should_change_dir()


### PR DESCRIPTION
vim.cmd only accept 1 arg, path will be discarded, see `:h vim.cmd`，so we should concate cmd and args