### PR TITLE
fix(view): Fix filter and file info popups with float enabled

### DIFF
--- a/lua/nvim-tree/actions/node/file-popup.lua
+++ b/lua/nvim-tree/actions/node/file-popup.lua
@@ -32,6 +32,7 @@ local function setup_window(node)
     width = max_width + 1,
     height = #lines,
     noautocmd = true,
+    zindex = 60,
   })
   local winnr = a.nvim_open_win(0, false, open_win_config)
   current_popup = {

--- a/lua/nvim-tree/live-filter.lua
+++ b/lua/nvim-tree/live-filter.lua
@@ -25,6 +25,15 @@ local overlay_bufnr = nil
 local overlay_winnr = nil
 
 local function remove_overlay()
+  if view.View.float.enable then
+    -- return to normal nvim-tree float behaviour when filter window is closed
+    a.nvim_create_autocmd("WinLeave", {
+      pattern = "NvimTree_*",
+      group = a.nvim_create_augroup("NvimTree", { clear = false }),
+      callback = view.close,
+    })
+  end
+
   a.nvim_win_close(overlay_winnr, { force = true })
   overlay_bufnr = nil
   overlay_winnr = nil
@@ -92,12 +101,24 @@ local function configure_buffer_overlay()
 end
 
 local function create_overlay()
+  local min_width = 20
+  if view.View.float.enable then
+    -- don't close nvim-tree float when focus is changed to filter window
+    a.nvim_clear_autocmds {
+      event = "WinLeave",
+      pattern = "NvimTree_*",
+      group = a.nvim_create_augroup("NvimTree", { clear = false }),
+    }
+
+    min_width = min_width - 2
+  end
+
   configure_buffer_overlay()
   overlay_winnr = a.nvim_open_win(overlay_bufnr, true, {
     col = 1,
     row = 0,
     relative = "cursor",
-    width = math.max(20, a.nvim_win_get_width(view.get_winnr()) - #M.prefix - 2),
+    width = math.max(min_width, a.nvim_win_get_width(view.get_winnr()) - #M.prefix - 2),
     height = 1,
     border = "none",
     style = "minimal",


### PR DESCRIPTION
This PR fixes floating nvim-tree behaviour involving pop-ups:

- [x] live-filter: focusing on filter window caused nvim-tree window to close,
- [x] file-popup: file info pop-up was displayed below nvim-tree window. 