### PR TITLE
fix(view): window options are set even if it is not a drawer

### DIFF
--- a/lua/nvim-tree/view.lua
+++ b/lua/nvim-tree/view.lua
@@ -297,7 +297,6 @@ function M.open_in_current_win(opts)
   create_buffer(opts.hijack_current_buf and a.nvim_get_current_buf())
   setup_tabpage(a.nvim_get_current_tabpage())
   set_current_win()
-  set_window_options_and_buffer()
   if opts.resize then
     M.reposition_window()
     M.resize()


### PR DESCRIPTION
Because they are window-local, options such as winfixwidth will remain after the file is opened.
