### PR TITLE
feat(adaptive_size): floating window's optional adaptive size specification

### DIFF
--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -246,7 +246,8 @@ function M.grow_from_content()
 end
 
 function M.resize(size)
-  if M.View.float.enable then
+  if M.View.float.enable and not M.View.adaptive_size then
+    -- if the floating windows's adaptive size is not desired, then the
     -- float size should be defined in view.float.open_win_config
     return
   end


### PR DESCRIPTION
Given the last merged PR (#1556) suggested by @Khrees, the floating window's adaptive size has been fully blocked, making impossible to allow it for those who actually use it.

```lua
if M.View.float.enable and not M.View.adaptive_size then
  -- if the floating windows's adaptive size is not desired, then the
  -- float size should be defined in view.float.open_win_config
  return
end
```

So i propose to check both the floating window and adaptive size configuration to avoid the resizing behavior in floating windows only when the adaptive size is disabled.