### PR TITLE
fix: correct 'opt' typo

### DIFF
--- a/lua/nvim-tree/actions/node/open-file.lua
+++ b/lua/nvim-tree/actions/node/open-file.lua
@@ -112,7 +112,7 @@ local function pick_window()
   end
   local _, resp = pcall(get_user_input_char)
   resp = (resp or ""):upper()
-  if vim.op.cmdheight._value ~= 0 then
+  if vim.opt.cmdheight._value ~= 0 then
     vim.api.nvim_command "normal! :"
   end
 


### PR DESCRIPTION
Fixes a typo which incorrectly tries to index `vim.op` instead of `vim.opt`.