### PR TITLE
fix(#1406): allow nvim-tree.renderer.icons.show.folder_arrow

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -679,8 +679,8 @@ UI rendering setup
               Type: `boolean`, Default: `true`
 
             *nvim-tree.renderer.icons.show.folder_arrow*
-            Show a small arrow before the folder icon.
-            Requires |renderer.icons.show.folder| `= true` and |renderer.indent_markers.enable| `= false`
+            Show a small arrow before the folder node. Arrow will be a part of the
+            node when using |renderer.indent_markers|.
               Type: `boolean`, Default: `true`
 
             *nvim-tree.renderer.icons.show.git*

--- a/lua/nvim-tree/renderer/builder.lua
+++ b/lua/nvim-tree/renderer/builder.lua
@@ -10,18 +10,13 @@ Builder.__index = Builder
 function Builder.new(root_cwd)
   return setmetatable({
     index = 0,
-    depth = nil,
+    depth = 0,
     highlights = {},
     lines = {},
     markers = {},
     signs = {},
     root_cwd = root_cwd,
   }, Builder)
-end
-
-function Builder:configure_initial_depth(show_arrows)
-  self.depth = show_arrows and 2 or 0
-  return self
 end
 
 function Builder:configure_root_modifier(root_folder_modifier)

--- a/lua/nvim-tree/renderer/builder.lua
+++ b/lua/nvim-tree/renderer/builder.lua
@@ -227,7 +227,7 @@ end
 function Builder:_build_line(node, idx, num_children)
   local padding = pad.get_padding(self.depth, idx, num_children, node, self.markers)
 
-  if self.depth > 0 then
+  if string.len(padding) > 0 then
     self:_insert_highlight("NvimTreeIndentMarker", 0, string.len(padding))
   end
 

--- a/lua/nvim-tree/renderer/components/padding.lua
+++ b/lua/nvim-tree/renderer/components/padding.lua
@@ -35,7 +35,7 @@ local function get_padding_indent_markers(depth, idx, nodes_number, _, markers)
 end
 
 function M.reload_padding_function()
-  if M.config.icons.show.folder and M.config.icons.show.folder_arrow then
+  if M.config.icons.show.folder_arrow then
     M.get_padding = get_padding_arrows()
   end
 

--- a/lua/nvim-tree/renderer/components/padding.lua
+++ b/lua/nvim-tree/renderer/components/padding.lua
@@ -1,21 +1,8 @@
 local M = {}
 
-function M.get_padding(depth)
-  return string.rep(" ", depth)
-end
-
-local function get_padding_arrows()
-  return function(depth, _, _, node)
-    if node.nodes then
-      local icon = M.config.icons.glyphs.folder[node.open and "arrow_open" or "arrow_closed"]
-      return string.rep(" ", depth - 2) .. icon .. " "
-    end
-    return string.rep(" ", depth)
-  end
-end
-
-local function get_padding_indent_markers(depth, idx, nodes_number, _, markers)
+local function get_padding_indent_markers(depth, idx, nodes_number, markers)
   local padding = ""
+
   if depth ~= 0 then
     local rdepth = depth / 2
     markers[rdepth] = idx ~= nodes_number
@@ -34,14 +21,30 @@ local function get_padding_indent_markers(depth, idx, nodes_number, _, markers)
   return padding
 end
 
-function M.reload_padding_function()
-  if M.config.icons.show.folder_arrow then
-    M.get_padding = get_padding_arrows()
+local function get_padding_arrows(node, indent)
+  if node.nodes then
+    return M.config.icons.glyphs.folder[node.open and "arrow_open" or "arrow_closed"] .. " "
+  elseif indent then
+    return "  "
+  else
+    return ""
   end
+end
+
+function M.get_padding(depth, idx, nodes_number, node, markers)
+  local padding = ""
 
   if M.config.indent_markers.enable then
-    M.get_padding = get_padding_indent_markers
+    padding = padding .. get_padding_indent_markers(depth, idx, nodes_number, markers)
+  else
+    padding = padding .. string.rep(" ", depth)
   end
+
+  if M.config.icons.show.folder_arrow then
+    padding = padding .. get_padding_arrows(node, not M.config.indent_markers.enable)
+  end
+
+  return padding
 end
 
 function M.setup(opts)

--- a/lua/nvim-tree/renderer/init.lua
+++ b/lua/nvim-tree/renderer/init.lua
@@ -41,7 +41,7 @@ function M.render_hl(bufnr, hl)
 end
 
 local function should_show_arrows()
-  return not M.config.indent_markers.enable and M.config.icons.show.folder and M.config.icons.show.folder_arrow
+  return not M.config.indent_markers.enable and M.config.icons.show.folder_arrow
 end
 
 local picture_map = {

--- a/lua/nvim-tree/renderer/init.lua
+++ b/lua/nvim-tree/renderer/init.lua
@@ -40,10 +40,6 @@ function M.render_hl(bufnr, hl)
   end
 end
 
-local function should_show_arrows()
-  return not M.config.indent_markers.enable and M.config.icons.show.folder_arrow
-end
-
 local picture_map = {
   jpg = true,
   jpeg = true,
@@ -60,7 +56,6 @@ function M.draw()
   local ps = log.profile_start "draw"
 
   local cursor = api.nvim_win_get_cursor(view.get_winnr())
-  _padding.reload_padding_function()
   icon_component.reset_config()
 
   local lines, hl
@@ -69,7 +64,6 @@ function M.draw()
     lines, hl = help.compute_lines()
   else
     lines, hl, signs = Builder.new(core.get_cwd())
-      :configure_initial_depth(should_show_arrows())
       :configure_root_modifier(M.config.root_folder_modifier)
       :configure_trailing_slash(M.config.add_trailing)
       :configure_special_files(M.config.special_files)

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -4,6 +4,12 @@ local M = {}
 
 local events = require "nvim-tree.events"
 
+local function get_win_sep_hl()
+  -- #1221 WinSeparator not present in nvim 0.6.1 and some builds of 0.7.0
+  local has_win_sep = pcall(vim.cmd, "silent hi WinSeparator")
+  return has_win_sep and "WinSeparator:NvimTreeWinSeparator" or "VertSplit:NvimTreeWinSeparator"
+end
+
 M.View = {
   adaptive_size = false,
   centralize_selection = false,
@@ -29,8 +35,7 @@ M.View = {
       "EndOfBuffer:NvimTreeEndOfBuffer",
       "Normal:NvimTreeNormal",
       "CursorLine:NvimTreeCursorLine",
-      -- #1221 WinSeparator not present in nvim 0.6.1 and some builds of 0.7.0
-      pcall(vim.cmd, "silent hi WinSeparator") and "WinSeparator:NvimTreeWinSeparator" or "VertSplit:NvimTreeWinSeparator",
+      get_win_sep_hl(),
       "StatusLine:NvimTreeStatusLine",
       "StatusLineNC:NvimTreeStatuslineNC",
       "SignColumn:NvimTreeSignColumn",

--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -30,8 +30,7 @@ M.View = {
       "Normal:NvimTreeNormal",
       "CursorLine:NvimTreeCursorLine",
       -- #1221 WinSeparator not present in nvim 0.6.1 and some builds of 0.7.0
-      pcall(vim.cmd, "silent hi WinSeparator") and "WinSeparator:NvimTreeWinSeparator"
-        or "VertSplit:NvimTreeWinSeparator",
+      pcall(vim.cmd, "silent hi WinSeparator") and "WinSeparator:NvimTreeWinSeparator" or "VertSplit:NvimTreeWinSeparator",
       "StatusLine:NvimTreeStatusLine",
       "StatusLineNC:NvimTreeStatuslineNC",
       "SignColumn:NvimTreeSignColumn",


### PR DESCRIPTION
closes #1406

Always allows folder arrows. When using indent markers the arrows do not indent the surrounding nodes.

@milessabin please test the combinations of 
* renderer.icons.show.folder
* renderer.icons.show.folder_arrow
* renderer.indent_markers.enable