### PR TITLE
Add nvim_open_win configuration for file-popup action

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -313,6 +313,15 @@ Subsequent calls to setup will replace the previous configuration.
           max_folder_discovery = 300,
           exclude = {},
         },
+        file_popup = {
+          open_win_config = {
+            col = 1,
+            row = 1,
+            relative = "cursor",
+            border = "shadow",
+            style = "minimal",
+          },
+        },
         open_file = {
           quit_on_open = false,
           resize_window = true,
@@ -868,6 +877,22 @@ Configuration for various actions.
         A list of directories that should not be expanded automatically.
         E.g `{ ".git", "target", "build" }` etc.
           Type: `table`, Default: `{}`
+
+    *nvim-tree.actions.file_popup*
+    Configuration for file_popup behaviour.
+
+        *nvim-tree.actions.file_popup.open_win_config*
+        Floating window config for file_popup. See |nvim_open_win| for more details.
+        You shouldn't define `"width"` and `"height"` values here. They will be
+        overridden to fit the file_popup content.
+          Type: `table`, Default:
+            `{`
+              `col = 1,`
+              `row = 1,`
+              `relative = "cursor",`
+              `border = "shadow",`
+              `style = "minimal",`
+            `}`
 
     *nvim-tree.actions.open_file*
     Configuration options for opening a file from nvim-tree.

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -576,6 +576,15 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
       max_folder_discovery = 300,
       exclude = {},
     },
+    file_popup = {
+      open_win_config = {
+        col = 1,
+        row = 1,
+        relative = "cursor",
+        border = "shadow",
+        style = "minimal",
+      },
+    },
     open_file = {
       quit_on_open = false,
       resize_window = true,

--- a/lua/nvim-tree/actions/init.lua
+++ b/lua/nvim-tree/actions/init.lua
@@ -389,6 +389,7 @@ local DEFAULT_MAPPING_CONFIG = {
 function M.setup(opts)
   require("nvim-tree.actions.fs.trash").setup(opts)
   require("nvim-tree.actions.node.system-open").setup(opts)
+  require("nvim-tree.actions.node.file-popup").setup(opts)
   require("nvim-tree.actions.node.open-file").setup(opts)
   require("nvim-tree.actions.root.change-dir").setup(opts)
   require("nvim-tree.actions.fs.create-file").setup(opts)

--- a/lua/nvim-tree/actions/node/file-popup.lua
+++ b/lua/nvim-tree/actions/node/file-popup.lua
@@ -28,16 +28,12 @@ local function setup_window(node)
   local max_width = vim.fn.max(vim.tbl_map(function(n)
     return #n
   end, lines))
-  local winnr = a.nvim_open_win(0, false, {
-    col = 1,
-    row = 1,
-    relative = "cursor",
+  local open_win_config = vim.tbl_extend("force", M.open_win_config, {
     width = max_width + 1,
     height = #lines,
-    border = "shadow",
     noautocmd = true,
-    style = "minimal",
   })
+  local winnr = a.nvim_open_win(0, false, open_win_config)
   current_popup = {
     winnr = winnr,
     file_path = node.absolute_path,
@@ -76,6 +72,10 @@ function M.toggle_file_info(node)
     group = a.nvim_create_augroup("NvimTreeRemoveFilePopup", {}),
     callback = M.close_popup,
   })
+end
+
+function M.setup(opts)
+  M.open_win_config = opts.actions.file_popup.open_win_config
 end
 
 return M


### PR DESCRIPTION
Judging by https://github.com/kyazdani42/nvim-tree.lua/pull/1042#discussion_r819384771 maybe I should put the configuration inside `actions.file_popup.nvim_open_win` instead.