### PR TITLE
feat: add config option for a tree indent width

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -221,6 +221,7 @@ Subsequent calls to setup will replace the previous configuration.
             corner = "└",
             edge = "│",
             item = "│",
+            bottom = "─",
             none = " ",
           },
         },
@@ -728,7 +729,7 @@ UI rendering setup
 
         *nvim-tree.renderer.indent_markers.icons*
         Icons shown before the file/directory.
-          Type: `table`, Default: `{ corner = "└", edge = "│", item = "│", none = " ", }`
+          Type: `table`, Default: `{ corner = "└", edge = "│", item = "│", bottom = "─", none = " ", }`
 
     *nvim-tree.renderer.icons*
     Configuration options for icons.

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -712,7 +712,7 @@ UI rendering setup
       Type: `string`, Default: `":~"`
 
     *nvim-tree.renderer.indent_width*
-    Number of spaces for an each tree nesting level.
+    Number of spaces for an each tree nesting level. Minimum 1.
       Type: `number`, Default: `2`
 
     *nvim-tree.renderer.indent_markers*
@@ -728,7 +728,7 @@ UI rendering setup
           Type: `boolean`, Default: `true`
 
         *nvim-tree.renderer.indent_markers.icons*
-        Icons shown before the file/directory.
+        Icons shown before the file/directory. Length 1.
           Type: `table`, Default: `{ corner = "└", edge = "│", item = "│", bottom = "─", none = " ", }`
 
     *nvim-tree.renderer.icons*

--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -213,6 +213,7 @@ Subsequent calls to setup will replace the previous configuration.
         full_name = false,
         highlight_opened_files = "none",
         root_folder_modifier = ":~",
