### PR TITLE
doc: reinstate mapping doc, mark on_attach as experimental

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -174,6 +174,8 @@ Subsequent calls to setup will replace the previous configuration.
       sync_root_with_cwd = false,
       reload_on_bufenter = false,
       respect_buf_cwd = false,
+      on_attach = "disable", -- function(bufnr). If nil, will use the deprecated mapping strategy
+      remove_keymaps = false, -- boolean (disable totally or not) or list of key (lhs)
       view = {
         adaptive_size = false,
         centralize_selection = false,
@@ -628,11 +630,14 @@ Window / buffer setup.
     Configuration options for |nvim-tree-mappings|
 
         *nvim-tree.view.mappings.custom_only*
-            DEPRECATED: see |nvim-tree.remove_keymaps|
-
+        Will use only the provided user mappings and not the default otherwise,
+        extends the default mappings with the provided user mappings.
+          Type: `boolean`, Default: `false`
 
         *nvim-tree.view.mappings.list*
-            DEPRECATED: see |nvim-tree.on_attach|
+        A list of keymaps that will extend or override the default keymaps.
+          Type: `table`
+          Default: see |nvim-tree-default-mappings|
 
 *nvim-tree.renderer*
 UI rendering setup
@@ -1076,55 +1081,132 @@ exists.
 ==============================================================================
  6. MAPPINGS                                              *nvim-tree-mappings*
 
-Setting your own mapping in the configuration is deprecated, see |nvim-tree.on_attach| now.
+Setting your own mapping in the configuration will soon be deprecated, see |nvim-tree.on_attach| for experimental replacement.
 
-You can remove default mappings with |nvim-tree.remove_keymaps|.
+The `list` option in `view.mappings.list` is a table of
 
-`<CR>`, `o`, `<2-LeftMouse>`    open a file or folder; root will cd to the above directory
-`<C-e>`                         edit the file in place, effectively replacing the tree explorer
-`O`                             same as (edit) with no window picker
-`<C-]>`, `<2-RightMouse>`       cd in the directory under the cursor
-`<C-v>`                         open the file in a vertical split
-`<C-x>`                         open the file in a horizontal split
-`<C-t>`                         open the file in a new tab
-`<`                             navigate to the previous sibling of current file/directory
-`>`                             navigate to the next sibling of current file/directory
-`P`                             move cursor to the parent directory
-`<BS>`                          close current opened directory or parent
-`<Tab>`                         open the file as a preview (keeps the cursor in the tree)
-`K`                             navigate to the first sibling of current file/directory
-`J`                             navigate to the last sibling of current file/directory
-`I`                             toggle visibility of files/folders hidden via |git.ignore| option
-`H`                             toggle visibility of dotfiles via |filters.dotfiles| option
-`U`                             toggle visibility of files/folders hidden via |filters.custom| option
-`R`                             refresh the tree
-`a`                             add a file; leaving a trailing `/` will add a directory
-`d`                             delete a file (will prompt for confirmation)
-`D`                             trash a file via |trash| option
-`r`                             rename a file
-`<C-r>`                         rename a file and omit the filename on input
-`x`                             add/remove file/directory to cut clipboard
-`c`                             add/remove file/directory to copy clipboard
-`p`                             paste from clipboard; cut clipboard has precedence over copy; will prompt for confirmation
-`y`                             copy name to system clipboard
-`Y`                             copy relative path to system clipboard
-`gy`                            copy absolute path to system clipboard
-`[e`                            go to next diagnostic item
-`[c`                            go to next git item
-`]e`                            go to prev diagnostic item
-`]c`                            go to prev git item
-`-`                             navigate up to the parent directory of the current file/directory
-`s`                             open a file with default system application or a folder with default file manager, using |system_open| option
-`f`                             live filter nodes dynamically based on regex matching.
-`F`                             clear live filter
-`q`                             close tree window
-`W`                             collapse the whole tree
-`E`                             expand the whole tree, stopping after expanding |actions.expand_all.max_folder_discovery| folders; this might hang neovim for a while if running on a big folder
-`S`                             prompt the user to enter a path and then expands the tree to match the path
-`.`                             enter vim command mode with the file the cursor is on
-`<C-k>`                         toggle a popup with file infos about the file under the cursor
-`g?`                            toggle help
-`m`                             Toggle node in bookmarks
+- `key` can be either a string or a table of string (lhs)
+- `action` is the name of the action, set to `""` to remove default action
+- `action_cb` is the function that will be called, it receives the node as a parameter. Optional for default actions
+- `mode` is normal by default
+>
+  local tree_cb = require'nvim-tree.config'.nvim_tree_callback
+
+  local function print_node_path(node) {
+    print(node.absolute_path)
+  }
+
+  local list = {
+    { key = {"<CR>", "o" }, action = "edit", mode = "n"},
+    { key = "p", action = "print_path", action_cb = print_node_path },
+    { key = "s", cb = tree_cb("vsplit") }, --tree_cb and the cb property are deprecated
+    { key = "<2-RightMouse>", action = "" }, -- will remove default cd action
+  }
+<
+Mouse support defined in |KeyBindings|
+
+DEFAULT MAPPINGS                                     *nvim-tree-default-mappings*
+
+`<CR>`            edit                open a file or folder; root will cd to the above directory
+`o`
+`<2-LeftMouse>`
+`<C-e>`           edit_in_place       edit the file in place, effectively replacing the tree explorer
+`O`               edit_no_picker      same as (edit) with no window picker
+`<C-]>`           cd                  cd in the directory under the cursor
+`<2-RightMouse>`
+`<C-v>`           vsplit              open the file in a vertical split
+`<C-x>`           split               open the file in a horizontal split
+`<C-t>`           tabnew              open the file in a new tab
+`<`               prev_sibling        navigate to the previous sibling of current file/directory
+`>`               next_sibling        navigate to the next sibling of current file/directory
+`P`               parent_node         move cursor to the parent directory
+`<BS>`            close_node          close current opened directory or parent
+`<Tab>`           preview             open the file as a preview (keeps the cursor in the tree)
+`K`               first_sibling       navigate to the first sibling of current file/directory
+`J`               last_sibling        navigate to the last sibling of current file/directory
+`I`               toggle_git_ignored  toggle visibility of files/folders hidden via |git.ignore| option
+`H`               toggle_dotfiles     toggle visibility of dotfiles via |filters.dotfiles| option
+`U`               toggle_custom       toggle visibility of files/folders hidden via |filters.custom| option
+`R`               refresh             refresh the tree
+`a`               create              add a file; leaving a trailing `/` will add a directory
+`d`               remove              delete a file (will prompt for confirmation)
+`D`               trash               trash a file via |trash| option
+`r`               rename              rename a file
+`<C-r>`           full_rename         rename a file and omit the filename on input
+`x`               cut                 add/remove file/directory to cut clipboard
+`c`               copy                add/remove file/directory to copy clipboard
+`p`               paste               paste from clipboard; cut clipboard has precedence over copy; will prompt for confirmation
+`y`               copy_name           copy name to system clipboard
+`Y`               copy_path           copy relative path to system clipboard
+`gy`              copy_absolute_path  copy absolute path to system clipboard
+`[e`              prev_diag_item      go to next diagnostic item
+`[c`              prev_git_item       go to next git item
+`]e`              next_diag_item      go to prev diagnostic item
+`]c`              next_git_item       go to prev git item
+`-`               dir_up              navigate up to the parent directory of the current file/directory
+`s`               system_open         open a file with default system application or a folder with default file manager, using |system_open| option
+`f`               live_filter         live filter nodes dynamically based on regex matching.
+`F`               clear_live_filter   clear live filter
+`q`               close               close tree window
+`W`               collapse_all        collapse the whole tree
+`E`               expand_all          expand the whole tree, stopping after expanding |actions.expand_all.max_folder_discovery| folders; this might hang neovim for a while if running on a big folder
+`S`               search_node         prompt the user to enter a path and then expands the tree to match the path
+`.`               run_file_command    enter vim command mode with the file the cursor is on
+`<C-k>`           toggle_file_info    toggle a popup with file infos about the file under the cursor
+`g?`              toggle_help         toggle help
+`m`               toggle_mark         Toggle node in bookmarks
+`bmv`             bulk_move           Move all bookmarked nodes into specified location
+
+>
+  view.mappings.list = { -- BEGIN_DEFAULT_MAPPINGS
+    { key = { "<CR>", "o", "<2-LeftMouse>" }, action = "edit" },
+    { key = "<C-e>",                          action = "edit_in_place" },
+    { key = "O",                              action = "edit_no_picker" },
+    { key = { "<C-]>", "<2-RightMouse>" },    action = "cd" },
+    { key = "<C-v>",                          action = "vsplit" },
+    { key = "<C-x>",                          action = "split" },
+    { key = "<C-t>",                          action = "tabnew" },
+    { key = "<",                              action = "prev_sibling" },
+    { key = ">",                              action = "next_sibling" },
+    { key = "P",                              action = "parent_node" },
+    { key = "<BS>",                           action = "close_node" },
+    { key = "<Tab>",                          action = "preview" },
+    { key = "K",                              action = "first_sibling" },
+    { key = "J",                              action = "last_sibling" },
+    { key = "I",                              action = "toggle_git_ignored" },
+    { key = "H",                              action = "toggle_dotfiles" },
+    { key = "U",                              action = "toggle_custom" },
+    { key = "R",                              action = "refresh" },
+    { key = "a",                              action = "create" },
+    { key = "d",                              action = "remove" },
+    { key = "D",                              action = "trash" },
+    { key = "r",                              action = "rename" },
+    { key = "<C-r>",                          action = "full_rename" },
+    { key = "x",                              action = "cut" },
+    { key = "c",                              action = "copy" },
+    { key = "p",                              action = "paste" },
+    { key = "y",                              action = "copy_name" },
+    { key = "Y",                              action = "copy_path" },
+    { key = "gy",                             action = "copy_absolute_path" },
+    { key = "[e",                             action = "prev_diag_item" },
+    { key = "[c",                             action = "prev_git_item" },
+    { key = "]e",                             action = "next_diag_item" },
+    { key = "]c",                             action = "next_git_item" },
+    { key = "-",                              action = "dir_up" },
+    { key = "s",                              action = "system_open" },
+    { key = "f",                              action = "live_filter" },
+    { key = "F",                              action = "clear_live_filter" },
+    { key = "q",                              action = "close" },
+    { key = "W",                              action = "collapse_all" },
+    { key = "E",                              action = "expand_all" },
+    { key = "S",                              action = "search_node" },
+    { key = ".",                              action = "run_file_command" },
+    { key = "<C-k>",                          action = "toggle_file_info" },
+    { key = "g?",                             action = "toggle_help" },
+    { key = "m",                              action = "toggle_mark" },
+    { key = "bmv",                            action = "bulk_move" },
+  } -- END_DEFAULT_MAPPINGS
+<
 
 ==============================================================================
  7. HIGHLIGHT GROUPS                                     *nvim-tree-highlight*

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -447,7 +447,6 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
     number = false,
     relativenumber = false,
     signcolumn = "yes",
-    -- @deprecated
     mappings = {
       custom_only = false,
       list = {


### PR DESCRIPTION
We don't have a complete story for on_attach yet, so restore the documentation for old style mappings.

As a new user, I would find it difficult to set up mappings: I don't have any examples or indication of how to create on_attach mappings for non-custom functions.