### PR TITLE
fix: count unicode codepoints instead of bytes

### DIFF
--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -211,8 +211,9 @@ local function grow()
   local lines = vim.api.nvim_buf_get_lines(M.get_bufnr(), starts_at, -1, false)
   local max_length = M.View.initial_width
   for _, l in pairs(lines) do
-    if max_length < #l then
-      max_length = #l
+    local count = vim.fn.strchars(l) + 3 -- plus some padding
+    if max_length < count then
+      max_length = count
     end
   end
   M.resize(max_length)


### PR DESCRIPTION
When using `adaptive_size = true` there is some extra padding (usually around 4-6 spaces). This is happening due to the unicode characters such as file or folder icon. For example `string.len("  .hooks")` (equivalent with #string ) will return 14, but this string only needs 10 spaces to be printed.

This commit fixes this issue and sets the width of the window to the *true* `max_length` + 1 space for padding.
