### PR TITLE
fix(#1480): break symlink cycle on find-file, search-node

### DIFF
--- a/lua/nvim-tree/actions/finders/find-file.lua
+++ b/lua/nvim-tree/actions/finders/find-file.lua
@@ -33,10 +33,7 @@ function M.fn(fname)
     end)
     :applier(function(node)
       line = line + 1
-      local abs_match = vim.startswith(fname_real, node.absolute_path .. utils.path_separator)
-      local link_match = node.link_to and vim.startswith(fname_real, node.link_to .. utils.path_separator)
-
-      if abs_match or link_match then
+      if vim.startswith(fname_real, node.absolute_path .. utils.path_separator) then
         node.open = true
         if #node.nodes == 0 then
           core.get_explorer():expand(node)

--- a/lua/nvim-tree/actions/finders/find-file.lua
+++ b/lua/nvim-tree/actions/finders/find-file.lua
@@ -27,13 +27,24 @@ function M.fn(fname)
 
   local line = core.get_nodes_starting_line()
 
+  local absolute_paths_searched = {}
+
   local found = Iterator.builder(core.get_explorer().nodes)
     :matcher(function(node)
       return node.absolute_path == fname_real or node.link_to == fname_real
     end)
     :applier(function(node)
       line = line + 1
-      if vim.startswith(fname_real, node.absolute_path .. utils.path_separator) then
+
+      if vim.tbl_contains(absolute_paths_searched, node.absolute_path) then
+        return
+      end
+      table.insert(absolute_paths_searched, node.absolute_path)
+
+      local abs_match = vim.startswith(fname_real, node.absolute_path .. utils.path_separator)
+      local link_match = node.link_to and vim.startswith(fname_real, node.link_to .. utils.path_separator)
+
+      if abs_match or link_match then
         node.open = true
         if #node.nodes == 0 then
           core.get_explorer():expand(node)

--- a/lua/nvim-tree/actions/finders/search-node.lua
+++ b/lua/nvim-tree/actions/finders/search-node.lua
@@ -7,14 +7,14 @@ local find_file = require("nvim-tree.actions.finders.find-file").fn
 
 local M = {}
 
-local function search(search_dir, search_input_path)
+local function search(search_dir, input_path)
   local realpaths = {}
 
   if not search_dir then
     return
   end
 
-  local function iter(dir, input_path)
+  local function iter(dir)
     local realpath, path, name, stat, handle, _
 
     handle, _ = uv.fs_scandir(dir)
@@ -54,7 +54,7 @@ local function search(search_dir, search_input_path)
     end
   end
 
-  return iter(search_dir, search_input_path)
+  return iter(search_dir)
 end
 
 function M.fn()

--- a/lua/nvim-tree/actions/finders/search-node.lua
+++ b/lua/nvim-tree/actions/finders/search-node.lua
@@ -7,42 +7,54 @@ local find_file = require("nvim-tree.actions.finders.find-file").fn
 
 local M = {}
 
-local function search(dir, input_path)
-  local path, name, stat, handle, _
+local function search(search_dir, search_input_path)
+  local realpaths = {}
 
-  if not dir then
+  if not search_dir then
     return
   end
 
-  handle, _ = uv.fs_scandir(dir)
-  if not handle then
-    return
-  end
+  local function iter(dir, input_path)
+    local realpath, path, name, stat, handle, _
 
-  name, _ = uv.fs_scandir_next(handle)
-  while name do
-    path = dir .. "/" .. name
-
-    stat, _ = uv.fs_stat(path)
-    if not stat then
-      break
+    handle, _ = uv.fs_scandir(dir)
+    if not handle then
+      return
     end
 
-    if not filters.should_ignore(path) then
-      if string.find(path, "/" .. input_path .. "$") then
-        return path
-      end
-
-      if stat.type == "directory" then
-        path = search(path, input_path)
-        if path then
-          return path
-        end
-      end
+    realpath, _ = uv.fs_realpath(dir)
+    if not realpath or vim.tbl_contains(realpaths, realpath) then
+      return
     end
+    table.insert(realpaths, realpath)
 
     name, _ = uv.fs_scandir_next(handle)
+    while name do
+      path = dir .. "/" .. name
+
+      stat, _ = uv.fs_stat(path)
+      if not stat then
+        break
+      end
+
+      if not filters.should_ignore(path) then
+        if string.find(path, "/" .. input_path .. "$") then
+          return path
+        end
+
+        if stat.type == "directory" then
+          path = iter(path, input_path)
+          if path then
+            return path
+          end
+        end
+      end
+
+      name, _ = uv.fs_scandir_next(handle)
+    end
   end
+
+  return iter(search_dir, search_input_path)
 end
 
 function M.fn()

--- a/lua/nvim-tree/actions/finders/search-node.lua
+++ b/lua/nvim-tree/actions/finders/search-node.lua
@@ -8,7 +8,7 @@ local find_file = require("nvim-tree.actions.finders.find-file").fn
 local M = {}
 
 local function search(search_dir, input_path)
-  local realpaths = {}
+  local realpaths_searched = {}
 
   if not search_dir then
     return
@@ -23,10 +23,10 @@ local function search(search_dir, input_path)
     end
 
     realpath, _ = uv.fs_realpath(dir)
-    if not realpath or vim.tbl_contains(realpaths, realpath) then
+    if not realpath or vim.tbl_contains(realpaths_searched, realpath) then
       return
     end
-    table.insert(realpaths, realpath)
+    table.insert(realpaths_searched, realpath)
 
     name, _ = uv.fs_scandir_next(handle)
     while name do
@@ -43,7 +43,7 @@ local function search(search_dir, input_path)
         end
 
         if stat.type == "directory" then
-          path = iter(path, input_path)
+          path = iter(path)
           if path then
             return path
           end


### PR DESCRIPTION
closes #1480 

* detect cycles on search-node `S`
* search link paths, not target paths on find-file

expand-all is OK as it stops after `max_folder_discovery`, however it does follow cycles. We should look at that if time permits.