### PR TITLE
chore(mappings): POC for help and :help on_attach keymaps

### DIFF
--- a/lua/nvim-tree/actions/init.lua
+++ b/lua/nvim-tree/actions/init.lua
@@ -248,8 +248,9 @@ local M = {
 
 local function set_map_for(bufnr)
   local opts = { noremap = true, silent = true, nowait = true, buffer = bufnr }
-  return function(mode, rhs)
+  return function(mode, rhs, desc)
     return function(lhs)
+      opts.desc = desc
       vim.keymap.set(mode or "n", lhs, rhs, opts)
     end
   end
@@ -266,7 +267,7 @@ function M.apply_mappings(bufnr)
   for _, b in pairs(M.mappings) do
     local rhs = b.cb or run_dispatch(b.action)
     if rhs then
-      local setter = setter_for(b.mode, rhs)
+      local setter = setter_for(b.mode, rhs, b.action)
 
       local keys = type(b.key) == "table" and b.key or { b.key }
       for _, key in pairs(keys) do

--- a/lua/nvim-tree/keymap.lua
+++ b/lua/nvim-tree/keymap.lua
@@ -2,236 +2,374 @@ local Api = require "nvim-tree.api"
 
 local M = {}
 
-local DEFAULT_KEYMAPS = {
+M.DEFAULT_KEYMAPS = {
   {
     key = { "<CR>", "o", "<2-LeftMouse>" },
     callback = Api.node.open.edit,
-    desc = "open a file or folder; root will cd to the above directory",
+    desc = {
+      long = "open a file or folder; root will cd to the above directory",
+      short = "Open",
+    },
   },
   {
     key = "<C-e>",
     callback = Api.node.open.replace_tree_buffer,
-    desc = "edit the file in place, effectively replacing the tree explorer",
+    desc = {
+      long = "edit the file in place, effectively replacing the tree explorer",
+      short = "Open: In Place",
+    },
   },
   {
     key = "O",
     callback = Api.node.open.no_window_picker,
-    desc = "same as (edit) with no window picker",
+    desc = {
+      long = "same as (edit) with no window picker",
+      short = "Open: No Window Picker",
+    },
   },
   {
     key = { "<C-]>", "<2-RightMouse>" },
     callback = Api.tree.change_root_to_node,
-    desc = "cd in the directory under the cursor",
+    desc = {
+      long = "cd in the directory under the cursor",
+      short = "cd",
+    },
   },
   {
     key = "<C-v>",
     callback = Api.node.open.vertical,
-    desc = "open the file in a vertical split",
+    desc = {
+      long = "open the file in a vertical split",
+      short = "Open: Vertical Split",
+    },
   },
   {
     key = "<C-x>",
     callback = Api.node.open.horizontal,
-    desc = "open the file in a horizontal split",
+    desc = {
+      long = "open the file in a horizontal split",
+      short = "Open: Horizontal Split",
+    },
   },
   {
     key = "<C-t>",
     callback = Api.node.open.tab,
-    desc = "open the file in a new tab",
+    desc = {
+      long = "open the file in a new tab",
+      short = "Open: New Tab",
+    },
   },
   {
     key = "<",
     callback = Api.node.navigate.sibling.prev,
-    desc = "navigate to the previous sibling of current file/directory",
+    desc = {
+      long = "navigate to the previous sibling of current file/directory",
+      short = "Previous Sibling",
+    },
   },
   {
     key = ">",
     callback = Api.node.navigate.sibling.next,
-    desc = "navigate to the next sibling of current file/directory",
+    desc = {
+      long = "navigate to the next sibling of current file/directory",
+      short = "Next Sibling",
+    },
   },
   {
     key = "P",
     callback = Api.node.navigate.parent,
-    desc = "move cursor to the parent directory",
+    desc = {
+      long = "move cursor to the parent directory",
+      short = "Parent Directory",
+    },
   },
   {
     key = "<BS>",
     callback = Api.node.navigate.parent_close,
-    desc = "close current opened directory or parent",
+    desc = {
+      long = "close current opened directory or parent",
+      short = "Close Folder",
+    },
   },
   {
     key = "<Tab>",
     callback = Api.node.open.preview,
-    desc = "open the file as a preview (keeps the cursor in the tree)",
+    desc = {
+      long = "open the file as a preview (keeps the cursor in the tree)",
+      short = "Open Preview",
+    },
   },
   {
     key = "K",
     callback = Api.node.navigate.sibling.first,
-    desc = "navigate to the first sibling of current file/directory",
+    desc = {
+      long = "navigate to the first sibling of current file/directory",
+      short = "First Sibling",
+    },
   },
   {
     key = "J",
     callback = Api.node.navigate.sibling.last,
-    desc = "navigate to the last sibling of current file/directory",
+    desc = {
+      long = "navigate to the last sibling of current file/directory",
+      short = "Last Sibling",
+    },
   },
   {
     key = "I",
     callback = Api.tree.toggle_gitignore_filter,
-    desc = "toggle visibility of files/folders hidden via |git.ignore| option",
+    desc = {
+      long = "toggle visibility of files/folders hidden via |git.ignore| option",
+      short = "Toggle Git Ignore",
+    },
   },
   {
     key = "H",
     callback = Api.tree.toggle_hidden_filter,
-    desc = "toggle visibility of dotfiles via |filters.dotfiles| option",
+    desc = {
+      long = "toggle visibility of dotfiles via |filters.dotfiles| option",
+      short = "Toggle Dotfiles",
+    },
   },
   {
     key = "U",
     callback = Api.tree.toggle_custom_filter,
-    desc = "toggle visibility of files/folders hidden via |filters.custom| option",
+    desc = {
+      long = "toggle visibility of files/folders hidden via |filters.custom| option",
+      short = "Toggle Hidden",
+    },
   },
   {
     key = "R",
     callback = Api.tree.reload,
-    desc = "refresh the tree",
+    desc = {
+      long = "refresh the tree",
+      short = "Refresh",
+    },
   },
   {
     key = "a",
     callback = Api.fs.create,
-    desc = "add a file; leaving a trailing `/` will add a directory",
+    desc = {
+      long = "add a file; leaving a trailing `/` will add a directory",
+      short = "Create",
+    },
   },
   {
     key = "d",
     callback = Api.fs.remove,
-    desc = "delete a file (will prompt for confirmation)",
+    desc = {
+      long = "delete a file (will prompt for confirmation)",
+      short = "Delete",
+    },
   },
   {
     key = "D",
     callback = Api.fs.trash,
-    desc = "trash a file via |trash| option",
+    desc = {
+      long = "trash a file via |trash| option",
+      short = "Trash",
+    },
   },
   {
     key = "r",
     callback = Api.fs.rename,
-    desc = "rename a file",
+    desc = {
+      long = "rename a file",
+      short = "Rename",
+    },
   },
   {
     key = "<C-r>",
     callback = Api.fs.rename_sub,
-    desc = "rename a file and omit the filename on input",
+    desc = {
+      long = "rename a file and omit the filename on input",
+      short = "Rename - Omit Filename",
+    },
   },
   {
     key = "x",
     callback = Api.fs.cut,
-    desc = "add/remove file/directory to cut clipboard",
+    desc = {
+      long = "add/remove file/directory to cut clipboard",
+      short = "Cut",
+    },
   },
   {
     key = "c",
     callback = Api.fs.copy.node,
-    desc = "add/remove file/directory to copy clipboard",
+    desc = {
+      long = "add/remove file/directory to copy clipboard",
+      short = "Copy",
+    },
   },
   {
     key = "p",
     callback = Api.fs.paste,
-    desc = "paste from clipboard; cut clipboard has precedence over copy; will prompt for confirmation",
+    desc = {
+      long = "paste from clipboard; cut clipboard has precedence over copy; will prompt for confirmation",
+      short = "Paste",
+    },
   },
   {
     key = "y",
     callback = Api.fs.copy.filename,
-    desc = "copy name to system clipboard",
+    desc = {
+      long = "copy name to system clipboard",
+      short = "Copy File Name",
+    },
   },
   {
     key = "Y",
     callback = Api.fs.copy.relative_path,
-    desc = "copy relative path to system clipboard",
+    desc = {
+      long = "copy relative path to system clipboard",
+      short = "Copy Relative Path",
+    },
   },
   {
     key = "gy",
     callback = Api.fs.copy.absolute_path,
-    desc = "copy absolute path to system clipboard",
+    desc = {
+      long = "copy absolute path to system clipboard",
+      short = "Copy Absolute Path",
+    },
   },
   {
     key = "[e",
     callback = Api.node.navigate.diagnostics.next,
-    desc = "go to next diagnostic item",
+    desc = {
+      long = "go to next diagnostic item",
+      short = "Next Diagnostic",
+    },
   },
   {
     key = "[c",
     callback = Api.node.navigate.git.next,
-    desc = "go to next git item",
+    desc = {
+      long = "go to next git item",
+      short = "Next Git",
+    },
   },
   {
     key = "]e",
     callback = Api.node.navigate.diagnostics.prev,
-    desc = "go to prev diagnostic item",
+    desc = {
+      long = "go to prev diagnostic item",
+      short = "Prev Diagnostic",
+    },
   },
   {
     key = "]c",
     callback = Api.node.navigate.git.prev,
-    desc = "go to prev git item",
+    desc = {
+      long = "go to prev git item",
+      short = "Prev Git",
+    },
   },
   {
     key = "-",
     callback = Api.tree.change_root_to_parent,
-    desc = "navigate up to the parent directory of the current file/directory",
+    desc = {
+      long = "navigate up to the parent directory of the current file/directory",
+      short = "Up",
+    },
   },
   {
     key = "s",
     callback = Api.node.run.system,
-    desc = "open a file with default system application or a folder with default file manager, using |system_open| option",
+    desc = {
+      long = "open a file with default system application or a folder with default file manager, using |system_open| option",
+      short = "Run System",
+    },
   },
   {
     key = "f",
     callback = Api.live_filter.start,
-    desc = "live filter nodes dynamically based on regex matching.",
+    desc = {
+      long = "live filter nodes dynamically based on regex matching.",
+      short = "Filter",
+    },
   },
   {
     key = "F",
     callback = Api.live_filter.clear,
-    desc = "clear live filter",
+    desc = {
+      long = "clear live filter",
+      short = "Clean Filter",
+    },
   },
   {
     key = "q",
     callback = Api.tree.close,
-    desc = "close tree window",
+    desc = {
+      long = "close tree window",
+      short = "Close",
+    },
   },
   {
     key = "W",
     callback = Api.tree.collapse_all,
-    desc = "collapse the whole tree",
+    desc = {
+      long = "collapse the whole tree",
+      short = "Collapse",
+    },
   },
   {
     key = "E",
     callback = Api.tree.expand_all,
-    desc = "expand the whole tree, stopping after expanding |callbacks.expand_all.max_folder_discovery| folders; this might hang neovim for a while if running on a big folder",
+    desc = {
+      long = "expand the whole tree, stopping after expanding |callbacks.expand_all.max_folder_discovery| folders; this might hang neovim for a while if running on a big folder",
+      short = "Expand All",
+    },
   },
   {
     key = "S",
     callback = Api.tree.search_node,
-    desc = "prompt the user to enter a path and then expands the tree to match the path",
+    desc = {
+      long = "prompt the user to enter a path and then expands the tree to match the path",
+      short = "Search",
+    },
   },
   {
     key = ".",
     callback = Api.node.run.cmd,
-    desc = "enter vim command mode with the file the cursor is on",
+    desc = {
+      long = "enter vim command mode with the file the cursor is on",
+      short = "Run Command",
+    },
   },
   {
     key = "<C-k>",
     callback = Api.node.show_info_popup,
-    desc = "toggle a popup with file infos about the file under the cursor",
+    desc = {
+      long = "toggle a popup with file infos about the file under the cursor",
+      short = "Info",
+    },
   },
   {
     key = "g?",
     callback = Api.tree.toggle_help,
-    desc = "toggle help",
+    desc = {
+      long = "toggle help",
+      short = "Help",
+    },
   },
   {
     key = "m",
     callback = Api.marks.toggle,
-    desc = "Toggle node in bookmarks",
+    desc = {
+      long = "Toggle node in bookmarks",
+      short = "Toggle Bookmark",
+    },
   },
   {
     key = "bmv",
     callback = Api.marks.bulk.move,
-    desc = "Move all bookmarked nodes into specified location",
+    desc = {
+      long = "Move all bookmarked nodes into specified location",
+      short = "Move Bookmarked",
+    },
   },
 }
 
@@ -247,7 +385,7 @@ end
 
 local function filter_default_mappings(keys_to_disable)
   local new_map = {}
-  for _, m in pairs(DEFAULT_KEYMAPS) do
+  for _, m in pairs(M.DEFAULT_KEYMAPS) do
     local keys = type(m.key) == "table" and m.key or { m.key }
     local reminding_keys = {}
     for _, key in pairs(keys) do
@@ -280,7 +418,7 @@ local function get_keymaps(keys_to_disable)
     return filter_default_mappings(keys_to_disable)
   end
 
-  return DEFAULT_KEYMAPS
+  return M.DEFAULT_KEYMAPS
 end
 
 function M.setup(opts)

--- a/lua/nvim-tree/keymap.lua
+++ b/lua/nvim-tree/keymap.lua
@@ -8,7 +8,7 @@ local DEFAULT_KEYMAPS = {
     key = { "<CR>", "o", "<2-LeftMouse>" },
     callback = Api.node.open.edit,
     desc = {
-      long = "open a file or folder; root will cd to the above directory",
+      long = "Open a file or directory; root will cd to the above directory.",
       short = "Open",
     },
   },
@@ -16,7 +16,7 @@ local DEFAULT_KEYMAPS = {
     key = "<C-e>",
     callback = Api.node.open.replace_tree_buffer,
     desc = {
-      long = "edit the file in place, effectively replacing the tree explorer",
+      long = "Open file in place, effectively replacing the tree explorer.",
       short = "Open: In Place",
     },
   },
@@ -24,7 +24,7 @@ local DEFAULT_KEYMAPS = {
     key = "O",
     callback = Api.node.open.no_window_picker,
     desc = {
-      long = "same as (edit) with no window picker",
+      long = "Open file with no window picker.",
       short = "Open: No Window Picker",
     },
   },
@@ -32,15 +32,16 @@ local DEFAULT_KEYMAPS = {
     key = { "<C-]>", "<2-RightMouse>" },
     callback = Api.tree.change_root_to_node,
     desc = {
-      long = "cd in the directory under the cursor",
-      short = "cd",
+      long = "cd in the directory under the cursor.",
+      short = "CD",
     },
   },
   {
-    key = "<C-v>",
+    -- key = "<C-v>",
+    key = "<ctrL-v>",
     callback = Api.node.open.vertical,
     desc = {
-      long = "open the file in a vertical split",
+      long = "Open file in a vertical split.",
       short = "Open: Vertical Split",
     },
   },
@@ -48,7 +49,7 @@ local DEFAULT_KEYMAPS = {
     key = "<C-x>",
     callback = Api.node.open.horizontal,
     desc = {
-      long = "open the file in a horizontal split",
+      long = "Open file in a horizontal split.",
       short = "Open: Horizontal Split",
     },
   },
@@ -56,7 +57,7 @@ local DEFAULT_KEYMAPS = {
     key = "<C-t>",
     callback = Api.node.open.tab,
     desc = {
-      long = "open the file in a new tab",
+      long = "Open file in a new tab.",
       short = "Open: New Tab",
     },
   },
@@ -64,7 +65,7 @@ local DEFAULT_KEYMAPS = {
     key = "<",
     callback = Api.node.navigate.sibling.prev,
     desc = {
-      long = "navigate to the previous sibling of current file/directory",
+      long = "Navigate to the previous sibling.",
       short = "Previous Sibling",
     },
   },
@@ -72,7 +73,7 @@ local DEFAULT_KEYMAPS = {
     key = ">",
     callback = Api.node.navigate.sibling.next,
     desc = {
-      long = "navigate to the next sibling of current file/directory",
+      long = "Navigate to the next sibling",
       short = "Next Sibling",
     },
   },
@@ -80,7 +81,7 @@ local DEFAULT_KEYMAPS = {
     key = "P",
     callback = Api.node.navigate.parent,
     desc = {
-      long = "move cursor to the parent directory",
+      long = "Move cursor to the parent directory.",
       short = "Parent Directory",
     },
   },
@@ -88,15 +89,15 @@ local DEFAULT_KEYMAPS = {
     key = "<BS>",
     callback = Api.node.navigate.parent_close,
     desc = {
-      long = "close current opened directory or parent",
-      short = "Close Folder",
+      long = "Close current opened directory or parent.",
+      short = "Close Directory",
     },
   },
   {
     key = "<Tab>",
     callback = Api.node.open.preview,
     desc = {
-      long = "open the file as a preview (keeps the cursor in the tree)",
+      long = "Open file as a preview (keeps the cursor in the tree).",
       short = "Open Preview",
     },
   },
@@ -104,7 +105,7 @@ local DEFAULT_KEYMAPS = {
     key = "K",
     callback = Api.node.navigate.sibling.first,
     desc = {
-      long = "navigate to the first sibling of current file/directory",
+      long = "Navigate to the first sibling.",
       short = "First Sibling",
     },
   },
@@ -112,7 +113,7 @@ local DEFAULT_KEYMAPS = {
     key = "J",
     callback = Api.node.navigate.sibling.last,
     desc = {
-      long = "navigate to the last sibling of current file/directory",
+      long = "Navigate to the last sibling.",
       short = "Last Sibling",
     },
   },
@@ -120,7 +121,7 @@ local DEFAULT_KEYMAPS = {
     key = "I",
     callback = Api.tree.toggle_gitignore_filter,
     desc = {
-      long = "toggle visibility of files/folders hidden via |git.ignore| option",
+      long = "Toggle visibility of files/directories hidden via |git.ignore| option.",
       short = "Toggle Git Ignore",
     },
   },
@@ -128,7 +129,7 @@ local DEFAULT_KEYMAPS = {
     key = "H",
     callback = Api.tree.toggle_hidden_filter,
     desc = {
-      long = "toggle visibility of dotfiles via |filters.dotfiles| option",
+      long = "Toggle visibility of dotfiles via |filters.dotfiles| option.",
       short = "Toggle Dotfiles",
     },
   },
@@ -136,7 +137,7 @@ local DEFAULT_KEYMAPS = {
     key = "U",
     callback = Api.tree.toggle_custom_filter,
     desc = {
-      long = "toggle visibility of files/folders hidden via |filters.custom| option",
+      long = "Toggle visibility of files/directories hidden via |filters.custom| option.",
       short = "Toggle Hidden",
     },
   },
@@ -144,7 +145,7 @@ local DEFAULT_KEYMAPS = {
     key = "R",
     callback = Api.tree.reload,
     desc = {
-      long = "refresh the tree",
+      long = "Refresh the tree.",
       short = "Refresh",
     },
   },
@@ -152,7 +153,7 @@ local DEFAULT_KEYMAPS = {
     key = "a",
     callback = Api.fs.create,
     desc = {
-      long = "add a file; leaving a trailing `/` will add a directory",
+      long = "Create a file; leaving a trailing `/` will add a directory.",
       short = "Create",
     },
   },
@@ -160,7 +161,7 @@ local DEFAULT_KEYMAPS = {
     key = "d",
     callback = Api.fs.remove,
     desc = {
-      long = "delete a file (will prompt for confirmation)",
+      long = "Delete a file, prompting for confirmation.",
       short = "Delete",
     },
   },
@@ -168,7 +169,7 @@ local DEFAULT_KEYMAPS = {
     key = "D",
     callback = Api.fs.trash,
     desc = {
-      long = "trash a file via |trash| option",
+      long = "Trash a file via |trash| option.",
       short = "Trash",
     },
   },
@@ -176,7 +177,7 @@ local DEFAULT_KEYMAPS = {
     key = "r",
     callback = Api.fs.rename,
     desc = {
-      long = "rename a file",
+      long = "Rename a file or directory.",
       short = "Rename",
     },
   },
@@ -280,7 +281,7 @@ local DEFAULT_KEYMAPS = {
     key = "s",
     callback = Api.node.run.system,
     desc = {
-      long = "open a file with default system application or a folder with default file manager, using |system_open| option",
+      long = "Open a file with default system application or a directory with default file manager, using |system_open| option.",
       short = "Run System",
     },
   },
@@ -288,7 +289,7 @@ local DEFAULT_KEYMAPS = {
     key = "f",
     callback = Api.live_filter.start,
     desc = {
-      long = "live filter nodes dynamically based on regex matching.",
+      long = "Live filter nodes dynamically based on regex matching.",
       short = "Filter",
     },
   },
@@ -296,7 +297,7 @@ local DEFAULT_KEYMAPS = {
     key = "F",
     callback = Api.live_filter.clear,
     desc = {
-      long = "clear live filter",
+      long = "Clear live filter.",
       short = "Clean Filter",
     },
   },
@@ -304,7 +305,7 @@ local DEFAULT_KEYMAPS = {
     key = "q",
     callback = Api.tree.close,
     desc = {
-      long = "close tree window",
+      long = "Close tree window.",
       short = "Close",
     },
   },
@@ -312,7 +313,7 @@ local DEFAULT_KEYMAPS = {
     key = "W",
     callback = Api.tree.collapse_all,
     desc = {
-      long = "collapse the whole tree",
+      long = "Collapse the whole tree.",
       short = "Collapse",
     },
   },
@@ -320,7 +321,7 @@ local DEFAULT_KEYMAPS = {
     key = "E",
     callback = Api.tree.expand_all,
     desc = {
-      long = "expand the whole tree, stopping after expanding |callbacks.expand_all.max_folder_discovery| folders; this might hang neovim for a while if running on a big folder",
+      long = "Expand the whole tree, stopping after expanding |callbacks.expand_all.max_folder_discovery| directories; this might hang neovim for a while if running on a big directory.",
       short = "Expand All",
     },
   },
@@ -328,7 +329,7 @@ local DEFAULT_KEYMAPS = {
     key = "S",
     callback = Api.tree.search_node,
     desc = {
-      long = "prompt the user to enter a path and then expands the tree to match the path",
+      long = "Prompt the user to enter a path and then expands the tree to match the path.",
       short = "Search",
     },
   },
@@ -336,7 +337,7 @@ local DEFAULT_KEYMAPS = {
     key = ".",
     callback = Api.node.run.cmd,
     desc = {
-      long = "enter vim command mode with the file the cursor is on",
+      long = "Enter vim command mode with the file the cursor is on.",
       short = "Run Command",
     },
   },
@@ -344,7 +345,7 @@ local DEFAULT_KEYMAPS = {
     key = "<C-k>",
     callback = Api.node.show_info_popup,
     desc = {
-      long = "toggle a popup with file infos about the file under the cursor",
+      long = "Toggle a popup with file info about the file under the cursor.",
       short = "Info",
     },
   },
@@ -352,7 +353,7 @@ local DEFAULT_KEYMAPS = {
     key = "g?",
     callback = Api.tree.toggle_help,
     desc = {
-      long = "toggle help",
+      long = "Toggle help.",
       short = "Help",
     },
   },
@@ -360,7 +361,7 @@ local DEFAULT_KEYMAPS = {
     key = "m",
     callback = Api.marks.toggle,
     desc = {
-      long = "Toggle node in bookmarks",
+      long = "Toggle node in bookmarks.",
       short = "Toggle Bookmark",
     },
   },
@@ -380,6 +381,7 @@ function M.set_keymaps(bufnr)
   for _, km in ipairs(M.keymaps) do
     local keys = type(km.key) == "table" and km.key or { km.key }
     for _, key in ipairs(keys) do
+      opts.desc = km.desc.short
       vim.keymap.set("n", key, km.callback, opts)
     end
   end

--- a/lua/nvim-tree/keymap.lua
+++ b/lua/nvim-tree/keymap.lua
@@ -2,7 +2,8 @@ local Api = require "nvim-tree.api"
 
 local M = {}
 
-M.DEFAULT_KEYMAPS = {
+-- BEGIN_DEFAULT_KEYMAPS
+local DEFAULT_KEYMAPS = {
   {
     key = { "<CR>", "o", "<2-LeftMouse>" },
     callback = Api.node.open.edit,
@@ -372,6 +373,7 @@ M.DEFAULT_KEYMAPS = {
     },
   },
 }
+-- END_DEFAULT_KEYMAPS
 
 function M.set_keymaps(bufnr)
   local opts = { noremap = true, silent = true, nowait = true, buffer = bufnr }
@@ -385,7 +387,7 @@ end
 
 local function filter_default_mappings(keys_to_disable)
   local new_map = {}
-  for _, m in pairs(M.DEFAULT_KEYMAPS) do
+  for _, m in pairs(DEFAULT_KEYMAPS) do
     local keys = type(m.key) == "table" and m.key or { m.key }
     local reminding_keys = {}
     for _, key in pairs(keys) do
@@ -418,11 +420,13 @@ local function get_keymaps(keys_to_disable)
     return filter_default_mappings(keys_to_disable)
   end
 
-  return M.DEFAULT_KEYMAPS
+  return DEFAULT_KEYMAPS
 end
 
 function M.setup(opts)
   M.keymaps = get_keymaps(opts.remove_keymaps)
 end
+
+M.DEFAULT_KEYMAPS = DEFAULT_KEYMAPS
 
 return M

--- a/lua/nvim-tree/keymap.lua
+++ b/lua/nvim-tree/keymap.lua
@@ -185,15 +185,15 @@ local DEFAULT_KEYMAPS = {
     key = "<C-r>",
     callback = Api.fs.rename_sub,
     desc = {
-      long = "rename a file and omit the filename on input",
-      short = "Rename - Omit Filename",
+      long = "Rename a file or directory and omit the filename on input.",
+      short = "Rename: Omit Filename",
     },
   },
   {
     key = "x",
     callback = Api.fs.cut,
     desc = {
-      long = "add/remove file/directory to cut clipboard",
+      long = "Cut file or directory to cut clipboard.",
       short = "Cut",
     },
   },
@@ -201,7 +201,7 @@ local DEFAULT_KEYMAPS = {
     key = "c",
     callback = Api.fs.copy.node,
     desc = {
-      long = "add/remove file/directory to copy clipboard",
+      long = "Copy file or directory to copy clipboard.",
       short = "Copy",
     },
   },
@@ -209,7 +209,7 @@ local DEFAULT_KEYMAPS = {
     key = "p",
     callback = Api.fs.paste,
     desc = {
-      long = "paste from clipboard; cut clipboard has precedence over copy; will prompt for confirmation",
+      long = "Paste from clipboard; cut clipboard has precedence over copy; will prompt for confirmation.",
       short = "Paste",
     },
   },
@@ -217,15 +217,15 @@ local DEFAULT_KEYMAPS = {
     key = "y",
     callback = Api.fs.copy.filename,
     desc = {
-      long = "copy name to system clipboard",
-      short = "Copy File Name",
+      long = "Copy name to system clipboard.",
+      short = "Copy Name",
     },
   },
   {
     key = "Y",
     callback = Api.fs.copy.relative_path,
     desc = {
-      long = "copy relative path to system clipboard",
+      long = "Copy relative path to system clipboard.",
       short = "Copy Relative Path",
     },
   },
@@ -233,7 +233,7 @@ local DEFAULT_KEYMAPS = {
     key = "gy",
     callback = Api.fs.copy.absolute_path,
     desc = {
-      long = "copy absolute path to system clipboard",
+      long = "Copy absolute path to system clipboard.",
       short = "Copy Absolute Path",
     },
   },
@@ -241,7 +241,7 @@ local DEFAULT_KEYMAPS = {
     key = "[e",
     callback = Api.node.navigate.diagnostics.next,
     desc = {
-      long = "go to next diagnostic item",
+      long = "Go to next diagnostic item.",
       short = "Next Diagnostic",
     },
   },
@@ -249,7 +249,7 @@ local DEFAULT_KEYMAPS = {
     key = "[c",
     callback = Api.node.navigate.git.next,
     desc = {
-      long = "go to next git item",
+      long = "Go to next git item.",
       short = "Next Git",
     },
   },
@@ -257,7 +257,7 @@ local DEFAULT_KEYMAPS = {
     key = "]e",
     callback = Api.node.navigate.diagnostics.prev,
     desc = {
-      long = "go to prev diagnostic item",
+      long = "Go to prev diagnostic item.",
       short = "Prev Diagnostic",
     },
   },
@@ -265,7 +265,7 @@ local DEFAULT_KEYMAPS = {
     key = "]c",
     callback = Api.node.navigate.git.prev,
     desc = {
-      long = "go to prev git item",
+      long = "Go to prev git item.",
       short = "Prev Git",
     },
   },
@@ -273,7 +273,7 @@ local DEFAULT_KEYMAPS = {
     key = "-",
     callback = Api.tree.change_root_to_parent,
     desc = {
-      long = "navigate up to the parent directory of the current file/directory",
+      long = "Navigate up to the parent directory of the current file/directory.",
       short = "Up",
     },
   },
@@ -369,7 +369,7 @@ local DEFAULT_KEYMAPS = {
     key = "bmv",
     callback = Api.marks.bulk.move,
     desc = {
-      long = "Move all bookmarked nodes into specified location",
+      long = "Move all bookmarked nodes into specified location.",
       short = "Move Bookmarked",
     },
   },

--- a/lua/nvim-tree/renderer/help.lua
+++ b/lua/nvim-tree/renderer/help.lua
@@ -10,22 +10,14 @@ local function tidy_lhs(lhs)
   end
 
   -- uppercase ctrls
-  if lhs:match "^<C%-" then
+  if lhs:lower():match "^<c%-" then
     lhs = lhs:upper()
   end
 
-  return lhs
-end
+  -- space is not escaped
+  lhs = lhs:gsub(" ", "<Space>")
 
-local function shorten_lhs(lhs)
   return lhs
-    :gsub("LeftMouse>$", "LM>")
-    :gsub("RightMouse>$", "RM>")
-    :gsub("MiddleMouse>$", "MM>")
-    :gsub("ScrollWheelDown>$", "SD>")
-    :gsub("ScrollWheelUp>$", "SU>")
-    :gsub("ScrollWheelLeft>$", "SL>")
-    :gsub("ScrollWheelRight>$", "SR>")
 end
 
 -- sort lhs roughly as per :help index
@@ -78,19 +70,16 @@ function M.compute_lines()
     return sort_lhs(a.lhs, b.lhs)
   end)
 
-  for _, p in pairs(lines) do
-    p.lhs = shorten_lhs(p.lhs)
-  end
-
   local num = 0
   for _, p in pairs(lines) do
     num = num + 1
-    local bind_string = string.format("%-6.6s %s", shorten_lhs(p.lhs), p.desc)
+    local bind_string = string.format("%-5s %s", p.lhs, p.desc)
+    local hl_len = math.max(5, string.len(p.lhs))
     table.insert(help_lines, bind_string)
 
-    table.insert(help_hl, { "NvimTreeFolderName", num, 0, 6 })
+    table.insert(help_hl, { "NvimTreeFolderName", num, 0, hl_len })
 
-    table.insert(help_hl, { "NvimTreeFileRenamed", num, 6, -1 })
+    table.insert(help_hl, { "NvimTreeFileRenamed", num, hl_len, -1 })
   end
   return help_lines, help_hl
 end

--- a/lua/nvim-tree/renderer/help.lua
+++ b/lua/nvim-tree/renderer/help.lua
@@ -70,20 +70,20 @@ function M.compute_lines()
 
   local buf_keymaps = vim.api.nvim_buf_get_keymap(vim.api.nvim_get_current_buf(), "")
 
-  local processed = vim.tbl_map(function(bkm)
+  local lines = vim.tbl_map(function(bkm)
     return { lhs = tidy_lhs(bkm.lhs), desc = bkm.desc }
   end, buf_keymaps)
 
-  table.sort(processed, function(a, b)
+  table.sort(lines, function(a, b)
     return sort_lhs(a.lhs, b.lhs)
   end)
 
-  for _, p in pairs(processed) do
+  for _, p in pairs(lines) do
     p.lhs = shorten_lhs(p.lhs)
   end
 
   local num = 0
-  for _, p in pairs(processed) do
+  for _, p in pairs(lines) do
     num = num + 1
     local bind_string = string.format("%-6.6s %s", shorten_lhs(p.lhs), p.desc)
     table.insert(help_lines, bind_string)

--- a/scripts/generate_default_keymaps.lua
+++ b/scripts/generate_default_keymaps.lua
@@ -1,0 +1,54 @@
+-- luacheck:ignore 113
+---@diagnostic disable: undefined-global
+
+-- write DEFAULT_KEYMAPS in various formats
+
+local max_key_help = 0
+local max_short_help = 0
+local outs_help = {}
+
+for _, m in pairs(DEFAULT_KEYMAPS) do
+  local first = true
+  local keys = type(m.key) == "table" and m.key or { m.key }
+  for _, key in ipairs(keys) do
+    local out = {}
+    out.key = key
+    max_key_help = math.max(#out.key, max_key_help)
+    if first then
+      out.short = m.desc.short
+      max_short_help = math.max(#out.short, max_short_help)
+      out.long = m.desc.long
+      first = false
+    end
+    table.insert(outs_help, out)
+  end
+end
+
+-- help
+local file = io.open("/tmp/DEFAULT_KEYMAPS.help", "w")
+io.output(file)
+io.write "\n"
+local fmt = string.format("%%-%d.%ds  %%-%d.%ds  %%s\n", max_key_help, max_key_help, max_short_help, max_short_help)
+for _, m in pairs(outs_help) do
+  if not m.short then
+    io.write(string.format("%s\n", m.key))
+  else
+    io.write(string.format(fmt, m.key, m.short, m.long))
+  end
+end
+io.write "\n"
+io.close(file)
+
+-- lua on_attach
+file = io.open("/tmp/DEFAULT_KEYMAPS.on_attach.lua", "w")
+io.output(file)
+io.write "local function on_attach(bufnr, mode, opts)\n"
+io.write "local Api = require('nvim-tree.api')\n"
+for _, m in pairs(DEFAULT_KEYMAPS) do
+  local keys = type(m.key) == "table" and m.key or { m.key }
+  for _, key in ipairs(keys) do
+    io.write(string.format("  vim.keymap.set(mode, '%s', %s, opts)\n", key, m.callback))
+  end
+end
+io.write "end\n"
+io.close(file)

--- a/scripts/generate_default_keymaps.lua
+++ b/scripts/generate_default_keymaps.lua
@@ -3,8 +3,9 @@
 
 -- write DEFAULT_KEYMAPS in various formats
 
-local max_key_help = 0
-local max_short_help = 0
+local max_key = 0
+local max_short = 0
+local max_callback = 0
 local outs_help = {}
 
 for _, m in pairs(DEFAULT_KEYMAPS) do
@@ -13,22 +14,23 @@ for _, m in pairs(DEFAULT_KEYMAPS) do
   for _, key in ipairs(keys) do
     local out = {}
     out.key = key
-    max_key_help = math.max(#out.key, max_key_help)
+    max_key = math.max(#out.key, max_key)
     if first then
       out.short = m.desc.short
-      max_short_help = math.max(#out.short, max_short_help)
+      max_short = math.max(#out.short, max_short)
       out.long = m.desc.long
       first = false
     end
     table.insert(outs_help, out)
   end
+  max_callback = math.max(#m.callback, max_callback)
 end
 
 -- help
 local file = io.open("/tmp/DEFAULT_KEYMAPS.help", "w")
 io.output(file)
 io.write "\n"
-local fmt = string.format("%%-%d.%ds  %%-%d.%ds  %%s\n", max_key_help, max_key_help, max_short_help, max_short_help)
+local fmt = string.format("%%-%d.%ds  %%-%d.%ds  %%s\n", max_key, max_key, max_short, max_short)
 for _, m in pairs(outs_help) do
   if not m.short then
     io.write(string.format("%s\n", m.key))
@@ -42,12 +44,19 @@ io.close(file)
 -- lua on_attach
 file = io.open("/tmp/DEFAULT_KEYMAPS.on_attach.lua", "w")
 io.output(file)
-io.write "local function on_attach(bufnr, mode, opts)\n"
-io.write "local Api = require('nvim-tree.api')\n"
+io.write "local Api = require('nvim-tree.api')\n\n"
+io.write "local function on_attach(bufnr)\n"
+fmt = string.format(
+  "  vim.keymap.set('n', %%-%d.%ds %%-%d.%ds { buffer = bufnr, noremap = true, silent = true, nowait = true, desc = '%%s', })\n",
+  max_key + 3,
+  max_key + 3,
+  max_callback + 1,
+  max_callback + 1
+)
 for _, m in pairs(DEFAULT_KEYMAPS) do
   local keys = type(m.key) == "table" and m.key or { m.key }
   for _, key in ipairs(keys) do
-    io.write(string.format("  vim.keymap.set(mode, '%s', %s, opts)\n", key, m.callback))
+    io.write(string.format(fmt, "'" .. key .. "',", m.callback .. ",", m.desc.short))
   end
 end
 io.write "end\n"

--- a/scripts/generate_default_keymaps.lua
+++ b/scripts/generate_default_keymaps.lua
@@ -13,7 +13,7 @@ for _, m in pairs(DEFAULT_KEYMAPS) do
   local keys = type(m.key) == "table" and m.key or { m.key }
   for _, key in ipairs(keys) do
     local out = {}
-    out.key = key
+    out.key = string.format("`%s`", key)
     max_key = math.max(#out.key, max_key)
     if first then
       out.short = m.desc.short

--- a/scripts/update-help.sh
+++ b/scripts/update-help.sh
@@ -31,3 +31,10 @@ sed -i -e "/${begin}/,/${end}/{ /${begin}/{p; r /tmp/DEFAULT_MAPPINGS.lua
            }; /${end}/p; d }" doc/nvim-tree-lua.txt
 sed -i -e "/^DEFAULT MAPPINGS/,/^>$/{ /^DEFAULT MAPPINGS/{p; r /tmp/DEFAULT_MAPPINGS.help
            }; /^>$/p; d }" doc/nvim-tree-lua.txt
+
+# generate various DEFAULT_KEYMAPS
+begin="BEGIN_DEFAULT_KEYMAPS"
+end="END_DEFAULT_KEYMAPS"
+sed -n -e "/${begin}/,/${end}/{ /${begin}/d; /${end}/d; s/callback = \(.*\),/callback = '\1',/g; p; }" lua/nvim-tree/keymap.lua > /tmp/DEFAULT_KEYMAPS.M.lua
+cat /tmp/DEFAULT_KEYMAPS.M.lua scripts/generate_default_keymaps.lua | lua
+


### PR DESCRIPTION
1. generate help view by mapping keymap functions back to `DEFAULT_KEYMAPS`
2. generate :help via update script
a. user readable table `/tmp/DEFAULT_KEYMAPS.help`
b. on_attach function `/tmp/DEFAULT_KEYMAPS.on_attach.lua`

I did mess around with `callback` as a string to loadstring. It works, however I lost the ability to map back, as the function from loadstring is a new wrapper function.

We don't need the complication of loadstring in code, so text processing in the update script is enough. If necessary, we can apply the same processing to generate lua to perform the legacy conversion.