### PR TITLE
fix(git): fix inverted condition logic introduced in #1433

### DIFF
--- a/lua/nvim-tree/git/init.lua
+++ b/lua/nvim-tree/git/init.lua
@@ -76,7 +76,7 @@ function M.get_project_root(cwd)
 end
 
 local function reload_tree_at(project_root)
-  if M.config.git.enable then
+  if not M.config.git.enable then
     return nil
   end
 


### PR DESCRIPTION
This PR contains one commit to fix an incorrect conditional that was introduced in #1433.