### PR TITLE
:help nvim-tree.setup -> :help nvim-tree-setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ require("nvim-tree").setup({
 })
 ```
 
-For complete list of available configuration options see [:help nvim-tree.setup](doc/nvim-tree-lua.txt)
+For complete list of available configuration options see [:help nvim-tree-setup](doc/nvim-tree-lua.txt)
 
 Each option is documented in `:help nvim-tree.OPTION_NAME`. Nested options can be accessed by appending `.`, for example [:help nvim-tree.view.mappings](doc/nvim-tree-lua.txt)
 


### PR DESCRIPTION
on `:help nvim-tree.setup` I get an error `E149: Sorry, no help for nvim-tree.setup`, but `:help nvim-tree-setup` is working