### PR TITLE
chore(mappings): migrate legacy mappings under the hood

### DIFF
--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -666,8 +666,9 @@ function M.setup(conf)
   validate_options(conf)
 
   local opts = merge_options(conf)
-  local netrw_disabled = opts.disable_netrw or opts.hijack_netrw
+  legacy.move_mappings_to_keymap(opts)
 
+  local netrw_disabled = opts.disable_netrw or opts.hijack_netrw
   _config.root_dirs = opts.root_dirs
   _config.prefer_startup_root = opts.prefer_startup_root
   _config.update_focused_file = opts.update_focused_file

--- a/lua/nvim-tree/api.lua
+++ b/lua/nvim-tree/api.lua
@@ -15,12 +15,20 @@ local function inject_node(f)
   end
 end
 
-Api.tree.open = require("nvim-tree").open
-Api.tree.toggle = require("nvim-tree").toggle
+Api.tree.open = function(...)
+  require("nvim-tree").open(...)
+end
+Api.tree.toggle = function(...)
+  require("nvim-tree").toggle(...)
+end
 Api.tree.close = require("nvim-tree.view").close
-Api.tree.focus = require("nvim-tree").focus
+Api.tree.focus = function()
+  require("nvim-tree").focus()
+end
 Api.tree.reload = require("nvim-tree.actions.reloaders.reloaders").reload_explorer
-Api.tree.change_root = require("nvim-tree").change_dir
+Api.tree.change_root = function(...)
+  require("nvim-tree").change_dir(...)
+end
 Api.tree.change_root_to_node = inject_node(function(node)
   if node.name == ".." then
     require("nvim-tree.actions.root.change-dir").fn ".."

--- a/lua/nvim-tree/legacy.lua
+++ b/lua/nvim-tree/legacy.lua
@@ -1,4 +1,5 @@
 local utils = require "nvim-tree.utils"
+local Api = require "nvim-tree.api"
 
 local M = {}
 
@@ -294,6 +295,99 @@ local function removed(opts)
   if opts.auto_close then
     utils.notify.warn "auto close feature has been removed, see note in the README (tips & reminder section)"
     opts.auto_close = nil
+  end
+end
+
+local OLD_MAPPING_TABLE = {
+  edit = Api.node.open.edit,
+  edit_in_place = Api.node.open.replace_tree_buffer,
+  edit_no_picker = Api.node.open.no_window_picker,
+  cd = Api.tree.change_root_to_node,
+  vsplit = Api.node.open.vertical,
+  split = Api.node.open.horizontal,
+  tabnew = Api.node.open.tab,
+  preview = Api.node.open.preview,
+  prev_sibling = Api.node.navigate.sibling.prev,
+  next_sibling = Api.node.navigate.sibling.next,
+  parent_node = Api.node.navigate.parent,
+  close_node = Api.node.navigate.parent_close,
+  first_sibling = Api.node.navigate.sibling.first,
+  last_sibling = Api.node.navigate.sibling.last,
+  toggle_git_ignored = Api.tree.toggle_gitignore_filter,
+  toggle_dotfiles = Api.tree.toggle_hidden_filter,
+  toggle_custom = Api.tree.toggle_custom_filter,
+  refresh = Api.tree.reload,
+  create = Api.fs.create,
+  remove = Api.fs.remove,
+  trash = Api.fs.trash,
+  rename = Api.fs.rename,
+  full_rename = Api.fs.rename_sub,
+  cut = Api.fs.cut,
+  copy = Api.fs.copy.node,
+  paste = Api.fs.paste,
+  copy_name = Api.fs.copy.filename,
+  copy_path = Api.fs.copy.relative_path,
+  copy_absolute_path = Api.fs.copy.absolute_path,
+  prev_git_item = Api.node.navigate.git.prev,
+  next_git_item = Api.node.navigate.git.next,
+  prev_diag_item = Api.node.navigate.diagnostics.prev,
+  next_diag_item = Api.node.navigate.diagnostics.next,
+  dir_up = Api.tree.change_root_to_parent,
+  system_open = Api.node.run.system,
+  live_filter = Api.live_filter.start,
+  clear_live_filter = Api.live_filter.clear,
+  close = Api.tree.close,
+  collapse_all = Api.tree.collapse_all,
+  expand_all = Api.tree.expand_all,
+  search_node = Api.tree.search_node,
+  run_file_command = Api.node.run.cmd,
+  toggle_file_info = Api.node.show_info_popup,
+  toggle_help = Api.tree.toggle_help,
+  toggle_mark = Api.marks.toggle,
+  bulk_move = Api.marks.bulk.move,
+}
+
+function M.move_mappings_to_keymap(opts)
+  if opts.on_attach == "disable" and opts.view and opts.view.mappings then
+    local custom_only, list = opts.view.mappings.custom_only, opts.view.mappings.list
+    if custom_only then
+      opts.remove_keymaps = true
+      opts.view.mappings.custom_only = nil
+    end
+    if list then
+      if not custom_only then
+        opts.remove_keymaps = {}
+      end
+      local call_list = {}
+      opts.on_attach = function(bufnr)
+        for _, el in pairs(call_list) do
+          vim.keymap.set(el.mode or "n", el.key, el.callback, { buffer = bufnr, remap = false, silent = true })
+        end
+      end
+      for _, map in pairs(list) do
+        local keys = type(map.key) == "table" and map.key or { map.key }
+        local mode = map.mode or "n"
+        local callback
+        if map.action ~= "" then
+          if map.action_cb then
+            callback = map.action_cb
+          else
+            callback = OLD_MAPPING_TABLE[map.action]
+          end
+        end
+
+        for _, k in pairs(keys) do
+          if not custom_only and not vim.tbl_contains(opts.remove_keymaps, k) then
+            table.insert(opts.remove_keymaps, k)
+          end
+
+          if callback then
+            table.insert(call_list, { mode = mode, key = k, callback = callback })
+          end
+        end
+      end
+      opts.view.mappings.list = nil
+    end
   end
 end
 


### PR DESCRIPTION
NOTE: this should not be merged before we tested it thoroughly.
NOTE2: this should not be merged before the help menu is rewritten
NOTE3: this can be used to print the on_attach migration to the user.