### PR TITLE
Fixed broken remove_keymaps option.

### DIFF
--- a/lua/nvim-tree/keymap.lua
+++ b/lua/nvim-tree/keymap.lua
@@ -280,7 +280,7 @@ local function get_keymaps(keys_to_disable)
 end
 
 function M.setup(opts)
-  M.keymaps = get_keymaps(opts)
+  M.keymaps = get_keymaps(opts.remove_keymaps)
 end
 
 return M


### PR DESCRIPTION
New here, just trying to set up nvim-tree. `remove_keymaps` option wasn't working for me and it looks like this is why.

Feel free to change as you see fit.