### PR TITLE
Reliably determine if nvim-tree is last window and exit gracefully

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -420,7 +420,7 @@ local function setup_autocommands(opts)
 	group = vim.api.nvim_create_augroup("NvimTreeClose", {clear = true}),
 	callback = function()
 		local layout = vim.api.nvim_call_function("winlayout", {})
-		if layout[1] == "leaf" and vim.api.nvim_buf_get_option(vim.api.nvim_win_get_buf(layout[2]), "filetype") == "NvimTree" and layout[3] == nil then vim.cmd("quit") end
+		if layout[1] == "leaf" and vim.api.nvim_buf_get_option(vim.api.nvim_win_get_buf(layout[2]), "filetype") == "NvimTree" and layout[3] == nil then vim.cmd("confirm quit") end
 	end
 })
   end

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -415,7 +415,7 @@ local function setup_autocommands(opts)
     })
   end
 
-  if opts.auto_exit_if_last_window then
+  if opts.quit_if_last_window then
   vim.api.nvim_create_autocmd("BufEnter", {
 	group = vim.api.nvim_create_augroup("NvimTreeClose", {clear = true}),
 	callback = function()
@@ -431,7 +431,7 @@ end
 
 local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
   auto_reload_on_write = true,
-  auto_exit_if_last_window = false,
+  quit_if_last_window = false,
   create_in_closed_folder = false,
   disable_netrw = false,
   hijack_cursor = false,

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -418,6 +418,7 @@ local function setup_autocommands(opts)
   if opts.quit_if_last_window then
   vim.api.nvim_create_autocmd("BufEnter", {
 	group = vim.api.nvim_create_augroup("NvimTreeClose", {clear = true}),
+  pattern = "NvimTree_*",
 	callback = function()
 		local layout = vim.api.nvim_call_function("winlayout", {})
 		if layout[1] == "leaf" and vim.api.nvim_buf_get_option(vim.api.nvim_win_get_buf(layout[2]), "filetype") == "NvimTree" and layout[3] == nil then vim.cmd("confirm quit") end

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -414,10 +414,24 @@ local function setup_autocommands(opts)
       end,
     })
   end
+
+  if opts.auto_exit_if_last_window then
+  vim.api.nvim_create_autocmd("BufEnter", {
+	group = vim.api.nvim_create_augroup("NvimTreeClose", {clear = true}),
+	callback = function()
+		local layout = vim.api.nvim_call_function("winlayout", {})
+		if layout[1] == "leaf" and vim.api.nvim_buf_get_option(vim.api.nvim_win_get_buf(layout[2]), "filetype") == "NvimTree" and layout[3] == nil then vim.cmd("quit") end
+	end
+})
+  end
+
+
+
 end
 
 local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
   auto_reload_on_write = true,
+  auto_exit_if_last_window = false,
   create_in_closed_folder = false,
   disable_netrw = false,
   hijack_cursor = false,


### PR DESCRIPTION
This is a PR aims to solve #1368 by parsing the window layout of the current window to reliably determine whether NvimTree if the last window and if so quits.

Also solving an apparent issue highlighted in snippet provided by readme this PR adds `confirm quit` so that we can also get a graceful exit in the case of unsaved buffers in the background.

I was sorely missing this feature when it was deprecated so I am hoping that this is good enough for it to be added back in :)