### PR TITLE
Use select instead of input for overwriting file

### DIFF
--- a/lua/nvim-tree/actions/fs/copy-paste.lua
+++ b/lua/nvim-tree/actions/fs/copy-paste.lua
@@ -94,11 +94,11 @@ local function do_single_paste(source, dest, action_type, action_fn)
   end
 
   if dest_stats then
-    vim.ui.input({ prompt = dest .. " already exists. Overwrite? y/n/r(ename): " }, function(choice)
+    vim.ui.select({ "Yes", "No", "Rename" }, { prompt = dest .. " already exists. Overwrite? y/n/r(ename): " }, function(choice)
       utils.clear_prompt()
-      if choice == "y" then
+      if choice == "Yes" then
         on_process()
-      elseif choice == "r" then
+      elseif choice == "Rename" then
         vim.ui.input({ prompt = "New name: ", default = dest, completion = "dir" }, function(new_dest)
           utils.clear_prompt()
           if new_dest then


### PR DESCRIPTION
Since the input is for 1 of 3 options (y = yes, n = no, r = rename), it only makes sense to use a select instead of input, which also fixes the truncated input box when using https://github.com/stevearc/dressing.nvim
Closes #1483