### PR TITLE
feat: add option for folder arrows to be inline with indent markers

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -201,6 +201,7 @@ Subsequent calls to setup will replace the previous configuration.
         root_folder_modifier = ":~",
         indent_markers = {
           enable = false,
+          inline_arrows = true,
           icons = {
             corner = "└",
             edge = "│",
@@ -669,6 +670,11 @@ UI rendering setup
         *nvim-tree.renderer.indent_markers.enable*
         Display indent markers when folders are open
           Type: `boolean`, Default: `false`
+
+        *nvim-tree.renderer.indent_markers.inline_arrows*
+        Display folder arrows in the same column as indent marker
+        when using |renderer.icons.show.folder_arrow|
+          Type: `boolean`, Default: `true`
 
         *nvim-tree.renderer.indent_markers.icons*
         Icons shown before the file/directory.

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -464,6 +464,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
     root_folder_modifier = ":~",
     indent_markers = {
       enable = false,
+      inline_arrows = true,
       icons = {
         corner = "└",
         edge = "│",

--- a/lua/nvim-tree/renderer/components/padding.lua
+++ b/lua/nvim-tree/renderer/components/padding.lua
@@ -21,7 +21,7 @@ end
 
 local function get_padding_indent_markers(depth, idx, nodes_number, markers, with_arrows, inline_arrows, node)
   local base_padding = with_arrows and (not node.nodes or depth > 0) and "  " or ""
-  local padding = inline_arrows and base_padding or ""
+  local padding = (inline_arrows or depth == 0) and base_padding or ""
 
   if depth > 0 then
     local has_folder_sibling = check_siblings_for_folder(node, with_arrows)

--- a/lua/nvim-tree/renderer/components/padding.lua
+++ b/lua/nvim-tree/renderer/components/padding.lua
@@ -19,9 +19,9 @@ local function check_siblings_for_folder(node, with_arrows)
   return false
 end
 
-local function get_padding_indent_markers(depth, idx, nodes_number, markers, with_arrows, node)
+local function get_padding_indent_markers(depth, idx, nodes_number, markers, with_arrows, inline_arrows, node)
   local base_padding = with_arrows and (not node.nodes or depth > 0) and "  " or ""
-  local padding = base_padding
+  local padding = inline_arrows and base_padding or ""
 
   if depth > 0 then
     local has_folder_sibling = check_siblings_for_folder(node, with_arrows)
@@ -39,8 +39,10 @@ local function get_padding_indent_markers(depth, idx, nodes_number, markers, wit
         glyph = M.config.indent_markers.icons.none
       end
 
-      if not with_arrows or i == 1 then
+      if not with_arrows or (inline_arrows and (rdepth ~= i or not node.nodes)) then
         padding = padding .. glyph .. " "
+      elseif inline_arrows then
+        padding = padding
       elseif idx == nodes_number and i == rdepth and has_folder_sibling then
         padding = padding .. base_padding .. glyph .. "── "
       elseif rdepth == i and not node.nodes and has_folder_sibling then
@@ -68,9 +70,10 @@ function M.get_padding(depth, idx, nodes_number, node, markers)
 
   local show_arrows = M.config.icons.show.folder_arrow
   local show_markers = M.config.indent_markers.enable
+  local inline_arrows = M.config.indent_markers.inline_arrows
 
   if show_markers then
-    padding = padding .. get_padding_indent_markers(depth, idx, nodes_number, markers, show_arrows, node)
+    padding = padding .. get_padding_indent_markers(depth, idx, nodes_number, markers, show_arrows, inline_arrows, node)
   else
     padding = padding .. string.rep(" ", depth)
   end


### PR DESCRIPTION
Add an option for folder arrows to be in the same column as the indent markers of their parent
inline_arrows = true
![on](https://user-images.githubusercontent.com/40039652/181151806-1545cffa-580c-4b6b-99f1-e4247f7c65dc.png)
inline_arrows = false
![off](https://user-images.githubusercontent.com/40039652/181151829-9efc8369-3556-4867-b332-9f6accd96d57.png)

references: #1460 
