### PR TITLE
fix(explorer): reload `executable` stat

### DIFF
--- a/lua/nvim-tree/explorer/node-builders.lua
+++ b/lua/nvim-tree/explorer/node-builders.lua
@@ -23,7 +23,7 @@ function M.folder(parent, absolute_path, name)
   }
 end
 
-local function is_executable(absolute_path, ext)
+function M.is_executable(absolute_path, ext)
   if M.is_windows then
     return utils.is_windows_exe(ext)
   end
@@ -35,7 +35,7 @@ function M.file(parent, absolute_path, name)
 
   return {
     absolute_path = absolute_path,
-    executable = is_executable(absolute_path, ext),
+    executable = M.is_executable(absolute_path, ext),
     extension = ext,
     fs_stat = uv.fs_stat(absolute_path),
     name = name,

--- a/lua/nvim-tree/explorer/reload.lua
+++ b/lua/nvim-tree/explorer/reload.lua
@@ -64,7 +64,9 @@ function M.reload(node, status)
         end
       end
       local n = nodes_by_path[abs]
-      n.executable = builders.is_executable(abs, n.extension)
+      if n then
+        n.executable = builders.is_executable(abs, n.extension)
+      end
     end
   end
 

--- a/lua/nvim-tree/explorer/reload.lua
+++ b/lua/nvim-tree/explorer/reload.lua
@@ -62,7 +62,6 @@ function M.reload(node, status)
             table.insert(node.nodes, link)
           end
         end
-
       end
       local n = nodes_by_path[abs]
       n.executable = builders.is_executable(abs, n.extension)

--- a/lua/nvim-tree/explorer/reload.lua
+++ b/lua/nvim-tree/explorer/reload.lua
@@ -62,7 +62,10 @@ function M.reload(node, status)
             table.insert(node.nodes, link)
           end
         end
+
       end
+      local n = nodes_by_path[abs]
+      n.executable = builders.is_executable(abs, n.extension)
     end
   end
 


### PR DESCRIPTION
The `NvimTreeRefresh` command didn't refresh `executable` field of the `node`.

## Step to reproduce:
1. Open `nvim-tree` by `:NvimTreeOpen`
2. Change the executable flag of any file by `chmod` command
3. Execute `:NvimTreeRefresh`
4. The style of the file node doesn't change at all while it should be