+        indent_width = 2,
         indent_markers = {
           enable = false,
           inline_arrows = true,
@@ -708,6 +709,10 @@ UI rendering setup
     In what format to show root folder. See `:help filename-modifiers` for
     available options.
       Type: `string`, Default: `":~"`
+
+    *nvim-tree.renderer.indent_width*
+    Number of spaces for an each tree nesting level.
+      Type: `number`, Default: `2`
 
     *nvim-tree.renderer.indent_markers*
     Configuration options for tree indent markers.

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -476,6 +476,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
     full_name = false,
     highlight_opened_files = "none",
     root_folder_modifier = ":~",
+    indent_width = 2,
     indent_markers = {
       enable = false,
       inline_arrows = true,

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -484,6 +484,7 @@ local DEFAULT_OPTS = { -- BEGIN_DEFAULT_OPTS
         corner = "└",
         edge = "│",
         item = "│",
+        bottom = "─",
         none = " ",
       },
     },

--- a/lua/nvim-tree/renderer/builder.lua
+++ b/lua/nvim-tree/renderer/builder.lua
@@ -258,9 +258,9 @@ function Builder:_build_line(node, idx, num_children)
   self.index = self.index + 1
 
   if node.open then
-    self.depth = self.depth + 2
+    self.depth = self.depth + 1
     self:build(node)
-    self.depth = self.depth - 2
+    self.depth = self.depth - 1
   end
 end
 

--- a/lua/nvim-tree/renderer/components/padding.lua
+++ b/lua/nvim-tree/renderer/components/padding.lua
@@ -100,7 +100,7 @@ function M.setup(opts)
     if #symbol == 0 then
       return " "
     end
-    return symbol:match("[%z\1-\127\194-\244][\128-\191]*")
+    return symbol:match "[%z\1-\127\194-\244][\128-\191]*"
   end
 
   for k, v in pairs(M.config.indent_markers.icons) do

--- a/lua/nvim-tree/renderer/components/padding.lua
+++ b/lua/nvim-tree/renderer/components/padding.lua
@@ -30,25 +30,27 @@ local function get_padding_indent_markers(depth, idx, nodes_number, markers, wit
     for i = 1, depth do
       local glyph
       if idx == nodes_number and i == depth then
-        glyph = M.config.indent_markers.icons.corner
+        local bottom_width = M.config.indent_width - 2 +
+          (with_arrows and not inline_arrows and has_folder_sibling and 2 or 0)
+        glyph = M.config.indent_markers.icons.corner ..
+          string.rep(M.config.indent_markers.icons.bottom, bottom_width) ..
+          (M.config.indent_width > 1 and " " or "")
       elseif markers[i] and i == depth then
-        glyph = M.config.indent_markers.icons.item
+        glyph = M.config.indent_markers.icons.item .. indent
       elseif markers[i] then
-        glyph = M.config.indent_markers.icons.edge
+        glyph = M.config.indent_markers.icons.edge .. indent
       else
-        glyph = M.config.indent_markers.icons.none
+        glyph = M.config.indent_markers.icons.none .. indent
       end
 
       if not with_arrows or (inline_arrows and (depth ~= i or not node.nodes)) then
-        padding = padding .. glyph .. indent
+        padding = padding .. glyph
       elseif inline_arrows then
         padding = padding
-      elseif idx == nodes_number and i == depth and has_folder_sibling then
-        padding = padding .. base_padding .. glyph .. "──" .. indent
-      elseif depth == i and not node.nodes and has_folder_sibling then
-        padding = padding .. base_padding .. glyph .. indent .. base_padding
+      elseif idx ~= nodes_number and depth == i and not node.nodes and has_folder_sibling then
+        padding = padding .. base_padding .. glyph .. base_padding
       else
-        padding = padding .. base_padding .. glyph .. indent
+        padding = padding .. base_padding .. glyph
       end
     end
   end

--- a/lua/nvim-tree/renderer/components/padding.lua
+++ b/lua/nvim-tree/renderer/components/padding.lua
@@ -25,13 +25,13 @@ local function get_padding_indent_markers(depth, idx, nodes_number, markers, wit
 
   if depth > 0 then
     local has_folder_sibling = check_siblings_for_folder(node, with_arrows)
-    local rdepth = depth / 2
-    markers[rdepth] = idx ~= nodes_number
-    for i = 1, rdepth do
+    local indent = string.rep(" ", M.config.indent_width - 1)
+    markers[depth] = idx ~= nodes_number
+    for i = 1, depth do
       local glyph
-      if idx == nodes_number and i == rdepth then
+      if idx == nodes_number and i == depth then
         glyph = M.config.indent_markers.icons.corner
-      elseif markers[i] and i == rdepth then
+      elseif markers[i] and i == depth then
         glyph = M.config.indent_markers.icons.item
       elseif markers[i] then
         glyph = M.config.indent_markers.icons.edge
@@ -39,16 +39,16 @@ local function get_padding_indent_markers(depth, idx, nodes_number, markers, wit
         glyph = M.config.indent_markers.icons.none
       end
 
-      if not with_arrows or (inline_arrows and (rdepth ~= i or not node.nodes)) then
-        padding = padding .. glyph .. " "
+      if not with_arrows or (inline_arrows and (depth ~= i or not node.nodes)) then
+        padding = padding .. glyph .. indent
       elseif inline_arrows then
         padding = padding
-      elseif idx == nodes_number and i == rdepth and has_folder_sibling then
-        padding = padding .. base_padding .. glyph .. "── "
-      elseif rdepth == i and not node.nodes and has_folder_sibling then
-        padding = padding .. base_padding .. glyph .. " " .. base_padding
+      elseif idx == nodes_number and i == depth and has_folder_sibling then
+        padding = padding .. base_padding .. glyph .. "──" .. indent
+      elseif depth == i and not node.nodes and has_folder_sibling then
+        padding = padding .. base_padding .. glyph .. indent .. base_padding
       else
-        padding = padding .. base_padding .. glyph .. " "
+        padding = padding .. base_padding .. glyph .. indent
       end
     end
   end
@@ -71,11 +71,12 @@ function M.get_padding(depth, idx, nodes_number, node, markers)
   local show_arrows = M.config.icons.show.folder_arrow
   local show_markers = M.config.indent_markers.enable
   local inline_arrows = M.config.indent_markers.inline_arrows
+  local indent_width = M.config.indent_width
 
   if show_markers then
     padding = padding .. get_padding_indent_markers(depth, idx, nodes_number, markers, show_arrows, inline_arrows, node)
   else
-    padding = padding .. string.rep(" ", depth)
+    padding = padding .. string.rep(" ", depth * indent_width)
   end
 
   if show_arrows then

--- a/lua/nvim-tree/renderer/components/padding.lua
+++ b/lua/nvim-tree/renderer/components/padding.lua
@@ -91,6 +91,10 @@ end
 
 function M.setup(opts)
   M.config = opts.renderer
+
+  if M.config.indent_width < 1 then
+    M.config.indent_width = 1
+  end
 end
 
 return M

--- a/lua/nvim-tree/renderer/components/padding.lua
+++ b/lua/nvim-tree/renderer/components/padding.lua
@@ -30,11 +30,12 @@ local function get_padding_indent_markers(depth, idx, nodes_number, markers, wit
     for i = 1, depth do
       local glyph
       if idx == nodes_number and i == depth then
-        local bottom_width = M.config.indent_width - 2 +
-          (with_arrows and not inline_arrows and has_folder_sibling and 2 or 0)
-        glyph = M.config.indent_markers.icons.corner ..
-          string.rep(M.config.indent_markers.icons.bottom, bottom_width) ..
-          (M.config.indent_width > 1 and " " or "")
+        local bottom_width = M.config.indent_width
+          - 2
+          + (with_arrows and not inline_arrows and has_folder_sibling and 2 or 0)
+        glyph = M.config.indent_markers.icons.corner
+          .. string.rep(M.config.indent_markers.icons.bottom, bottom_width)
+          .. (M.config.indent_width > 1 and " " or "")
       elseif markers[i] and i == depth then
         glyph = M.config.indent_markers.icons.item .. indent
       elseif markers[i] then

--- a/lua/nvim-tree/renderer/components/padding.lua
+++ b/lua/nvim-tree/renderer/components/padding.lua
@@ -95,6 +95,17 @@ function M.setup(opts)
   if M.config.indent_width < 1 then
     M.config.indent_width = 1
   end
+
+  local function check_marker(symbol)
+    if #symbol == 0 then
+      return " "
+    end
+    return symbol:match("[%z\1-\127\194-\244][\128-\191]*")
+  end
+
+  for k, v in pairs(M.config.indent_markers.icons) do
+    M.config.indent_markers.icons[k] = check_marker(v)
+  end
 end
 
 return M

--- a/lua/nvim-tree/renderer/components/padding.lua
+++ b/lua/nvim-tree/renderer/components/padding.lua
@@ -100,6 +100,7 @@ function M.setup(opts)
     if #symbol == 0 then
       return " "
     end
+    -- return the first character from the UTF-8 encoded string; we may use utf8.codes from Lua 5.3 when available
     return symbol:match "[%z\1-\127\194-\244][\128-\191]*"
   end
 


### PR DESCRIPTION
This PR adds 'indent_width' option to configure visible indent for tree nesting levels (default is 2). Both enabled and disabled indent markers are supported.

A little context: 9a02dedd92fad67b04b2a3fee2de20555956b089 seemingly removed the ability to have a compact 1-symbol width indentations (and also without indent markers it was only possible to have a fixed 2-space indents, no more, no less). This PR adds ability to have a both smaller and larger (3+) indentations.