### PR TITLE
Fix focusing directories with a trailing slash in their path doesn't work

### DIFF
--- a/lua/nvim-tree/actions/fs/create-file.lua
+++ b/lua/nvim-tree/actions/fs/create-file.lua
@@ -108,7 +108,7 @@ function M.fn(node)
     end
     -- INFO: defer needed when reload is automatic (watchers)
     vim.defer_fn(function()
-      utils.focus_file(new_file_path)
+      utils.focus_file(utils.path_remove_trailing(new_file_path))
     end, 150)
   end)
 end


### PR DESCRIPTION
The issue here was that the directory path generated when a new directory was created through the `fs.create-file` function was not formatted correctly as `utils.focus_file` required, so it wasn't focused after it's creation. The solution was to remove the trailing slash on this path, which was solved using the `utils.path_remove_trailing` utility when attempting to focus the newly created dir in the above mentioned functions.

Solves https://github.com/kyazdani42/nvim-tree.lua/issues/1500