### PR TITLE
fix(git): prevent execution of git commands when git integration is disabled

### DIFF
--- a/lua/nvim-tree/git/init.lua
+++ b/lua/nvim-tree/git/init.lua
@@ -68,11 +68,18 @@ function M.get_project_root(cwd)
     return nil
   end
 
-  local project_root = git_utils.get_toplevel(cwd)
-  return project_root
+  if M.config.git.enable then
+    return git_utils.get_toplevel(cwd)
+  end
+
+  return nil
 end
 
 local function reload_tree_at(project_root)
+  if M.config.git.enable then
+    return nil
+  end
+
   log.line("watcher", "git event executing '%s'", project_root)
   local root_node = utils.get_node_from_path(project_root)
   if not root_node then


### PR DESCRIPTION
This PR contains one commit to prevent the execution of Git commands even when Git integration is explicitly disabled.

To replicate the issue prior to this commit:
1. Set `git.enable` to `false`.
2. Add `print(cmd)` [here](https://github.com/kyazdani42/nvim-tree.lua/blob/06e48c29c4543331eee41753e69e3bd2235bf430/lua/nvim-tree/git/utils.lua#L8).
3. Expand multiple directories in the tree.
4. Run `:NvimTreeRefresh`.
5. Observe that multiple Git commands are printed/executed (one for each expanded directory).

Explanation: Without this commit, when `get_project_root` is called (for example as a result of executing `:NvimTreeRefresh`), `get_toplevel` (which [unconditionally executes](https://github.com/kyazdani42/nvim-tree.lua/blob/06e48c29c4543331eee41753e69e3bd2235bf430/lua/nvim-tree/git/utils.lua#L6-L7) Git commands) is called. 

