### PR TITLE
fix(#1270): open_on_setup_file does not override open_on_setup, hijack_directories does not override startup behaviour

### DIFF
--- a/doc/nvim-tree-lua.txt
+++ b/doc/nvim-tree-lua.txt
@@ -390,29 +390,33 @@ Hijack netrw windows (overridden if |disable_netrw| is `true`)
   Type: `boolean`, Default: `true`
 
 *nvim-tree.open_on_setup*
-Will automatically open the tree when running setup if startup buffer is
-a directory, is empty or is unnamed. nvim-tree window will be focused.
+Will automatically open the tree when running setup if startup buffer is a
+directory, empty or unnamed.
+nvim-tree window will be focused.
 See |nvim-tree.focus_empty_on_setup|
   Type: `boolean`, Default: `false`
 
 *nvim-tree.open_on_setup_file*
-Will automatically open the tree when running setup if startup buffer is a file.
+Will automatically open the tree when running setup if startup buffer is a
+file.
 File window will be focused.
-File will be found if update_focused_file is enabled.
+File will be found if |nvim-tree.update_focused_file| is enabled.
   Type: `boolean`, Default: `false`
 
 *nvim-tree.ignore_buffer_on_setup*
-Will ignore the buffer, when deciding to open the tree on setup.
+Always open the tree when |nvim-tree.open_on_setup| is enabled, regardless of
+the startup buffer.
+Buffer window will be focused.
   Type: `boolean`, Default: `false`
 
 *nvim-tree.ignore_ft_on_setup*
-List of filetypes that will prevent `open_on_setup` to open.
+List of filetypes that will prevent |nvim-tree.open_on_setup_file|.
 You can use this option if you don't want the tree to open
 in some scenarios (eg using vim startify).
   Type: {string}, Default: `{}`
 
 *nvim-tree.ignore_buf_on_tab_change*
-List of filetypes or buffer names that will prevent `open_on_tab` to open.
+List of filetypes or buffer names that will prevent |nvim-tree.open_on_tab|.
   Type: {string}, Default: `{}`
 
 *nvim-tree.auto_reload_on_write*

--- a/lua/nvim-tree.lua
+++ b/lua/nvim-tree.lua
@@ -237,32 +237,26 @@ function M.on_enter(netrw_disabled)
   local buf_has_content = #lines > 1 or (#lines == 1 and lines[1] ~= "")
 
   local buf_is_dir = is_dir and netrw_disabled
-  local buf_is_empty = bufname == "" and not buf_has_content
   local should_be_preserved = vim.tbl_contains(ft_ignore, buftype)
 
   local should_open = false
   local should_focus_other_window = false
   local should_find = false
   if (_config.open_on_setup or _config.open_on_setup_file) and not should_be_preserved then
-    if buf_is_empty then
+    if not buf_has_content and _config.open_on_setup then
       should_open = true
       should_focus_other_window = _config.focus_empty_on_setup
-    elseif buf_is_dir then
+    elseif buf_is_dir and _config.open_on_setup then
       should_open = true
     elseif is_file and _config.open_on_setup_file then
       should_open = true
       should_focus_other_window = true
       should_find = _config.update_focused_file.enable
-    elseif _config.ignore_buffer_on_setup then
+    elseif _config.ignore_buffer_on_setup and _config.open_on_setup then
       should_open = true
       should_focus_other_window = true
     end
   end
-
-  local should_hijack = _config.hijack_directories.enable
-    and _config.hijack_directories.auto_open
-    and is_dir
-    and not should_be_preserved
 
   -- Session that left a NvimTree Buffer opened, reopen with it
   local existing_tree_wins = find_existing_windows()
@@ -270,7 +264,7 @@ function M.on_enter(netrw_disabled)
     api.nvim_set_current_win(existing_tree_wins[1])
   end
 
-  if should_open or should_hijack or existing_tree_wins[1] ~= nil then
+  if should_open or existing_tree_wins[1] ~= nil then
     lib.open(cwd)
 
     if should_focus_other_window then


### PR DESCRIPTION
Investigating #1270 and found some bugs and inconsistencies:

Bugs: `open_on_setup_file` overrides `open_on_setup`

Inconsistencies: `hijack_directories` overrides `open_on_setup`. Not necessarily a bug, however this behaviour has been updated to match the documentation.

Documentation has been clarified.